### PR TITLE
Add stamp option to docker_bundle rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,10 +597,26 @@ A rule that aliases and saves N images into a single `docker save` tarball.
       <td><code>images</code></td>
       <td>
         <p><code>Map of Tag to image Label; required</code></p>
-        <p>A collection of the images to save into the tarball.  The keys
-           are the tags with which to alias the image specified by the
-           value.  The value may be the output of `docker_pull`,
-           `docker_build`, or a `docker save` tarball.</p>
+        <p>A collection of the images to save into the tarball.</p>
+        <p>The keys are the tags with which to alias the image specified by the
+           value. These tags may contain make variables (<code>$FOO</code>),
+           and if <code>stamp</code> is set to true, may also contain workspace
+           status variables (<code>{BAR}</code>).</p>
+        <p>The values may be the output of <code>docker_pull</code>,
+           <code>docker_build</code>, or a <code>docker save</code> tarball.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>stamp</code></td>
+      <td>
+        <p><code>Bool; optional</code></p>
+        <p>If true, enable use of workspace status variables
+        (e.g. <code>BUILD_USER</code>, <code>BUILD_EMBED_LABEL</code>,
+        and custom values set using <code>--workspace_status_command</code>)
+        in tags.</p>
+        <p>These fields are specified in the tag using using Python format
+        syntax, e.g.
+        <code>example.org/{BUILD_USER}/image:{BUILD_EMBED_LABEL}</code>.</p>
       </td>
     </tr>
   </tbody>

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -54,6 +54,7 @@ TEST_DATA = [
     # TODO(mattmoor): Re-enable once archive is visible
     # "//docker/testdata:extras_with_deb.tar",
     "//docker/testdata:bundle_test.tar",
+    "//docker/testdata:stamped_bundle_test.tar",
     "//docker/testdata:pause_based.tar",
 ]
 

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -522,6 +522,11 @@ function test_bundle() {
     "[\"gcr.io/google-containers/pause:2.0\"]"
 }
 
