### PR TITLE
Introduce a docker_import rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Bazel ≥0.4.4 | linux-x86_64 | ubuntu_16.04-x86_64 | darwin-x86_64
 
 * [docker_build](#docker_build)
 * [docker_bundle](#docker_bundle)
+* [docker_import](#docker_import)
 * [docker_pull](#docker_pull)
 * [docker_push](#docker_push)
 
@@ -676,6 +677,55 @@ A rule that aliases and saves N images into a single `docker save` tarball.
         <p>These fields are specified in the tag using using Python format
         syntax, e.g.
         <code>example.org/{BUILD_USER}/image:{BUILD_EMBED_LABEL}</code>.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<a name="docker_import"></a>
+## docker_import
+
+```python
+docker_import(name, config, layers)
+```
+
+A rule that imports a docker image into our intermediate form.
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code>Name, required</code></p>
+        <p>Unique name for this rule.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>config</code></td>
+      <td>
+        <p><code>The v2.2 image's json configuration; required</code></p>
+        <p>A json configuration file containing the image's metadata.</p>
+        <p>This appears in `docker save` tarballs as `<hex>.json` and is
+           referenced by `manifest.json` in the config field.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>layers</code></td>
+      <td>
+        <p><code>The list of layer `.tar.gz`s; required</code></p>
+        <p>The list of layer `.tar.gz` files in the order they appear
+           in the `config.json`'s layer section, or in the order that
+           they appear in `docker save` tarballs' `manifest.json`
+           `Layers` field (although these are gzipped).</p>
       </td>
     </tr>
   </tbody>

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -62,6 +62,7 @@ TEST_DATA = [
     "//docker/testdata:dashdash_entrypoint.tar",
     "//docker/testdata:base_based.tar",
     "//docker/testdata:cc_based.tar",
+    "//docker/testdata:pause_piecemeal.tar",
 ]
 
 sh_test(

--- a/docker/docker.bzl
+++ b/docker/docker.bzl
@@ -18,6 +18,9 @@
 load(":build.bzl", "docker_build")
 load(":bundle.bzl", "docker_bundle")
 
+# Expose the docker_import rule.
+load(":import.bzl", "docker_import")
+
 # Expose the docker_pull repository rule.
 load(":pull.bzl", "docker_pull")
 

--- a/docker/filetype.bzl
+++ b/docker/filetype.bzl
@@ -13,13 +13,13 @@
 # limitations under the License.
 """Filetype constants."""
 
+tgz = [".tar.gz", ".tgz"]
+
 # Filetype to restrict inputs
 tar = [
     ".tar",
-    ".tar.gz",
-    ".tgz",
     ".tar.xz",
-]
+] + tgz
 
 deb = [
     ".deb",

--- a/docker/import.bzl
+++ b/docker/import.bzl
@@ -1,0 +1,117 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rule for building a Docker image."""
+
+load(
+    ":filetype.bzl",
+    tgz_filetype = "tgz",
+)
+load(
+    ":hash.bzl",
+    _hash_tools = "tools",
+    _sha256 = "sha256",
+)
+load(
+    ":zip.bzl",
+    _gunzip = "gunzip",
+)
+load(
+    ":layers.bzl",
+    _assemble_image = "assemble",
+    _incr_load = "incremental_load",
+    _layer_tools = "tools",
+)
+load(
+    ":path.bzl",
+    "dirname",
+    "strip_prefix",
+    _canonicalize_path = "canonicalize",
+    _join_path = "join",
+)
+
+def _unzip_layer(ctx, zipped_layer):
+  unzipped_layer = _gunzip(ctx, zipped_layer)
+  return unzipped_layer, _sha256(ctx, unzipped_layer)
+
+def _repository_name(ctx):
+  """Compute the repository name for the current rule."""
+  return _join_path(ctx.attr.repository, ctx.label.package)
+
+def _docker_import_impl(ctx):
+  """Implementation for the docker_import rule."""
+
+  blobsums = []
+  unzipped_layers = []
+  diff_ids = []
+  for layer in ctx.files.layers:
+    blobsums += [_sha256(ctx, layer)]
+    unzipped, diff_id = _unzip_layer(ctx, layer)
+    unzipped_layers += [unzipped]
+    diff_ids += [diff_id]
+
+  # These are the constituent parts of the Docker image, which each
+  # rule in the chain must preserve.
+  docker_parts = {
+      # The path to the v2.2 configuration file.
+      "config": ctx.files.config[0],
+      "config_digest": _sha256(ctx, ctx.files.config[0]),
+
+      # A list of paths to the layer .tar.gz files
+      "zipped_layer": ctx.files.layers,
+      # A list of paths to the layer digests.
+      "blobsum": blobsums,
+
+      # A list of paths to the layer .tar files
+      "unzipped_layer": unzipped_layers,
+      # A list of paths to the layer diff_ids.
+      "diff_id": diff_ids,
+
+      # We do not have a "legacy" field, because we are importing a
+      # more efficient form.
+  }
+
+  # We support incrementally loading or assembling this single image
+  # with a temporary name given by its build rule.
+  images = {
+      _repository_name(ctx) + ":" + ctx.label.name: docker_parts
+  }
+
+  _incr_load(ctx, images, ctx.outputs.executable)
+  _assemble_image(ctx, images, ctx.outputs.out)
+
+  runfiles = ctx.runfiles(
+      files = (docker_parts["unzipped_layer"] +
+               docker_parts["diff_id"] +
+               [docker_parts["config"],
+                docker_parts["config_digest"]]))
+  return struct(runfiles = runfiles,
+                files = set([ctx.outputs.out]),
+                docker_parts = docker_parts)
+
+docker_import_ = rule(
+    attrs = {
+        "config": attr.label(allow_files = [".json"]),
+        "layers": attr.label_list(allow_files = tgz_filetype),
+        "repository": attr.string(default = "bazel"),
+    } + _hash_tools + _layer_tools,
+    executable = True,
+    outputs = {
+        "out": "%{name}.tar",
+    },
+    implementation = _docker_import_impl,
+)
+
+def docker_import(**kwargs):
+  """Imports a Docker image into our model's intermediate form."""
+  docker_import_(**kwargs)

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -17,6 +17,7 @@ load(
     "//docker:docker.bzl",
     "docker_build",
     "docker_bundle",
+    "docker_import",
     "docker_push",
 )
 
@@ -344,4 +345,34 @@ docker_build(
 docker_build(
     name = "cc_based",
     base = "@distroless_cc//image:image.tar",
+)
+
+PAUSE_CONFIG = "2b58359142b094165abfc9ad9c327c453a3eaa624d0c5ee8f0ed1ab50483603b.json"
+
+genrule(
+    name = "pause_config",
+    cmd = ("tar xOf $(location :pause.tar) %s " +
+           "> $(location :pause_config.json)") % PAUSE_CONFIG,
+    outs = ["pause_config.json"],
+    srcs = [":pause.tar"],
+)
+
+PAUSE_LAYERS = [
+    "9285c41a2f85a67c85185be04743004e806fd1e16777f2230166281f4e49cb4c",
+    "da7bd81140ca921a067c604a3ba3f54d4e0d51ba5276cd9f32ad6a28e588f470",
+]
+
+[genrule(
+    name = "extract_%s" % id,
+    cmd = ("tar xOf $(location :pause.tar) %s/layer.tar " +
+           "| gzip -n > $(location :%s.tar.gz)") % (id, id),
+    outs = ["%s.tar.gz" % id],
+    srcs = [":pause.tar"],
+) for id in PAUSE_LAYERS]
+
+
+docker_import(
+   name = "pause_piecemeal",
+   config = ":pause_config.json",
+    layers = ["%s.tar.gz" % x for x in PAUSE_LAYERS],
 )

--- a/docker/zip.bzl
+++ b/docker/zip.bzl
@@ -23,4 +23,14 @@ def gzip(ctx, artifact):
       mnemonic = "GZIP")
   return out
 
+def gunzip(ctx, artifact):
+  """Create an action to compute the gunzipped artifact."""
+  out = ctx.new_file(artifact.basename + ".nogz")
+  ctx.action(
+      command = 'gunzip < %s > %s' % (artifact.path, out.path),
+      inputs = [artifact],
+      outputs = [out],
+      mnemonic = "GUNZIP")
+  return out
+
 tools = {}

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -84,6 +84,15 @@ function test_bazel_run_docker_bundle_clean() {
   done
 }
 
+function test_bazel_run_docker_import_clean() {
+  cd "${ROOT}"
+  for target in $(bazel query 'kind("docker_import", "docker/testdata/...")');
+  do
+    clear_docker
+    bazel run $target
+  done
+}
+
 function test_bazel_run_docker_build_incremental() {
   cd "${ROOT}"
   clear_docker
@@ -102,8 +111,19 @@ function test_bazel_run_docker_bundle_incremental() {
   done
 }
 
+function test_bazel_run_docker_import_incremental() {
+  cd "${ROOT}"
+  clear_docker
+  for target in $(bazel query 'kind("docker_import", "docker/testdata/...")');
+  do
+    bazel run $target
+  done
+}
+
 test_top_level
 test_bazel_run_docker_build_clean
 test_bazel_run_docker_bundle_clean
+test_bazel_run_docker_import_clean
 test_bazel_run_docker_build_incremental
 test_bazel_run_docker_bundle_incremental
+test_bazel_run_docker_import_incremental


### PR DESCRIPTION
`docker_import` imports the constituent elements of an image into our intermediate form.

This will shortly become an implementation detail of `docker_pull`, but in mono-repo scenarios it can be used to more efficiently commit an image to avoid expensive legacy `ExtractConfig` actions.
