### PR TITLE
Add docker/__init__.py so that "docker" dir is always considered a package

### DIFF
--- a/docker/BUILD
+++ b/docker/BUILD
@@ -137,7 +137,10 @@ py_binary(
 
 py_library(
     name = "utils",
-    srcs = ["utils.py"],
+    srcs = [
+        "__init__.py",
+        "utils.py",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_docker/issues/49