+function test_stamped_bundle() {
+  check_manifest_property "RepoTags" "stamped_bundle_test" \
+    "[\"example.com/$USER:stamped\"]"
+}
+
 function test_pause_based() {
   # Check that when we add a single layer on top of a checked in tarball, that
   # all of the layers from the original tarball are included.  We omit the

--- a/docker/bundle.bzl
+++ b/docker/bundle.bzl
@@ -62,7 +62,7 @@ def _docker_bundle_impl(ctx):
       # points to the name of the layer.
       k: images[k]["name"]
       for k in images
-  }, ctx.outputs.out)
+  }, ctx.outputs.out, stamp=ctx.attr.stamp)
 
   runfiles = ctx.runfiles(
       files = ([l["name"] for l in layers] +
@@ -78,6 +78,10 @@ docker_bundle_ = rule(
         # Implicit dependencies.
         "image_targets": attr.label_list(allow_files = True),
         "image_target_strings": attr.string_list(),
+        "stamp": attr.bool(
+            default = False,
+            mandatory = False,
+        ),
     } + _layer_tools,
     executable = True,
     outputs = {

--- a/docker/join_layers.py
+++ b/docker/join_layers.py
@@ -43,6 +43,9 @@ parser.add_argument('--tags', action='append', required=True,
                           'and the layer they tag. '
                           'e.g. ubuntu=deadbeef,gcr.io/blah/debian=baadf00d'))
 
+parser.add_argument('--stamp-info-file', action='append', required=False,
+                    help=('If stamping these layers, the list of files from '
+                          'which to obtain workspace information'))
 
 def create_image(output, layers, tag_to_layer=None, layer_to_tags=None):
   """Creates a Docker image from a list of layers.
@@ -87,13 +90,24 @@ def main():
 
   tag_to_layer = {}
   layer_to_tags = {}
+  stamp_info = {}
+
+  if args.stamp_info_file:
+    for infofile in args.stamp_info_file:
+      with open(infofile) as info:
+        for line in info:
+          line = line.strip("\n")
+          key, value = line.split(" ")
+          stamp_info[key] = value
+
   for entry in args.tags:
     elts = entry.split('=')
     if len(elts) != 2:
       raise Exception('Expected associative list key=value, got: %s' % entry)
     (fq_tag, layer_id) = elts
 
-    tag = docker_name.Tag(fq_tag)
+    formatted_tag = fq_tag.format(**stamp_info)
+    tag = docker_name.Tag(formatted_tag)
     layer_id = utils.ExtractValue(layer_id)
 
     # Add the mapping in one direction.

--- a/docker/join_layers.py
+++ b/docker/join_layers.py
@@ -97,7 +97,10 @@ def main():
       with open(infofile) as info:
         for line in info:
           line = line.strip("\n")
-          key, value = line.split(" ")
+          key, value = line.split(" ", 1)
+          if key in stamp_info:
+            print ("WARNING: Duplicate value for workspace status key '%s': "
+                   "using '%s'" % (key, value))
           stamp_info[key] = value
 
   for entry in args.tags:

--- a/docker/layers.bzl
+++ b/docker/layers.bzl
@@ -59,10 +59,9 @@ def assemble(ctx, layers, tags_to_names, output, stamp=False):
       "--tags=" + tag + "=@" + tags_to_names[tag].path
       for tag in tags_to_names
   ] + ["--layer=" + l.path for l in layers]
-  if stamp:
-    args += ["--stamp-info-file=%s" % f.path for f in (ctx.info_file, ctx.version_file)]
   inputs = layers + tags_to_names.values()
   if stamp:
+    args += ["--stamp-info-file=%s" % f.path for f in (ctx.info_file, ctx.version_file)]
     inputs += [ctx.info_file, ctx.version_file]
   ctx.action(
       executable = ctx.executable.join_layers,

--- a/docker/layers.bzl
+++ b/docker/layers.bzl
@@ -50,7 +50,7 @@ def get_from_target(ctx, attr_target, file_target):
         "name": name_out
     }]
 
-def assemble(ctx, layers, tags_to_names, output):
+def assemble(ctx, layers, tags_to_names, output, stamp=False):
   """Create the full image from the list of layers."""
   layers = [l["layer"] for l in layers]
   args = [
@@ -59,7 +59,11 @@ def assemble(ctx, layers, tags_to_names, output):
       "--tags=" + tag + "=@" + tags_to_names[tag].path
       for tag in tags_to_names
   ] + ["--layer=" + l.path for l in layers]
+  if stamp:
+    args += ["--stamp-info-file=%s" % f.path for f in (ctx.info_file, ctx.version_file)]
   inputs = layers + tags_to_names.values()
+  if stamp:
+    inputs += [ctx.info_file, ctx.version_file]
   ctx.action(
       executable = ctx.executable.join_layers,
       arguments = args,

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -253,6 +253,14 @@ docker_bundle(
     },
 )
 
+docker_bundle(
+    name = "stamped_bundle_test",
+    images = {
+        "example.com/{BUILD_USER}:stamped": ":with_user",
+    },
+    stamp = True,
+)
+
 # Generate a dummy debian package with a test/ directory
 py_binary(
     name = "gen_deb",


### PR DESCRIPTION
This allows using workspace status information (such as git describe) in image tags. To differentiate from make variables (and laziness), I'm using python formatting syntax, e.g. `{STABLE_BUILD_USER}` or `{MY_CUSTOM_VAR}`.

This is basically an implementation of what I was describing in https://github.com/bazelbuild/rules_docker/issues/3#issuecomment-297563224.

I think it'd work for what I need for kubernetes right now, though I'm not sure if this is the correct implementation, e.g. does it makes sense to do the stamping in `docker_bundle`? Should it also be supported in `docker_build` and/or `docker_push`? What things should be "stampable"? Do we want to be able to embed stamping info in image labels? (I might in the future, e.g. embed revision/other build data.)

(`docker_push` actually looks harder, since it's basically just a shell script template wrapper to the code in containerregistry.)

The proper way to do all of this would be entirely in skylark, though that depends on  https://github.com/bazelbuild/bazel/issues/1054 being resolved.