### PR TITLE
Expose a derivative of docker_build that tags as well.

### DIFF
--- a/docker/BUILD
+++ b/docker/BUILD
@@ -39,6 +39,7 @@ TEST_TARGETS = [
     "with_user",
     "workdir_with_tar_base",
     "link_with_files_base",
+    "build_with_tag",
 ]
 
 TEST_DATA = [

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -540,6 +540,13 @@ function test_pause_based() {
     "da7bd81140ca921a067c604a3ba3f54d4e0d51ba5276cd9f32ad6a28e588f470"
 }
 
+function test_build_with_tag() {
+  # We should have a tag in our manifest containing the name
+  # specified via the tag kwarg.
+  check_manifest_property "RepoTags" "build_with_tag" \
+    "[\"gcr.io/build/with:tag\"]"
+}
+
 tests=$(grep "^function test_" "${BASH_SOURCE[0]}" \
           | cut -d' ' -f 2 | cut -d'(' -f 1)
 

--- a/docker/contrib/BUILD
+++ b/docker/contrib/BUILD
@@ -1,0 +1,16 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0

--- a/docker/contrib/with-tag.bzl
+++ b/docker/contrib/with-tag.bzl
@@ -1,0 +1,25 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "//docker:docker.bzl",
+    "docker_bundle",
+    docker_build_ = "docker_build",
+)
+
+def docker_build(name=None, tag=None, **kwargs):
+    docker_build_(name=name + '-internal', **kwargs)
+    docker_bundle(name=name, images={
+      tag: ':' + name + '-internal'
+    })

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -284,3 +284,15 @@ genrule(
 #     debs = [":gen.deb"],
 #     tars = ["extras.tar"],
 # )
+
+load(
+    "//docker/contrib:with-tag.bzl",
+    docker_build_with_tag = "docker_build",
+)
+
+docker_build_with_tag(
+    name = "build_with_tag",
+    base = ":with_user",
+    files = ["foo"],
+    tag = "gcr.io/build/with:tag",
+)


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/rules_docker/issues/8