### PR TITLE
Run buildifier on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ addons:
     packages:
       - bazel
 
+install:
+  - go get -u github.com/bazelbuild/buildifier/buildifier
+
 script:
   - bazel clean && bazel build //...
   - bazel clean && bazel test --test_output=errors //...
+  - buildifier -mode=check $(find . -name BUILD -o -name '*.bzl' -type f)


### PR DESCRIPTION
Supposedly [all Travis runtimes include the go compiler](https://docs.travis-ci.com/user/ci-environment/#Runtimes). Let's see if that's true?