### PR TITLE
fix(push): set image attr as mandatory

### DIFF
--- a/docker/push.bzl
+++ b/docker/push.bzl
@@ -57,6 +57,7 @@ _docker_push = rule(
         "image": attr.label(
             allow_files = [".tar"],
             single_file = True,
+            mandatory = True,
         ),
         "registry": attr.string(mandatory = True),
         "repository": attr.string(mandatory = True),


### PR DESCRIPTION
Add mandatory=True to the image label of the push command.