### PR TITLE
docs(readme): use v0.0.2 in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add the following to your `WORKSPACE` file to add the external repositories:
 git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    tag = "v0.0.1",
+    tag = "v0.0.2",
 )
 
 load(


### PR DESCRIPTION
Use the tag v0.0.2 in the example instead of v0.0.1