### PR TITLE
Upgrade to v0.0.7 of google/containerregistry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,14 @@ install:
   - go get -u github.com/bazelbuild/buildifier/buildifier
 
 script:
+  # Check that our direct testing passes.
   - bazel clean && bazel build //...
   - bazel clean && bazel test --test_output=errors //...
-  - buildifier -mode=check $(find . -name BUILD -o -name '*.bzl' -type f)
+
+  # Check for issues with the format of our bazel config files.
+  - buildifier -mode=check $(find . -name BUILD -type f)
+  - buildifier -mode=check $(find . -name WORKSPACE -type f)
+  - buildifier -mode=check $(find . -name '*.bzl' -type f)
+
+  # Test things by executing the various build configurations under testing/
+  - ./testing/e2e.sh

--- a/docker/create_image.py
+++ b/docker/create_image.py
@@ -72,11 +72,9 @@ class ImageShard(v1_image.DockerImage):
   def repositories(self):
     """Override."""
     return {
-        '{registry}/{repository}'.format(
-            registry=self._tag.registry,
-            repository=self._tag.repository): {
-                self._tag.tag: self.top()
-            }
+        str(self._tag.as_repository()): {
+            self._tag.tag: self.top()
+        }
     }
 
   def json(self, layer_id):
@@ -125,7 +123,7 @@ def create_image(output,
     repository: repository name for this docker image.
   """
   tag = docker_name.Tag('{repository}:{tag}'.format(
-      repository=repository, tag=name))
+      repository=repository, tag=name), strict=False)
 
   with tarfile.open(name=output, mode='w') as tar:
     def add_file(filename, contents):

--- a/docker/docker.bzl
+++ b/docker/docker.bzl
@@ -25,7 +25,7 @@ load(":pull.bzl", "docker_pull")
 load(":push.bzl", "docker_push")
 
 # The release of the github.com/google/containerregistry to consume.
-CONTAINERREGISTRY_RELEASE = "v0.0.6"
+CONTAINERREGISTRY_RELEASE = "v0.0.7"
 
 def docker_repositories():
   """Download dependencies of docker rules."""
@@ -33,7 +33,7 @@ def docker_repositories():
     name = "puller",
     url = ("https://storage.googleapis.com/containerregistry-releases/" +
            CONTAINERREGISTRY_RELEASE + "/puller.par"),
-    sha256 = "39674ec7ac8456e4b67bfcd67e03a4e6e86f3cc5c2e94003a7aec4550ef8c5d9",
+    sha256 = "163bcf9fd4627d3dc9d454eee26605552de1201b152a40702c860a120307096c",
     executable = True,
   )
 
@@ -41,7 +41,7 @@ def docker_repositories():
     name = "pusher",
     url = ("https://storage.googleapis.com/containerregistry-releases/" +
            CONTAINERREGISTRY_RELEASE + "/pusher.par"),
-    sha256 = "daeedba9f31bb5f9b8691a6ca6a371f701544c7c29878033b5c0793dd62bab78",
+    sha256 = "45219688ba9d2cafcc791393b4ba321fe6b8592f8b251f49f422f2d202d5a44d",
     executable = True,
   )
 

--- a/docker/join_layers.py
+++ b/docker/join_layers.py
@@ -146,7 +146,7 @@ def main():
     (fq_tag, layer_id) = elts
 
     formatted_tag = fq_tag.format(**stamp_info)
-    tag = docker_name.Tag(formatted_tag)
+    tag = docker_name.Tag(formatted_tag, strict=False)
     layer_id = utils.ExtractValue(layer_id)
 
     # Add the mapping in one direction.

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -1,0 +1,65 @@
+#!/bin/bash -ex
+
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Must be invoked from the root of the repo.
+ROOT=$PWD
+
+function test_top_level() {
+  local directory=$(mktemp -d)
+
+  cd "${directory}"
+
+  cat > "BUILD" <<EOF
+package(default_visibility = ["//visibility:private"])
+
+load(
+  "@io_bazel_rules_docker//docker:docker.bzl",
+  "docker_build",
+)
+
+docker_build(
+  name = "pause_based",
+  base = "@pause//image:image.tar",
+  workdir = "/tmp",
+)
+EOF
+
+  cat > "WORKSPACE" <<EOF
+workspace(name = "top_level")
+
+local_repository(
+    name = "io_bazel_rules_docker",
+    path = "$ROOT",
+)
+
+load(
+  "@io_bazel_rules_docker//docker:docker.bzl",
+  "docker_repositories", "docker_pull"
+)
+docker_repositories()
+
+docker_pull(
+  name = "pause",
+  registry = "gcr.io",
+  repository = "google-containers/pause",
+  tag = "2.0",
+)
+EOF
+
+  bazel build --verbose_failures --spawn_strategy=standalone :pause_based
+}
+
+test_top_level


### PR DESCRIPTION
Switch to using the new relaxed naming to fix the linked issue.

Fixes: https://github.com/bazelbuild/rules_docker/issues/28