### PR TITLE
Update README.md for docker_build example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ docker-credential-gcr configure-docker
 docker_build(
     name = "app",
     # References docker_pull from WORKSPACE (above)
-    base = ["@java_base//image:image.tar"],
+    base = "@java_base//image:image.tar",
     files = ["//java/com/example/app:Hello_deploy.jar"],
     cmd = ["Hello_deploy.jar"]
 )


### PR DESCRIPTION
I don't think this example intended to provide a list for `base`.

Fixes #42