### PR TITLE
First cut at a foo_image rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,3 +39,10 @@ load(
 )
 
 _py_image_repos()
+
+# Have the cc_image dependencies for testing.
+load(
+  "//docker/contrib/cc:image.bzl",
+  _cc_image_repos="repositories"
+)
+_cc_image_repos()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,7 +34,8 @@ docker_pull(
 
 # Have the py_image dependencies for testing.
 load(
-  "//docker/contrib/python:image.bzl",
-  _py_image_repos="repositories"
+    "//docker/contrib/python:image.bzl",
+    _py_image_repos = "repositories",
 )
+
 _py_image_repos()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,7 +42,8 @@ _py_image_repos()
 
 # Have the cc_image dependencies for testing.
 load(
-  "//docker/contrib/cc:image.bzl",
-  _cc_image_repos="repositories"
+    "//docker/contrib/cc:image.bzl",
+    _cc_image_repos = "repositories",
 )
+
 _cc_image_repos()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,3 +47,11 @@ load(
 )
 
 _cc_image_repos()
+
+# Have the java_image dependencies for testing.
+load(
+    "//docker/contrib/java:image.bzl",
+    _java_image_repos = "repositories",
+)
+
+_java_image_repos()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,3 +55,10 @@ load(
 )
 
 _java_image_repos()
+
+# For our java_image test.
+maven_jar(
+    name = "com_google_guava_guava",
+    artifact = "com.google.guava:guava:18.0",
+    sha1 = "cce0823396aa693798f8882e64213b1772032b09",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,3 +31,10 @@ docker_pull(
     registry = "gcr.io",
     repository = "distroless/cc",
 )
+
+# Have the py_image dependencies for testing.
+load(
+  "//docker/contrib/python:image.bzl",
+  _py_image_repos="repositories"
+)
+_py_image_repos()

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -63,6 +63,7 @@ TEST_DATA = [
     "//docker/testdata:base_based_warning.tar",
     "//docker/testdata:cc_based_warning.tar",
     "//docker/testdata:pause_piecemeal.tar",
+    "//docker/testdata:py_image.tar",
 ]
 
 sh_test(

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -142,7 +142,7 @@ py_binary(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_tools//tools/build_defs/pkg:archive",
         "@bazel_tools//third_party/py/gflags",
+        "@bazel_tools//tools/build_defs/pkg:archive",
     ],
 )

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -65,6 +65,7 @@ TEST_DATA = [
     "//docker/testdata:pause_piecemeal.tar",
     "//docker/testdata:py_image.tar",
     "//docker/testdata:cc_image.tar",
+    "//docker/testdata:war_image.tar",
 ]
 
 sh_test(

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -65,6 +65,7 @@ TEST_DATA = [
     "//docker/testdata:pause_piecemeal.tar",
     "//docker/testdata:py_image.tar",
     "//docker/testdata:cc_image.tar",
+    "//docker/testdata:java_image.tar",
     "//docker/testdata:war_image.tar",
 ]
 

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -64,6 +64,7 @@ TEST_DATA = [
     "//docker/testdata:cc_based_warning.tar",
     "//docker/testdata:pause_piecemeal.tar",
     "//docker/testdata:py_image.tar",
+    "//docker/testdata:cc_image.tar",
 ]
 
 sh_test(

--- a/docker/build.bzl
+++ b/docker/build.bzl
@@ -11,7 +11,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Rule for building a Docker image."""
+"""Rule for building a Docker image.
+
+In addition to the base docker_build rule, we expose its constituents
+(attr, outputs, implementation) directly so that others may expose a
+more specialized build leveraging the same implementation.  The
+expectation in such cases is that users will write something like:
+
+  load(
+    "@io_bazel_rules_docker//docker:build.bzl",
+    _build_attrs="attrs",
+    _build_outputs="outputs",
+    _build_implementation="implementation",
+  )
+
+  def _impl(ctx):
+    ...
+    return _build_implementation(ctx, ... kwarg overrides ...)
+
+  _foo_image = rule(
+      attrs = _build_attrs + {
+         # My attributes, or overrides of _build_attrs defaults.
+         ...
+      },
+      executable = True,
+      outputs = _build_outputs,
+      implementation = _impl,
+  )
+
+"""
 
 load(
     ":filetype.bzl",
@@ -51,14 +79,14 @@ load(
     _serialize_dict = "dict_to_associative_list",
 )
 
-def _build_layer(ctx):
+def _build_layer(ctx, files=None, directory=None, symlinks=None):
   """Build the current layer for appending it the base layer."""
 
   layer = ctx.outputs.layer
   build_layer = ctx.executable.build_layer
   args = [
       "--output=" + layer.path,
-      "--directory=" + ctx.attr.directory,
+      "--directory=" + directory,
       "--mode=" + ctx.attr.mode,
   ]
 
@@ -68,23 +96,23 @@ def _build_layer(ctx):
         dirname(ctx.outputs.out.short_path),
         _canonicalize_path(ctx.attr.data_path))
     args += ["--file=%s=%s" % (f.path, strip_prefix(f.short_path, data_path))
-             for f in ctx.files.files]
+             for f in files]
   else:
     # Otherwise, files are added without a directory prefix at all.
     args += ["--file=%s=%s" % (f.path, f.basename)
-             for f in ctx.files.files]
+             for f in files]
 
   args += ["--tar=" + f.path for f in ctx.files.tars]
   args += ["--deb=" + f.path for f in ctx.files.debs if f.path.endswith(".deb")]
-  args += ["--link=%s:%s" % (k, ctx.attr.symlinks[k])
-           for k in ctx.attr.symlinks]
+  args += ["--link=%s:%s" % (k, symlinks[k])
+           for k in symlinks]
   arg_file = ctx.new_file(ctx.label.name + ".layer.args")
   ctx.file_action(arg_file, "\n".join(args))
 
   ctx.action(
       executable = build_layer,
       arguments = ["--flagfile=" + arg_file.path],
-      inputs = ctx.files.files + ctx.files.tars + ctx.files.debs + [arg_file],
+      inputs = files + ctx.files.tars + ctx.files.debs + [arg_file],
       outputs = [layer],
       use_default_shell_env=True,
       mnemonic="DockerLayer"
@@ -101,7 +129,7 @@ def _get_base_config(ctx):
     l = _get_layers(ctx, ctx.attr.base, ctx.files.base)
     return l.get("config")
 
-def _image_config(ctx, layer_name):
+def _image_config(ctx, layer_name, entrypoint=None, cmd=None):
   """Create the configuration for a new docker image."""
   config = ctx.new_file(ctx.label.name + ".config")
 
@@ -119,9 +147,9 @@ def _image_config(ctx, layer_name):
   args = [
       "--output=%s" % config.path,
   ] + [
-      "--entrypoint=%s" % x for x in ctx.attr.entrypoint
+      "--entrypoint=%s" % x for x in entrypoint
   ] + [
-      "--command=%s" % x for x in ctx.attr.cmd
+      "--command=%s" % x for x in cmd
   ] + [
       "--ports=%s" % x for x in ctx.attr.ports
   ] + [
@@ -168,17 +196,26 @@ def _repository_name(ctx):
   # the v2 registry specification.
   return _join_path(ctx.attr.repository, ctx.label.package)
 
-def _docker_build_impl(ctx):
+def implementation(ctx, files=None, directory=None,
+                   entrypoint=None, cmd=None, symlinks=None):
   """Implementation for the docker_build rule."""
 
+  files = files or ctx.files.files
+  directory = directory or ctx.attr.directory
+  entrypoint = entrypoint or ctx.attr.entrypoint
+  cmd = cmd or ctx.attr.cmd
+  symlinks = symlinks or ctx.attr.symlinks
+
   # Generate the unzipped filesystem layer, and its sha256 (aka diff_id).
-  unzipped_layer, diff_id = _build_layer(ctx)
+  unzipped_layer, diff_id = _build_layer(ctx, files=files,
+                                         directory=directory, symlinks=symlinks)
 
   # Generate the zipped filesystem layer, and its sha256 (aka blob sum)
   zipped_layer, blob_sum = _zip_layer(ctx, unzipped_layer)
 
   # Generate the new config using the attributes specified and the diff_id
-  config_file, config_digest = _image_config(ctx, diff_id)
+  config_file, config_digest = _image_config(
+    ctx, diff_id, entrypoint=entrypoint, cmd=cmd)
 
   # Construct a temporary name based on the build target.
   tag_name = _repository_name(ctx) + ":" + ctx.label.name
@@ -230,50 +267,54 @@ def _docker_build_impl(ctx):
                 files = set([ctx.outputs.layer]),
                 docker_parts = docker_parts)
 
-docker_build_ = rule(
-    attrs = {
-        "base": attr.label(allow_files = docker_filetype),
-        "data_path": attr.string(),
-        "directory": attr.string(default = "/"),
-        "tars": attr.label_list(allow_files = tar_filetype),
-        "debs": attr.label_list(allow_files = deb_filetype),
-        "files": attr.label_list(allow_files = True),
-        "legacy_repository_naming": attr.bool(default = False),
-        "mode": attr.string(default = "0555"),
-        "symlinks": attr.string_dict(),
-        "entrypoint": attr.string_list(),
-        "cmd": attr.string_list(),
-        "user": attr.string(),
-        "env": attr.string_dict(),
-        "labels": attr.string_dict(),
-        "ports": attr.string_list(),  # Skylark doesn't support int_list...
-        "volumes": attr.string_list(),
-        "workdir": attr.string(),
-        "repository": attr.string(default = "bazel"),
-        # Implicit dependencies.
-        "label_files": attr.label_list(
-            allow_files = True,
-        ),
-        "label_file_strings": attr.string_list(),
-        "build_layer": attr.label(
-            default = Label("//docker:build_tar"),
-            cfg = "host",
-            executable = True,
-            allow_files = True,
-        ),
-        "create_image_config": attr.label(
-            default = Label("//docker:create_image_config"),
-            cfg = "host",
-            executable = True,
-            allow_files = True,
-        ),
-    } + _hash_tools + _layer_tools,
+attrs = {
+  "base": attr.label(allow_files = docker_filetype),
+  "data_path": attr.string(),
+  "directory": attr.string(default = "/"),
+  "tars": attr.label_list(allow_files = tar_filetype),
+  "debs": attr.label_list(allow_files = deb_filetype),
+  "files": attr.label_list(allow_files = True),
+  "legacy_repository_naming": attr.bool(default = False),
+  "mode": attr.string(default = "0555"),
+  "symlinks": attr.string_dict(),
+  "entrypoint": attr.string_list(),
+  "cmd": attr.string_list(),
+  "user": attr.string(),
+  "env": attr.string_dict(),
+  "labels": attr.string_dict(),
+  "ports": attr.string_list(),  # Skylark doesn't support int_list...
+  "volumes": attr.string_list(),
+  "workdir": attr.string(),
+  "repository": attr.string(default = "bazel"),
+  # Implicit dependencies.
+  "label_files": attr.label_list(
+    allow_files = True,
+  ),
+  "label_file_strings": attr.string_list(),
+  "build_layer": attr.label(
+    default = Label("//docker:build_tar"),
+    cfg = "host",
     executable = True,
-    outputs = {
-        "out": "%{name}.tar",
-        "layer": "%{name}-layer.tar",
-    },
-    implementation = _docker_build_impl,
+    allow_files = True,
+  ),
+  "create_image_config": attr.label(
+    default = Label("//docker:create_image_config"),
+    cfg = "host",
+    executable = True,
+    allow_files = True,
+  ),
+} + _hash_tools + _layer_tools
+
+outputs = {
+  "out": "%{name}.tar",
+  "layer": "%{name}-layer.tar",
+}
+
+docker_build_ = rule(
+    attrs = attrs,
+    executable = True,
+    outputs = outputs,
+    implementation = implementation,
 )
 
 # This validates the two forms of value accepted by

--- a/docker/build.bzl
+++ b/docker/build.bzl
@@ -293,7 +293,7 @@ attrs = {
     "debs": attr.label_list(allow_files = deb_filetype),
     "files": attr.label_list(allow_files = True),
     "legacy_repository_naming": attr.bool(default = False),
-    "mode": attr.string(default = "0555"),   # 0555 == a+rx
+    "mode": attr.string(default = "0555"),  # 0555 == a+rx
     "symlinks": attr.string_dict(),
     "entrypoint": attr.string_list(),
     "cmd": attr.string_list(),

--- a/docker/build.bzl
+++ b/docker/build.bzl
@@ -268,46 +268,46 @@ def implementation(ctx, files=None, directory=None,
                 docker_parts = docker_parts)
 
 attrs = {
-  "base": attr.label(allow_files = docker_filetype),
-  "data_path": attr.string(),
-  "directory": attr.string(default = "/"),
-  "tars": attr.label_list(allow_files = tar_filetype),
-  "debs": attr.label_list(allow_files = deb_filetype),
-  "files": attr.label_list(allow_files = True),
-  "legacy_repository_naming": attr.bool(default = False),
-  "mode": attr.string(default = "0555"),
-  "symlinks": attr.string_dict(),
-  "entrypoint": attr.string_list(),
-  "cmd": attr.string_list(),
-  "user": attr.string(),
-  "env": attr.string_dict(),
-  "labels": attr.string_dict(),
-  "ports": attr.string_list(),  # Skylark doesn't support int_list...
-  "volumes": attr.string_list(),
-  "workdir": attr.string(),
-  "repository": attr.string(default = "bazel"),
-  # Implicit dependencies.
-  "label_files": attr.label_list(
-    allow_files = True,
-  ),
-  "label_file_strings": attr.string_list(),
-  "build_layer": attr.label(
-    default = Label("//docker:build_tar"),
-    cfg = "host",
-    executable = True,
-    allow_files = True,
-  ),
-  "create_image_config": attr.label(
-    default = Label("//docker:create_image_config"),
-    cfg = "host",
-    executable = True,
-    allow_files = True,
-  ),
+    "base": attr.label(allow_files = docker_filetype),
+    "data_path": attr.string(),
+    "directory": attr.string(default = "/"),
+    "tars": attr.label_list(allow_files = tar_filetype),
+    "debs": attr.label_list(allow_files = deb_filetype),
+    "files": attr.label_list(allow_files = True),
+    "legacy_repository_naming": attr.bool(default = False),
+    "mode": attr.string(default = "0555"),
+    "symlinks": attr.string_dict(),
+    "entrypoint": attr.string_list(),
+    "cmd": attr.string_list(),
+    "user": attr.string(),
+    "env": attr.string_dict(),
+    "labels": attr.string_dict(),
+    "ports": attr.string_list(),  # Skylark doesn't support int_list...
+    "volumes": attr.string_list(),
+    "workdir": attr.string(),
+    "repository": attr.string(default = "bazel"),
+    # Implicit dependencies.
+    "label_files": attr.label_list(
+        allow_files = True,
+    ),
+    "label_file_strings": attr.string_list(),
+    "build_layer": attr.label(
+        default = Label("//docker:build_tar"),
+        cfg = "host",
+        executable = True,
+        allow_files = True,
+    ),
+    "create_image_config": attr.label(
+        default = Label("//docker:create_image_config"),
+        cfg = "host",
+        executable = True,
+        allow_files = True,
+    ),
 } + _hash_tools + _layer_tools
 
 outputs = {
-  "out": "%{name}.tar",
-  "layer": "%{name}-layer.tar",
+    "out": "%{name}.tar",
+    "layer": "%{name}-layer.tar",
 }
 
 docker_build_ = rule(

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -760,6 +760,33 @@ function test_cc_image() {
 /app/docker/testdata/cc_image.binary'
 }
 
+function test_war_image() {
+  # Don't check the full layer set because the base will vary,
+  # but check the files in our top two layers.
+  local layers=($(get_layers "war_image"))
+  local length="${#layers[@]}"
+  local lib_layer=$(dirname "${layers[$((length-2))]}")
+  local bin_layer=$(dirname "${layers[$((length-1))]}")
+
+  check_listing "war_image" "${lib_layer}" \
+'./
+./jetty/
+./jetty/webapps/
+./jetty/webapps/ROOT/
+./jetty/webapps/ROOT/WEB-INF/
+./jetty/webapps/ROOT/WEB-INF/lib/
+./jetty/webapps/ROOT/WEB-INF/lib/javax.servlet-api-3.0.1.jar'
+
+  check_listing "war_image" "${bin_layer}" \
+'./
+./jetty/
+./jetty/webapps/
+./jetty/webapps/ROOT/
+./jetty/webapps/ROOT/WEB-INF/
+./jetty/webapps/ROOT/WEB-INF/lib/
+./jetty/webapps/ROOT/WEB-INF/lib/libwar_image.library.jar'
+}
+
 tests=$(grep "^function test_" "${BASH_SOURCE[0]}" \
           | cut -d' ' -f 2 | cut -d'(' -f 1)
 

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -698,13 +698,10 @@ function test_py_image() {
     './
 ./app/
 ./app/docker/
+./app/docker/__init__.py
 ./app/docker/testdata/
-./app/docker/testdata/py_image_library.py
-/app/
-/app/docker/
-/app/docker/__init__.py
-/app/docker/testdata/
-/app/docker/testdata/__init__.py'
+./app/docker/testdata/__init__.py
+./app/docker/testdata/py_image_library.py'
 
   check_listing "py_image" "${bin_layer}" \
     './

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -732,6 +732,34 @@ function test_py_image() {
 /app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/docker/testdata/py_image_library.py'
 }
 
+function test_cc_image() {
+  # Don't check the full layer set because the base will vary,
+  # but check the files in our top two layers.
+  local layers=($(get_layers "cc_image"))
+  local length="${#layers[@]}"
+  local lib_layer=$(dirname "${layers[$((length-2))]}")
+  local bin_layer=$(dirname "${layers[$((length-1))]}")
+
+  # The linker pulls the object files into the final binary,
+  # so in C++ dependencies don't help when specified via `layers`.
+  check_listing "cc_image" "${lib_layer}" ''
+
+  check_listing "cc_image" "${bin_layer}" \
+    './
+./app/
+./app/docker/
+./app/docker/testdata/
+./app/docker/testdata/cc_image.binary.runfiles/
+./app/docker/testdata/cc_image.binary.runfiles/io_bazel_rules_docker/
+./app/docker/testdata/cc_image.binary.runfiles/io_bazel_rules_docker/docker/
+./app/docker/testdata/cc_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/
+./app/docker/testdata/cc_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/cc_image.binary
+/app/
+/app/docker/
+/app/docker/testdata/
+/app/docker/testdata/cc_image.binary'
+}
+
 tests=$(grep "^function test_" "${BASH_SOURCE[0]}" \
           | cut -d' ' -f 2 | cut -d'(' -f 1)
 

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -667,6 +667,52 @@ function test_build_with_passwd() {
   check_eq ${passwd_contents} "foobar:x:1234:2345:myusernameinfo:/myhomedir:/myshell"
 }
 
+function test_py_image() {
+  # Don't check the full layer set because the base will vary,
+  # but check the files in our top two layers.
+  local lib_layer="e630f7fae644295272b97017c0720a9eef05ca669766777fcfa4c98be8ee8fca"
+  local bin_layer="f81fc255066d534e7b85acdc37b353ebf3cb818a263af108eca567a1ec29af4a"
+
+  # TODO(mattmoor): The path normalization for symlinks should match
+  # files to avoid this redundancy.
+  check_listing "py_image" "${lib_layer}" \
+    './
+./app/
+./app/docker/
+./app/docker/testdata/
+./app/docker/testdata/py_image_library.py
+/app/
+/app/docker/
+/app/docker/__init__.py
+/app/docker/testdata/
+/app/docker/testdata/__init__.py'
+
+  check_listing "py_image" "${bin_layer}" \
+    './
+./app/
+./app/docker/
+./app/docker/testdata/
+./app/docker/testdata/py_image.binary.runfiles/
+./app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/
+./app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/
+./app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/
+./app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/py_image.binary
+./app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/py_image.py
+/app/
+/app/docker/
+/app/docker/testdata/
+/app/docker/testdata/py_image.binary
+/app/docker/testdata/py_image.binary.runfiles/
+/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/
+/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/
+/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/
+/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/docker/
+/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/docker/__init__.py
+/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/docker/testdata/
+/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/docker/testdata/__init__.py
+/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/docker/testdata/py_image_library.py'
+}
+
 tests=$(grep "^function test_" "${BASH_SOURCE[0]}" \
           | cut -d' ' -f 2 | cut -d'(' -f 1)
 

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -760,6 +760,30 @@ function test_cc_image() {
 /app/docker/testdata/cc_image.binary'
 }
 
+function test_java_image() {
+  # Don't check the full layer set because the base will vary,
+  # but check the files in our top two layers.
+  local layers=($(get_layers "java_image"))
+  local length="${#layers[@]}"
+  local lib_layer=$(dirname "${layers[$((length-2))]}")
+  local bin_layer=$(dirname "${layers[$((length-1))]}")
+
+  check_listing "java_image" "${lib_layer}" \
+'./
+./app/
+./app/docker/
+./app/docker/testdata/
+./app/docker/testdata/libjava_image_library.jar'
+
+  check_listing "java_image" "${bin_layer}" \
+'./
+./app/
+./app/docker/
+./app/docker/testdata/
+./app/docker/testdata/java_image.binary
+./app/docker/testdata/java_image.binary.jar'
+}
+
 function test_war_image() {
   # Don't check the full layer set because the base will vary,
   # but check the files in our top two layers.

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -688,8 +688,9 @@ function test_py_image() {
   # Don't check the full layer set because the base will vary,
   # but check the files in our top two layers.
   local layers=($(get_layers "py_image"))
-  local lib_layer=$(dirname "${layers[-2]}")
-  local bin_layer=$(dirname "${layers[-1]}")
+  local length="${#layers[@]}"
+  local lib_layer=$(dirname "${layers[$((length-2))]}")
+  local bin_layer=$(dirname "${layers[$((length-1))]}")
 
   # TODO(mattmoor): The path normalization for symlinks should match
   # files to avoid this redundancy.

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -680,7 +680,7 @@ with tarfile.open("${test_data}", "r") as tar:
   assert len(manifests) == 1
   for m in manifests:
     for l in m["Layers"]:
-      print l
+      print(l)
 EOF
 }
 

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -768,10 +768,15 @@ function test_java_image() {
   local lib_layer=$(dirname "${layers[$((length-2))]}")
   local bin_layer=$(dirname "${layers[$((length-1))]}")
 
+  # The path here for Guava is *really* weird, which is a function
+  # of the bug linked from build.bzl's magic_path function.
   check_listing "java_image" "${lib_layer}" \
 './
 ./app/
 ./app/docker/
+./app/docker/com_google_guava_guava/
+./app/docker/com_google_guava_guava/jar/
+./app/docker/com_google_guava_guava/jar/guava-18.0.jar
 ./app/docker/testdata/
 ./app/docker/testdata/libjava_image_library.jar'
 

--- a/docker/contrib/cc/BUILD
+++ b/docker/contrib/cc/BUILD
@@ -1,0 +1,16 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0

--- a/docker/contrib/cc/image.bzl
+++ b/docker/contrib/cc/image.bzl
@@ -17,12 +17,11 @@ The signature of this rule is compatible with cc_binary.
 """
 
 load(
-  "//docker:build.bzl",
-  _build_attrs="attrs",
-  _build_outputs="outputs",
-  _build_implementation="implementation",
+    "//docker:build.bzl",
+    _build_attrs = "attrs",
+    _build_implementation = "implementation",
+    _build_outputs = "outputs",
 )
-
 load("//docker:pull.bzl", "docker_pull")
 
 # TODO(mattmoor): If we can share this stuff with the other
@@ -48,13 +47,13 @@ def _dep_layer_impl(ctx):
 
 _dep_layer = rule(
     attrs = _build_attrs + {
-	# The base image on which to overlay the dependency layers.
+        # The base image on which to overlay the dependency layers.
         "base": attr.label(default = Label("@cc_image_base//image")),
-	# The dependency whose runfiles we're appending.
+        # The dependency whose runfiles we're appending.
         "dep": attr.label(mandatory = True),
 
         # Override the defaults.
-	# https://github.com/bazelbuild/bazel/issues/2176
+        # https://github.com/bazelbuild/bazel/issues/2176
         "data_path": attr.string(default = "."),
         "directory": attr.string(default = "/app"),
     },
@@ -126,10 +125,10 @@ _app_layer = rule(
     attrs = _build_attrs + {
         # The cc_binary target for which we are synthesizing an image.
         "binary": attr.label(mandatory = True),
-	# The full list of dependencies that have their own layers
+        # The full list of dependencies that have their own layers
         # factored into our base.
         "layers": attr.label_list(),
-	# The base image on which to overlay the dependency layers.
+        # The base image on which to overlay the dependency layers.
         "base": attr.label(default = Label("@cc_image_base//image")),
 
         # Override the defaults.
@@ -172,4 +171,3 @@ def cc_image(name, deps=[], layers=[], **kwargs):
     index += 1
 
   _app_layer(name=name, base=base, binary=binary_name, layers=layers)
-

--- a/docker/contrib/cc/image.bzl
+++ b/docker/contrib/cc/image.bzl
@@ -44,6 +44,9 @@ def cc_image(name, base=None, deps=[], layers=[], **kwargs):
   """
   binary_name = name + ".binary"
 
+  if layers:
+    print("cc_image does not benefit from layers=[], got: %s" % layers)
+
   native.cc_binary(name=binary_name, deps=deps + layers, **kwargs)
 
   index = 0

--- a/docker/contrib/cc/image.bzl
+++ b/docker/contrib/cc/image.bzl
@@ -34,7 +34,7 @@ def repositories():
       digest = "sha256:942eb947818e7e32200950b600cc94d5477b03e0b99bf732b4c1e2bba6eec717",
     )
 
-def cc_image(name, deps=[], layers=[], **kwargs):
+def cc_image(name, base=None, deps=[], layers=[], **kwargs):
   """Constructs a Docker image wrapping a cc_binary target.
 
   Args:
@@ -47,7 +47,7 @@ def cc_image(name, deps=[], layers=[], **kwargs):
   native.cc_binary(name=binary_name, deps=deps + layers, **kwargs)
 
   index = 0
-  base = "@cc_image_base//image"
+  base = base or "@cc_image_base//image"
   for dep in layers:
     this_name = "%s.%d" % (name, index)
     dep_layer(name=this_name, base=base, dep=dep)

--- a/docker/contrib/cc/image.bzl
+++ b/docker/contrib/cc/image.bzl
@@ -17,128 +17,11 @@ The signature of this rule is compatible with cc_binary.
 """
 
 load(
-    "//docker:build.bzl",
-    _build_attrs = "attrs",
-    _build_implementation = "implementation",
-    _build_outputs = "outputs",
+    "//docker/contrib/common:lang-image.bzl",
+    "dep_layer",
+    "app_layer",
 )
 load("//docker:pull.bzl", "docker_pull")
-
-# TODO(mattmoor): If we can share this stuff with the other
-# languages, then factor out a helper.
-def _dep_layer_impl(ctx):
-  """Appends a layer for a single dependency's runfiles."""
-
-  return _build_implementation(
-    ctx,
-    # We put the files from dependency layers into a binary-agnostic
-    # path to increase the likelihood of layer sharing across images,
-    # then we symlink them into the appropriate place in the app layer.
-    # This references the binary package because the file paths are
-    # relative to it, and normalized by the tarball package.
-    directory="/app/" + ctx.label.package,
-    files=list(ctx.attr.dep.default_runfiles.files),
-    symlinks={
-      # Handle empty files by linking to /dev/null
-      "/app/" + empty: "/dev/null"
-      for empty in ctx.attr.dep.default_runfiles.empty_filenames
-    }
-  )
-
-_dep_layer = rule(
-    attrs = _build_attrs + {
-        # The base image on which to overlay the dependency layers.
-        "base": attr.label(default = Label("@cc_image_base//image")),
-        # The dependency whose runfiles we're appending.
-        "dep": attr.label(mandatory = True),
-
-        # Override the defaults.
-        # https://github.com/bazelbuild/bazel/issues/2176
-        "data_path": attr.string(default = "."),
-        "directory": attr.string(default = "/app"),
-    },
-    executable = True,
-    outputs = _build_outputs,
-    implementation = _dep_layer_impl,
-)
-
-def _app_layer_impl(ctx):
-  """Appends the app layer with all remaining runfiles."""
-
-  # Compute the set of runfiles that have been made available
-  # in our base image.
-  available = set()
-  for dep in ctx.attr.layers:
-    available += [f.short_path for f in dep.default_runfiles.files]
-    available += [f for f in dep.default_runfiles.empty_filenames]
-
-  # The name of the binary target for which we are populating
-  # this application layer.
-  basename = ctx.attr.binary.label.name
-  binary_name = "/".join([
-    "/app",
-    ctx.label.package,
-    basename
-  ])
-
-  # Empty filenames are relative to this base.
-  base_directory = "/".join([
-    binary_name + ".runfiles",
-    ctx.workspace_name,
-  ])
-  # All of the files are included with paths relative to
-  # this directory.
-  directory = "/".join([base_directory, ctx.label.package])
-
-  # Compute the set of remaining runfiles to include into the
-  # application layer.
-  files = [f for f in ctx.attr.binary.default_runfiles.files
-           if f.short_path not in available]
-
-  empty_files = [f for f in ctx.attr.binary.default_runfiles.empty_filenames
-                 if f not in available]
-
-  # For each of the runfiles we aren't including directly into
-  # the application layer, link to their binary-agnostic
-  # location from the runfiles path.
-  symlinks = {
-    binary_name: directory + "/" + basename
-  } + {
-    directory + "/" + input: "/app/" + input
-    for input in available
-  } + {
-    # Handle empty files by linking to /dev/null
-    base_directory + "/" + empty: "/dev/null"
-    for empty in empty_files
-  }
-
-  return _build_implementation(
-    ctx, files=files,
-    # Use entrypoint so we can easily add arguments when the resulting
-    # image is `docker run ...`.
-    # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
-    # we should use the "exec" (list) form of entrypoint.
-    entrypoint=[binary_name],
-    directory=directory, symlinks=symlinks)
-
-_app_layer = rule(
-    attrs = _build_attrs + {
-        # The cc_binary target for which we are synthesizing an image.
-        "binary": attr.label(mandatory = True),
-        # The full list of dependencies that have their own layers
-        # factored into our base.
-        "layers": attr.label_list(),
-        # The base image on which to overlay the dependency layers.
-        "base": attr.label(default = Label("@cc_image_base//image")),
-
-        # Override the defaults.
-        "data_path": attr.string(default = "."),
-        "workdir": attr.string(default = "/app"),
-    },
-    executable = True,
-    outputs = _build_outputs,
-    implementation = _app_layer_impl,
-)
 
 def repositories():
   excludes = native.existing_rules().keys()
@@ -155,7 +38,8 @@ def cc_image(name, deps=[], layers=[], **kwargs):
   """Constructs a Docker image wrapping a cc_binary target.
 
   Args:
-    layers: Augments "deps" with dependencies that should be put into their own layers.
+    layers: Augments "deps" with dependencies that should be put into
+           their own layers.
     **kwargs: See cc_binary.
   """
   binary_name = name + ".binary"
@@ -163,11 +47,11 @@ def cc_image(name, deps=[], layers=[], **kwargs):
   native.cc_binary(name=binary_name, deps=deps + layers, **kwargs)
 
   index = 0
-  base = None # Makes us use ctx.attr.base
+  base = "@cc_image_base//image"
   for dep in layers:
     this_name = "%s.%d" % (name, index)
-    _dep_layer(name=this_name, base=base, dep=dep)
+    dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
     index += 1
 
-  _app_layer(name=name, base=base, binary=binary_name, layers=layers)
+  app_layer(name=name, base=base, binary=binary_name, layers=layers)

--- a/docker/contrib/cc/image.bzl
+++ b/docker/contrib/cc/image.bzl
@@ -1,0 +1,173 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A rule for creating a C++ Docker image.
+
+The signature of this rule is compatible with cc_binary.
+"""
+
+load(
+  "//docker:build.bzl",
+  _build_attrs="attrs",
+  _build_outputs="outputs",
+  _build_implementation="implementation",
+)
+
+load("//docker:pull.bzl", "docker_pull")
+
+# TODO(mattmoor): If we can share this stuff with the other
+# languages, then factor out a helper.
+def _dep_layer_impl(ctx):
+  """Appends a layer for a single dependencies runfiles."""
+
+  return _build_implementation(
+    ctx,
+    # We put the files from dependency layers into a binary-agnostic
+    # path to increase the likelihood of layer sharing across images,
+    # then we symlink them into the appropriate place in the app layer.
+    # This references the binary package because the file paths are
+    # relative to it, and normalized by the tarball package.
+    directory="/app/" + ctx.label.package,
+    files=list(ctx.attr.dep.default_runfiles.files),
+    symlinks={
+      # Handle empty files by linking to /dev/null
+      "/app/" + empty: "/dev/null"
+      for empty in ctx.attr.dep.default_runfiles.empty_filenames
+    }
+  )
+
+_dep_layer = rule(
+    attrs = _build_attrs + {
+	# The base image on which to overlay the dependency layers.
+        "base": attr.label(default = Label("@cc_image_base//image")),
+	# The dependency whose runfiles we're appending.
+        "dep": attr.label(mandatory = True),
+
+        # Override the defaults.
+        "data_path": attr.string(default = "."),
+        "directory": attr.string(default = "/app"),
+    },
+    executable = True,
+    outputs = _build_outputs,
+    implementation = _dep_layer_impl,
+)
+
+def _app_layer_impl(ctx):
+  """Appends the app layer with all remaining runfiles."""
+
+  # Compute the set of runfiles that have been made available
+  # in our base image.
+  available = set()
+  for dep in ctx.attr.layers:
+    available += [f.short_path for f in dep.default_runfiles.files]
+    available += [f for f in dep.default_runfiles.empty_filenames]
+
+  # The name of the binary target for which we are populating
+  # this application layer.
+  basename = ctx.attr.binary.label.name
+  binary_name = "/".join([
+    "/app",
+    ctx.label.package,
+    basename
+  ])
+
+  # Empty filenames are relative to this base.
+  base_directory = "/".join([
+    binary_name + ".runfiles",
+    ctx.workspace_name,
+  ])
+  # All of the files are included with paths relative to
+  # this directory.
+  directory = "/".join([base_directory, ctx.label.package])
+
+  # Compute the set of remaining runfiles to include into the
+  # application layer.
+  files = [f for f in ctx.attr.binary.default_runfiles.files
+           if f.short_path not in available]
+
+  empty_files = [f for f in ctx.attr.binary.default_runfiles.empty_filenames
+                 if f not in available]
+
+  # For each of the runfiles we aren't including directly into
+  # the application layer, link to their binary-agnostic
+  # location from the runfiles path.
+  symlinks = {
+    binary_name: directory + "/" + basename
+  } + {
+    directory + "/" + input: "/app/" + input
+    for input in available
+  } + {
+    # Handle empty files by linking to /dev/null
+    base_directory + "/" + empty: "/dev/null"
+    for empty in empty_files
+  }
+
+  return _build_implementation(
+    ctx, files=files,
+    # Use entrypoint so we can easily add arguments when the resulting
+    # image is `docker run ...`.
+    # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
+    # we should use the "exec" (list) form of entrypoint.
+    entrypoint=[binary_name],
+    directory=directory, symlinks=symlinks)
+
+_app_layer = rule(
+    attrs = _build_attrs + {
+        # The cc_binary target for which we are synthesizing an image.
+        "binary": attr.label(mandatory = True),
+	# The full list of dependencies that have their own layers
+        # factored into our base.
+        "layers": attr.label_list(),
+	# The base image on which to overlay the dependency layers.
+        "base": attr.label(default = Label("@cc_image_base//image")),
+
+        # Override the defaults.
+        "data_path": attr.string(default = "."),
+        "workdir": attr.string(default = "/app"),
+    },
+    executable = True,
+    outputs = _build_outputs,
+    implementation = _app_layer_impl,
+)
+
+def repositories():
+  excludes = native.existing_rules().keys()
+  if "cc_image_base" not in excludes:
+    docker_pull(
+      name = "cc_image_base",
+      registry = "gcr.io",
+      repository = "distroless/cc",
+      # 'latest' circa 2017-07-21
+      digest = "sha256:942eb947818e7e32200950b600cc94d5477b03e0b99bf732b4c1e2bba6eec717",
+    )
+
+def cc_image(name, deps=[], layers=[], **kwargs):
+  """Constructs a Docker image wrapping a cc_binary target.
+
+  Args:
+    **kwargs: See cc_binary.
+  """
+  binary_name = name + ".binary"
+
+  native.cc_binary(name=binary_name, deps=deps + layers, **kwargs)
+
+  index = 0
+  base = None # Makes us use ctx.attr.base
+  for dep in layers:
+    this_name = "%s.%d" % (name, index)
+    _dep_layer(name=this_name, base=base, dep=dep)
+    base = this_name
+    index += 1
+
+  _app_layer(name=name, base=base, binary=binary_name, layers=layers)
+

--- a/docker/contrib/cc/image.bzl
+++ b/docker/contrib/cc/image.bzl
@@ -28,7 +28,7 @@ load("//docker:pull.bzl", "docker_pull")
 # TODO(mattmoor): If we can share this stuff with the other
 # languages, then factor out a helper.
 def _dep_layer_impl(ctx):
-  """Appends a layer for a single dependencies runfiles."""
+  """Appends a layer for a single dependency's runfiles."""
 
   return _build_implementation(
     ctx,
@@ -54,6 +54,7 @@ _dep_layer = rule(
         "dep": attr.label(mandatory = True),
 
         # Override the defaults.
+	# https://github.com/bazelbuild/bazel/issues/2176
         "data_path": attr.string(default = "."),
         "directory": attr.string(default = "/app"),
     },
@@ -155,6 +156,7 @@ def cc_image(name, deps=[], layers=[], **kwargs):
   """Constructs a Docker image wrapping a cc_binary target.
 
   Args:
+    layers: Augments "deps" with dependencies that should be put into their own layers.
     **kwargs: See cc_binary.
   """
   binary_name = name + ".binary"

--- a/docker/contrib/common/BUILD
+++ b/docker/contrib/common/BUILD
@@ -1,0 +1,16 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0

--- a/docker/contrib/common/lang-image.bzl
+++ b/docker/contrib/common/lang-image.bzl
@@ -15,17 +15,15 @@
 """
 
 load(
-    "//docker:build.bzl",
-    _build_attrs = "attrs",
-    _build_implementation = "implementation",
-    _build_outputs = "outputs",
+    "//docker:docker.bzl",
+    _docker = "docker",
 )
 load("//docker:pull.bzl", "docker_pull")
 
 def _dep_layer_impl(ctx):
   """Appends a layer for a single dependency's runfiles."""
 
-  return _build_implementation(
+  return _docker.build.implementation(
     ctx,
     # We put the files from dependency layers into a binary-agnostic
     # path to increase the likelihood of layer sharing across images,
@@ -46,7 +44,7 @@ def _dep_layer_impl(ctx):
   )
 
 dep_layer = rule(
-    attrs = _build_attrs + {
+    attrs = _docker.build.attrs + {
         # The base image on which to overlay the dependency layers.
         "base": attr.label(mandatory = True),
         # The dependency whose runfiles we're appending.
@@ -58,7 +56,7 @@ dep_layer = rule(
         "directory": attr.string(default = "/app"),
     },
     executable = True,
-    outputs = _build_outputs,
+    outputs = _docker.build.outputs,
     implementation = _dep_layer_impl,
 )
 
@@ -120,7 +118,7 @@ def _app_layer_impl(ctx):
     for empty in empty_files
   }
 
-  return _build_implementation(
+  return _docker.build.implementation(
     ctx, files=files,
     # Use entrypoint so we can easily add arguments when the resulting
     # image is `docker run ...`.
@@ -130,7 +128,7 @@ def _app_layer_impl(ctx):
     directory=directory, symlinks=symlinks)
 
 app_layer = rule(
-    attrs = _build_attrs + {
+    attrs = _docker.build.attrs + {
         # The binary target for which we are synthesizing an image.
         "binary": attr.label(mandatory = True),
         # The full list of dependencies that have their own layers
@@ -146,6 +144,6 @@ app_layer = rule(
         "directory": attr.string(default = "/app"),
     },
     executable = True,
-    outputs = _build_outputs,
+    outputs = _docker.build.outputs,
     implementation = _app_layer_impl,
 )

--- a/docker/contrib/common/lang-image.bzl
+++ b/docker/contrib/common/lang-image.bzl
@@ -1,0 +1,151 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers for synthesizing foo_image targets matching foo_binary.
+"""
+
+load(
+    "//docker:build.bzl",
+    _build_attrs = "attrs",
+    _build_implementation = "implementation",
+    _build_outputs = "outputs",
+)
+load("//docker:pull.bzl", "docker_pull")
+
+def _dep_layer_impl(ctx):
+  """Appends a layer for a single dependency's runfiles."""
+
+  return _build_implementation(
+    ctx,
+    # We put the files from dependency layers into a binary-agnostic
+    # path to increase the likelihood of layer sharing across images,
+    # then we symlink them into the appropriate place in the app layer.
+    # This references the binary package because the file paths are
+    # relative to it, and normalized by the tarball package.
+    directory=ctx.attr.directory + "/" + ctx.label.package,
+    files=list(ctx.attr.dep.default_runfiles.files),
+    symlinks={
+      # Handle empty files by linking to /dev/null
+      # TODO(mattmoor): This doesn't work in Python3,
+      # so investigate how to properly create empty files.
+      #   bazelbuild/bazel#1458
+      #   http://bugs.python.org/issue28425
+      ctx.attr.directory + "/" + empty: "/dev/null"
+      for empty in ctx.attr.dep.default_runfiles.empty_filenames
+    }
+  )
+
+dep_layer = rule(
+    attrs = _build_attrs + {
+        # The base image on which to overlay the dependency layers.
+        "base": attr.label(mandatory = True),
+        # The dependency whose runfiles we're appending.
+        "dep": attr.label(mandatory = True),
+
+        # Override the defaults.
+        # https://github.com/bazelbuild/bazel/issues/2176
+        "data_path": attr.string(default = "."),
+        "directory": attr.string(default = "/app"),
+    },
+    executable = True,
+    outputs = _build_outputs,
+    implementation = _dep_layer_impl,
+)
+
+def _app_layer_impl(ctx):
+  """Appends the app layer with all remaining runfiles."""
+
+  # Compute the set of runfiles that have been made available
+  # in our base image.
+  available = set()
+  for dep in ctx.attr.layers:
+    available += [f.short_path for f in dep.default_runfiles.files]
+    available += [f for f in dep.default_runfiles.empty_filenames]
+
+  # The name of the binary target for which we are populating
+  # this application layer.
+  basename = ctx.attr.binary.label.name
+  binary_name = "/".join([
+    ctx.attr.directory,
+    ctx.label.package,
+    basename
+  ])
+
+  # Empty filenames are relative to this base.
+  base_directory = "/".join([
+    binary_name + ".runfiles",
+    ctx.workspace_name,
+  ])
+  # All of the files are included with paths relative to
+  # this directory.
+  directory = "/".join([base_directory, ctx.label.package])
+
+  # Compute the set of remaining runfiles to include into the
+  # application layer.
+  files = [f for f in ctx.attr.binary.default_runfiles.files
+           # It is notable that this assumes that our version of
+	   # this runfile matches that of the dependency.  It is
+	   # not clear at this time whether that is an invariant
+	   # broadly in Bazel.
+           if f.short_path not in available]
+
+  empty_files = [f for f in ctx.attr.binary.default_runfiles.empty_filenames
+                 if f not in available]
+
+  # For each of the runfiles we aren't including directly into
+  # the application layer, link to their binary-agnostic
+  # location from the runfiles path.
+  symlinks = {
+    binary_name: directory + "/" + basename
+  } + {
+    directory + "/" + input: ctx.attr.directory + "/" + input
+    for input in available
+  } + {
+    # Handle empty files by linking to /dev/null
+    # TODO(mattmoor): This doesn't work in Python3,
+    # so investigate how to properly create empty files.
+    #   bazelbuild/bazel#1458
+    #   http://bugs.python.org/issue28425
+    base_directory + "/" + empty: "/dev/null"
+    for empty in empty_files
+  }
+
+  return _build_implementation(
+    ctx, files=files,
+    # Use entrypoint so we can easily add arguments when the resulting
+    # image is `docker run ...`.
+    # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
+    # we should use the "exec" (list) form of entrypoint.
+    entrypoint=ctx.attr.entrypoint + [binary_name],
+    directory=directory, symlinks=symlinks)
+
+app_layer = rule(
+    attrs = _build_attrs + {
+        # The binary target for which we are synthesizing an image.
+        "binary": attr.label(mandatory = True),
+        # The full list of dependencies that have their own layers
+        # factored into our base.
+        "layers": attr.label_list(),
+        # The base image on which to overlay the dependency layers.
+        "base": attr.label(mandatory = True),
+        "entrypoint": attr.string_list(default = []),
+
+        # Override the defaults.
+        "data_path": attr.string(default = "."),
+        "workdir": attr.string(default = "/app"),
+        "directory": attr.string(default = "/app"),
+    },
+    executable = True,
+    outputs = _build_outputs,
+    implementation = _app_layer_impl,
+)

--- a/docker/contrib/go/BUILD
+++ b/docker/contrib/go/BUILD
@@ -1,0 +1,16 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0

--- a/docker/contrib/go/image.bzl
+++ b/docker/contrib/go/image.bzl
@@ -1,0 +1,178 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A rule for creating a Go Docker image.
+
+The signature of this rule is compatible with go_binary.
+"""
+
+load(
+  "//docker:build.bzl",
+  _build_attrs="attrs",
+  _build_outputs="outputs",
+  _build_implementation="implementation",
+)
+
+load("//docker:pull.bzl", "docker_pull")
+
+# It is expected that the Go rules have been properly
+# initialized before loading this file to initialize
+# go_image.
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+# TODO(mattmoor): If we can share this stuff with the other
+# languages, then factor out a helper.
+def _dep_layer_impl(ctx):
+  """Appends a layer for a single dependencies runfiles."""
+
+  return _build_implementation(
+    ctx,
+    # We put the files from dependency layers into a binary-agnostic
+    # path to increase the likelihood of layer sharing across images,
+    # then we symlink them into the appropriate place in the app layer.
+    # This references the binary package because the file paths are
+    # relative to it, and normalized by the tarball package.
+    directory="/app/" + ctx.label.package,
+    files=list(ctx.attr.dep.default_runfiles.files),
+    symlinks={
+      # Handle empty files by linking to /dev/null
+      "/app/" + empty: "/dev/null"
+      for empty in ctx.attr.dep.default_runfiles.empty_filenames
+    }
+  )
+
+_dep_layer = rule(
+    attrs = _build_attrs + {
+	# The base image on which to overlay the dependency layers.
+        "base": attr.label(default = Label("@go_image_base//image")),
+	# The dependency whose runfiles we're appending.
+        "dep": attr.label(mandatory = True),
+
+        # Override the defaults.
+        "data_path": attr.string(default = "."),
+        "directory": attr.string(default = "/app"),
+    },
+    executable = True,
+    outputs = _build_outputs,
+    implementation = _dep_layer_impl,
+)
+
+def _app_layer_impl(ctx):
+  """Appends the app layer with all remaining runfiles."""
+
+  # Compute the set of runfiles that have been made available
+  # in our base image.
+  available = set()
+  for dep in ctx.attr.layers:
+    available += [f.short_path for f in dep.default_runfiles.files]
+    available += [f for f in dep.default_runfiles.empty_filenames]
+
+  # The name of the binary target for which we are populating
+  # this application layer.
+  basename = ctx.attr.binary.label.name
+  binary_name = "/".join([
+    "/app",
+    ctx.label.package,
+    basename
+  ])
+
+  # Empty filenames are relative to this base.
+  base_directory = "/".join([
+    binary_name + ".runfiles",
+    ctx.workspace_name,
+  ])
+  # All of the files are included with paths relative to
+  # this directory.
+  directory = "/".join([base_directory, ctx.label.package])
+
+  # Compute the set of remaining runfiles to include into the
+  # application layer.
+  files = [f for f in ctx.attr.binary.default_runfiles.files
+           if f.short_path not in available]
+
+  empty_files = [f for f in ctx.attr.binary.default_runfiles.empty_filenames
+                 if f not in available]
+
+  # For each of the runfiles we aren't including directly into
+  # the application layer, link to their binary-agnostic
+  # location from the runfiles path.
+  symlinks = {
+    binary_name: directory + "/" + basename
+  } + {
+    directory + "/" + input: "/app/" + input
+    for input in available
+  } + {
+    # Handle empty files by linking to /dev/null
+    base_directory + "/" + empty: "/dev/null"
+    for empty in empty_files
+  }
+
+  return _build_implementation(
+    ctx, files=files,
+    # Use entrypoint so we can easily add arguments when the resulting
+    # image is `docker run ...`.
+    # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
+    # we should use the "exec" (list) form of entrypoint.
+    entrypoint=[binary_name],
+    directory=directory, symlinks=symlinks)
+
+_app_layer = rule(
+    attrs = _build_attrs + {
+        # The go_binary target for which we are synthesizing an image.
+        "binary": attr.label(mandatory = True),
+	# The full list of dependencies that have their own layers
+        # factored into our base.
+        "layers": attr.label_list(),
+	# The base image on which to overlay the dependency layers.
+        "base": attr.label(default = Label("@go_image_base//image")),
+
+        # Override the defaults.
+        "data_path": attr.string(default = "."),
+        "workdir": attr.string(default = "/app"),
+    },
+    executable = True,
+    outputs = _build_outputs,
+    implementation = _app_layer_impl,
+)
+
+def repositories():
+  excludes = native.existing_rules().keys()
+  if "go_image_base" not in excludes:
+    docker_pull(
+      name = "go_image_base",
+      registry = "gcr.io",
+      repository = "distroless/base",
+      # 'latest' circa 2017-07-21
+      digest = "sha256:06fcd3edcfeefe13b82fa8bdb9e3f4fa3bf4c7e8fe997bee0230e392f77d0e04",
+    )
+
+def go_image(name, deps=[], layers=[], **kwargs):
+  """Constructs a Docker image wrapping a go_binary target.
+
+  Args:
+    **kwargs: See go_binary.
+  """
+  binary_name = name + ".binary"
+
+  go_binary(name=binary_name, deps=deps + layers, **kwargs)
+
+  index = 0
+  base = None # Makes us use ctx.attr.base
+  for dep in layers:
+    this_name = "%s.%d" % (name, index)
+    _dep_layer(name=this_name, base=base, dep=dep)
+    base = this_name
+    index += 1
+
+  _app_layer(name=name, base=base, binary=binary_name, layers=layers)
+

--- a/docker/contrib/go/image.bzl
+++ b/docker/contrib/go/image.bzl
@@ -33,7 +33,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 # TODO(mattmoor): If we can share this stuff with the other
 # languages, then factor out a helper.
 def _dep_layer_impl(ctx):
-  """Appends a layer for a single dependencies runfiles."""
+  """Appends a layer for a single dependency's runfiles."""
 
   return _build_implementation(
     ctx,
@@ -59,6 +59,7 @@ _dep_layer = rule(
         "dep": attr.label(mandatory = True),
 
         # Override the defaults.
+	# https://github.com/bazelbuild/bazel/issues/2176
         "data_path": attr.string(default = "."),
         "directory": attr.string(default = "/app"),
     },
@@ -160,6 +161,7 @@ def go_image(name, deps=[], layers=[], **kwargs):
   """Constructs a Docker image wrapping a go_binary target.
 
   Args:
+    layers: Augments "deps" with dependencies that should be put into their own layers.
     **kwargs: See go_binary.
   """
   binary_name = name + ".binary"

--- a/docker/contrib/go/image.bzl
+++ b/docker/contrib/go/image.bzl
@@ -17,12 +17,11 @@ The signature of this rule is compatible with go_binary.
 """
 
 load(
-  "//docker:build.bzl",
-  _build_attrs="attrs",
-  _build_outputs="outputs",
-  _build_implementation="implementation",
+    "//docker:build.bzl",
+    _build_attrs = "attrs",
+    _build_implementation = "implementation",
+    _build_outputs = "outputs",
 )
-
 load("//docker:pull.bzl", "docker_pull")
 
 # It is expected that the Go rules have been properly
@@ -53,13 +52,13 @@ def _dep_layer_impl(ctx):
 
 _dep_layer = rule(
     attrs = _build_attrs + {
-	# The base image on which to overlay the dependency layers.
+        # The base image on which to overlay the dependency layers.
         "base": attr.label(default = Label("@go_image_base//image")),
-	# The dependency whose runfiles we're appending.
+        # The dependency whose runfiles we're appending.
         "dep": attr.label(mandatory = True),
 
         # Override the defaults.
-	# https://github.com/bazelbuild/bazel/issues/2176
+        # https://github.com/bazelbuild/bazel/issues/2176
         "data_path": attr.string(default = "."),
         "directory": attr.string(default = "/app"),
     },
@@ -131,10 +130,10 @@ _app_layer = rule(
     attrs = _build_attrs + {
         # The go_binary target for which we are synthesizing an image.
         "binary": attr.label(mandatory = True),
-	# The full list of dependencies that have their own layers
+        # The full list of dependencies that have their own layers
         # factored into our base.
         "layers": attr.label_list(),
-	# The base image on which to overlay the dependency layers.
+        # The base image on which to overlay the dependency layers.
         "base": attr.label(default = Label("@go_image_base//image")),
 
         # Override the defaults.
@@ -177,4 +176,3 @@ def go_image(name, deps=[], layers=[], **kwargs):
     index += 1
 
   _app_layer(name=name, base=base, binary=binary_name, layers=layers)
-

--- a/docker/contrib/go/image.bzl
+++ b/docker/contrib/go/image.bzl
@@ -39,7 +39,7 @@ def repositories():
       digest = "sha256:06fcd3edcfeefe13b82fa8bdb9e3f4fa3bf4c7e8fe997bee0230e392f77d0e04",
     )
 
-def go_image(name, deps=[], layers=[], **kwargs):
+def go_image(name, base=None, deps=[], layers=[], **kwargs):
   """Constructs a Docker image wrapping a go_binary target.
 
   Args:
@@ -51,7 +51,7 @@ def go_image(name, deps=[], layers=[], **kwargs):
   go_binary(name=binary_name, deps=deps + layers, **kwargs)
 
   index = 0
-  base = "@go_image_base//image"
+  base = base or "@go_image_base//image"
   for dep in layers:
     this_name = "%s.%d" % (name, index)
     dep_layer(name=this_name, base=base, dep=dep)

--- a/docker/contrib/go/image.bzl
+++ b/docker/contrib/go/image.bzl
@@ -17,10 +17,9 @@ The signature of this rule is compatible with go_binary.
 """
 
 load(
-    "//docker:build.bzl",
-    _build_attrs = "attrs",
-    _build_implementation = "implementation",
-    _build_outputs = "outputs",
+    "//docker/contrib/common:lang-image.bzl",
+    "dep_layer",
+    "app_layer",
 )
 load("//docker:pull.bzl", "docker_pull")
 
@@ -28,122 +27,6 @@ load("//docker:pull.bzl", "docker_pull")
 # initialized before loading this file to initialize
 # go_image.
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
-
-# TODO(mattmoor): If we can share this stuff with the other
-# languages, then factor out a helper.
-def _dep_layer_impl(ctx):
-  """Appends a layer for a single dependency's runfiles."""
-
-  return _build_implementation(
-    ctx,
-    # We put the files from dependency layers into a binary-agnostic
-    # path to increase the likelihood of layer sharing across images,
-    # then we symlink them into the appropriate place in the app layer.
-    # This references the binary package because the file paths are
-    # relative to it, and normalized by the tarball package.
-    directory="/app/" + ctx.label.package,
-    files=list(ctx.attr.dep.default_runfiles.files),
-    symlinks={
-      # Handle empty files by linking to /dev/null
-      "/app/" + empty: "/dev/null"
-      for empty in ctx.attr.dep.default_runfiles.empty_filenames
-    }
-  )
-
-_dep_layer = rule(
-    attrs = _build_attrs + {
-        # The base image on which to overlay the dependency layers.
-        "base": attr.label(default = Label("@go_image_base//image")),
-        # The dependency whose runfiles we're appending.
-        "dep": attr.label(mandatory = True),
-
-        # Override the defaults.
-        # https://github.com/bazelbuild/bazel/issues/2176
-        "data_path": attr.string(default = "."),
-        "directory": attr.string(default = "/app"),
-    },
-    executable = True,
-    outputs = _build_outputs,
-    implementation = _dep_layer_impl,
-)
-
-def _app_layer_impl(ctx):
-  """Appends the app layer with all remaining runfiles."""
-
-  # Compute the set of runfiles that have been made available
-  # in our base image.
-  available = set()
-  for dep in ctx.attr.layers:
-    available += [f.short_path for f in dep.default_runfiles.files]
-    available += [f for f in dep.default_runfiles.empty_filenames]
-
-  # The name of the binary target for which we are populating
-  # this application layer.
-  basename = ctx.attr.binary.label.name
-  binary_name = "/".join([
-    "/app",
-    ctx.label.package,
-    basename
-  ])
-
-  # Empty filenames are relative to this base.
-  base_directory = "/".join([
-    binary_name + ".runfiles",
-    ctx.workspace_name,
-  ])
-  # All of the files are included with paths relative to
-  # this directory.
-  directory = "/".join([base_directory, ctx.label.package])
-
-  # Compute the set of remaining runfiles to include into the
-  # application layer.
-  files = [f for f in ctx.attr.binary.default_runfiles.files
-           if f.short_path not in available]
-
-  empty_files = [f for f in ctx.attr.binary.default_runfiles.empty_filenames
-                 if f not in available]
-
-  # For each of the runfiles we aren't including directly into
-  # the application layer, link to their binary-agnostic
-  # location from the runfiles path.
-  symlinks = {
-    binary_name: directory + "/" + basename
-  } + {
-    directory + "/" + input: "/app/" + input
-    for input in available
-  } + {
-    # Handle empty files by linking to /dev/null
-    base_directory + "/" + empty: "/dev/null"
-    for empty in empty_files
-  }
-
-  return _build_implementation(
-    ctx, files=files,
-    # Use entrypoint so we can easily add arguments when the resulting
-    # image is `docker run ...`.
-    # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
-    # we should use the "exec" (list) form of entrypoint.
-    entrypoint=[binary_name],
-    directory=directory, symlinks=symlinks)
-
-_app_layer = rule(
-    attrs = _build_attrs + {
-        # The go_binary target for which we are synthesizing an image.
-        "binary": attr.label(mandatory = True),
-        # The full list of dependencies that have their own layers
-        # factored into our base.
-        "layers": attr.label_list(),
-        # The base image on which to overlay the dependency layers.
-        "base": attr.label(default = Label("@go_image_base//image")),
-
-        # Override the defaults.
-        "data_path": attr.string(default = "."),
-        "workdir": attr.string(default = "/app"),
-    },
-    executable = True,
-    outputs = _build_outputs,
-    implementation = _app_layer_impl,
-)
 
 def repositories():
   excludes = native.existing_rules().keys()
@@ -168,11 +51,11 @@ def go_image(name, deps=[], layers=[], **kwargs):
   go_binary(name=binary_name, deps=deps + layers, **kwargs)
 
   index = 0
-  base = None # Makes us use ctx.attr.base
+  base = "@go_image_base//image"
   for dep in layers:
     this_name = "%s.%d" % (name, index)
-    _dep_layer(name=this_name, base=base, dep=dep)
+    dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
     index += 1
 
-  _app_layer(name=name, base=base, binary=binary_name, layers=layers)
+  app_layer(name=name, base=base, binary=binary_name, layers=layers)

--- a/docker/contrib/go/image.bzl
+++ b/docker/contrib/go/image.bzl
@@ -48,6 +48,9 @@ def go_image(name, base=None, deps=[], layers=[], **kwargs):
   """
   binary_name = name + ".binary"
 
+  if layers:
+    print("go_image does not benefit from layers=[], got: %s" % layers)
+
   go_binary(name=binary_name, deps=deps + layers, **kwargs)
 
   index = 0

--- a/docker/contrib/java/BUILD
+++ b/docker/contrib/java/BUILD
@@ -1,0 +1,16 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0

--- a/docker/contrib/java/image.bzl
+++ b/docker/contrib/java/image.bzl
@@ -45,10 +45,8 @@ def repositories():
     )
 
 load(
-    "//docker:build.bzl",
-    _build_attrs = "attrs",
-    _build_implementation = "implementation",
-    _build_outputs = "outputs",
+    "//docker:docker.bzl",
+    _docker = "docker",
 )
 
 def _dep_layer_impl(ctx):
@@ -66,14 +64,14 @@ def _dep_layer_impl(ctx):
     # vs. collapsing things (WAR).  For more info see:
     # https://github.com/bazelbuild/bazel/issues/2176
     directory += "/" + ctx.label.package
-  return _build_implementation(
+  return _docker.build.implementation(
     ctx,
     directory=directory,
     files=list(transitive_deps),
   )
 
 _jar_dep_layer = rule(
-    attrs = _build_attrs + {
+    attrs = _docker.build.attrs + {
         # The base image on which to overlay the dependency layers.
         "base": attr.label(mandatory = True),
         # The dependency whose runfiles we're appending.
@@ -85,12 +83,12 @@ _jar_dep_layer = rule(
         "data_path": attr.string(default = "."),
     },
     executable = True,
-    outputs = _build_outputs,
+    outputs = _docker.build.outputs,
     implementation = _dep_layer_impl,
 )
 
 _war_dep_layer = rule(
-    attrs = _build_attrs + {
+    attrs = _docker.build.attrs + {
         # The base image on which to overlay the dependency layers.
         "base": attr.label(mandatory = True),
         # The dependency whose runfiles we're appending.
@@ -102,7 +100,7 @@ _war_dep_layer = rule(
         # "data_path": attr.string(default = "."),
     },
     executable = True,
-    outputs = _build_outputs,
+    outputs = _docker.build.outputs,
     implementation = _dep_layer_impl,
 )
 
@@ -137,12 +135,12 @@ def _jar_app_layer_impl(ctx):
   binary_path = ctx.attr.directory + "/" + (ctx.files.binary[0].short_path)
   entrypoint = ['/usr/bin/java', '-cp', classpath, ctx.attr.main_class]
 
-  return _build_implementation(
+  return _docker.build.implementation(
     ctx, files=files, entrypoint=entrypoint,
     directory=ctx.attr.directory + "/" + ctx.label.package)
 
 _jar_app_layer = rule(
-    attrs = _build_attrs + {
+    attrs = _docker.build.attrs + {
         # The binary target for which we are synthesizing an image.
         "binary": attr.label(mandatory = True),
         # The full list of dependencies that have their own layers
@@ -161,7 +159,7 @@ _jar_app_layer = rule(
         "data_path": attr.string(default = "."),
     },
     executable = True,
-    outputs = _build_outputs,
+    outputs = _docker.build.outputs,
     implementation = _jar_app_layer_impl,
 )
 
@@ -215,11 +213,11 @@ def _war_app_layer_impl(ctx):
       # then consider adding symlinks here.
       files += [d]
 
-  return _build_implementation(
+  return _docker.build.implementation(
     ctx, files=files, directory=ctx.attr.directory)
 
 _war_app_layer = rule(
-    attrs = _build_attrs + {
+    attrs = _docker.build.attrs + {
         # The library target for which we are synthesizing an image.
         "library": attr.label(mandatory = True),
         # The full list of dependencies that have their own layers
@@ -235,7 +233,7 @@ _war_app_layer = rule(
         # "data_path": attr.string(default = "."),
     },
     executable = True,
-    outputs = _build_outputs,
+    outputs = _docker.build.outputs,
     implementation = _war_app_layer_impl,
 )
 

--- a/docker/contrib/java/image.bzl
+++ b/docker/contrib/java/image.bzl
@@ -48,7 +48,6 @@ load(
     "//docker:docker.bzl",
     _docker = "docker",
 )
-
 load("//docker:build.bzl", "magic_path")
 
 def _dep_layer_impl(ctx):

--- a/docker/contrib/java/image.bzl
+++ b/docker/contrib/java/image.bzl
@@ -165,7 +165,7 @@ _jar_app_layer = rule(
     implementation = _jar_app_layer_impl,
 )
 
-def java_image(name, main_class=None, deps=[], layers=[], **kwargs):
+def java_image(name, base=None, main_class=None, deps=[], layers=[], **kwargs):
   """Builds a Docker image overlaying the java_binary.
 
   Args:
@@ -179,7 +179,7 @@ def java_image(name, main_class=None, deps=[], layers=[], **kwargs):
                      deps=deps + layers, **kwargs)
 
   index = 0
-  base = "@java_image_base//image"
+  base = base or "@java_image_base//image"
   for dep in layers:
     this_name = "%s.%d" % (name, index)
     _jar_dep_layer(name=this_name, base=base, dep=dep)
@@ -239,7 +239,7 @@ _war_app_layer = rule(
     implementation = _war_app_layer_impl,
 )
 
-def war_image(name, deps=[], layers=[], **kwargs):
+def war_image(name, base=None, deps=[], layers=[], **kwargs):
   """Builds a Docker image overlaying the java_library as an exploded WAR.
 
   Args:
@@ -252,7 +252,7 @@ def war_image(name, deps=[], layers=[], **kwargs):
   native.java_library(name=library_name, deps=deps + layers, **kwargs)
 
   index = 0
-  base = "@jetty_image_base//image"
+  base = base or "@jetty_image_base//image"
   for dep in layers:
     this_name = "%s.%d" % (name, index)
     _war_dep_layer(name=this_name, base=base, dep=dep)

--- a/docker/contrib/java/image.bzl
+++ b/docker/contrib/java/image.bzl
@@ -1,0 +1,157 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A rule for creating a Java Docker image.
+
+TODO(mattmoor): java_image
+
+The signature of war_image is compatible with java_library.
+"""
+
+load("//docker:pull.bzl", "docker_pull")
+
+def repositories():
+  excludes = native.existing_rules().keys()
+  if "jetty_image_base" not in excludes:
+    docker_pull(
+      name = "jetty_image_base",
+      registry = "gcr.io",
+      repository = "distroless/java/jetty",
+      # 'latest' circa 2017-08-04
+      digest = "sha256:09dfe023367b743ee01ec5e51245014ba1b43c1a4f5ff7a314be821e7314baf1",
+    )
+  if "servlet_api" not in excludes:
+    native.maven_jar(
+        name = "javax_servlet_api",
+        artifact = "javax.servlet:javax.servlet-api:3.0.1",
+    )
+
+load(
+    "//docker:build.bzl",
+    _build_attrs = "attrs",
+    _build_implementation = "implementation",
+    _build_outputs = "outputs",
+)
+load("@subpar//:debug.bzl", "dump")
+
+def _war_dep_layer_impl(ctx):
+  """Appends a layer for a single dependency's runfiles."""
+
+  transitive_deps = set()
+  if hasattr(ctx.attr.dep, "java"):  # java_library, java_import
+    transitive_deps += ctx.attr.dep.java.transitive_runtime_deps
+  elif hasattr(ctx.attr.dep, "files"):  # a jar file
+    transitive_deps += ctx.attr.dep.files
+
+  # This path could be more context agnostic, but with defaults
+  # the name doesn't change, so this is good enough for now.
+  directory = ctx.attr.directory + "/" + ctx.attr.servlet + "/WEB-INF/lib"
+  return _build_implementation(
+    ctx,
+    directory=directory,
+    files=list(transitive_deps),
+  )
+
+_war_dep_layer = rule(
+    attrs = _build_attrs + {
+        # The base image on which to overlay the dependency layers.
+        "base": attr.label(mandatory = True),
+        # The dependency whose runfiles we're appending.
+        "dep": attr.label(mandatory = True),
+        "servlet": attr.string(default = "ROOT"),
+
+        # Override the defaults.
+        "directory": attr.string(default = "/jetty/webapps/"),
+        # WE WANT PATHS FLATTENED
+        # "data_path": attr.string(default = "."),
+    },
+    executable = True,
+    outputs = _build_outputs,
+    implementation = _war_dep_layer_impl,
+)
+
+def _war_app_layer_impl(ctx):
+  """Appends the app layer with all remaining runfiles."""
+
+  available = set()
+  for jar in ctx.attr.layers:
+    if hasattr(jar, "java"):  # java_library, java_import
+      available += jar.java.transitive_runtime_deps
+    elif hasattr(jar, "files"):  # a jar file
+      available += jar.files
+
+  # This is based on rules_appengine's WAR rules.
+  transitive_deps = set()
+  if hasattr(ctx.attr.library, "java"):  # java_library, java_import
+    transitive_deps += ctx.attr.library.java.transitive_runtime_deps
+  elif hasattr(ctx.attr.library, "files"):  # a jar file
+    transitive_deps += ctx.attr.library.files
+
+  # TODO(mattmoor): Handle data files.
+
+  directory = ctx.attr.directory + "/" + ctx.attr.servlet + "/WEB-INF/lib"
+
+  files = []
+  for d in transitive_deps:
+    if d not in available:
+      # If we start putting libs in servlet-agnostic paths,
+      # then consider adding symlinks here.
+      files += [d]
+
+  return _build_implementation(
+    ctx, files=files,
+    directory=directory)
+
+_war_app_layer = rule(
+    attrs = _build_attrs + {
+        # The library target for which we are synthesizing an image.
+        "library": attr.label(mandatory = True),
+        # The full list of dependencies that have their own layers
+        # factored into our base.
+        "layers": attr.label_list(),
+        "servlet": attr.string(default = "ROOT"),
+        # The base image on which to overlay the dependency layers.
+        "base": attr.label(mandatory = True),
+        "entrypoint": attr.string_list(default = []),
+
+        # Override the defaults.
+        "directory": attr.string(default = "/jetty/webapps/"),
+        # WE WANT PATHS FLATTENED
+        # "data_path": attr.string(default = "."),
+    },
+    executable = True,
+    outputs = _build_outputs,
+    implementation = _war_app_layer_impl,
+)
+
+def war_image(name, deps=[], layers=[], **kwargs):
+  """Builds a Docker image overlaying the java_library as an exploded WAR.
+
+  Args:
+    layers: Augments "deps" with dependencies that should be put into
+           their own layers.
+    **kwargs: See java_library.
+  """
+  library_name = name + ".library"
+
+  native.java_library(name=library_name, deps=deps + layers, **kwargs)
+
+  index = 0
+  base = "@jetty_image_base//image"
+  for dep in layers:
+    this_name = "%s.%d" % (name, index)
+    _war_dep_layer(name=this_name, base=base, dep=dep)
+    base = this_name
+    index += 1
+
+  _war_app_layer(name=name, base=base, library=library_name, layers=layers)

--- a/docker/contrib/python/BUILD
+++ b/docker/contrib/python/BUILD
@@ -1,0 +1,16 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0

--- a/docker/contrib/python/image.bzl
+++ b/docker/contrib/python/image.bzl
@@ -34,7 +34,7 @@ def repositories():
       digest = "sha256:9c839437f182e4d93cb908b3177f72954a91893bd7120ec121846b69fc1cca4a",
     )
 
-def py_image(name, deps=[], layers=[], **kwargs):
+def py_image(name, base=None, deps=[], layers=[], **kwargs):
   """Constructs a Docker image wrapping a py_binary target.
 
   Args:
@@ -56,8 +56,7 @@ def py_image(name, deps=[], layers=[], **kwargs):
   # TODO(mattmoor): Consider making the directory into which the app
   # is placed configurable.
   index = 0
-  # TODO(mattmoor): Consider making the base configurable.
-  base = "@py_image_base//image"
+  base = base or "@py_image_base//image"
   for dep in layers:
     this_name = "%s.%d" % (name, index)
     dep_layer(name=this_name, base=base, dep=dep)

--- a/docker/contrib/python/image.bzl
+++ b/docker/contrib/python/image.bzl
@@ -17,12 +17,11 @@ The signature of this rule is compatible with py_binary.
 """
 
 load(
-  "//docker:build.bzl",
-  _build_attrs="attrs",
-  _build_outputs="outputs",
-  _build_implementation="implementation",
+    "//docker:build.bzl",
+    _build_attrs = "attrs",
+    _build_implementation = "implementation",
+    _build_outputs = "outputs",
 )
-
 load("//docker:pull.bzl", "docker_pull")
 
 def _dep_layer_impl(ctx):
@@ -46,9 +45,9 @@ def _dep_layer_impl(ctx):
 
 _dep_layer = rule(
     attrs = _build_attrs + {
-	# The base image on which to overlay the dependency layers.
+        # The base image on which to overlay the dependency layers.
         "base": attr.label(default = Label("@py_image_base//image")),
-	# The dependency whose runfiles we're appending.
+        # The dependency whose runfiles we're appending.
         "dep": attr.label(mandatory = True),
 
         # Override the defaults.
@@ -123,10 +122,10 @@ _app_layer = rule(
     attrs = _build_attrs + {
         # The py_binary target for which we are synthesizing an image.
         "binary": attr.label(mandatory = True),
-	# The full list of dependencies that have their own layers
+        # The full list of dependencies that have their own layers
         # factored into our base.
         "layers": attr.label_list(),
-	# The base image on which to overlay the dependency layers.
+        # The base image on which to overlay the dependency layers.
         "base": attr.label(default = Label("@py_image_base//image")),
 
         # Override the defaults.
@@ -170,4 +169,3 @@ def py_image(name, deps=[], layers=[], **kwargs):
     index += 1
 
   _app_layer(name=name, base=base, binary=binary_name, layers=layers)
-

--- a/docker/contrib/python/image.bzl
+++ b/docker/contrib/python/image.bzl
@@ -1,0 +1,173 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A rule for creating a Python Docker image.
+
+The signature of this rule is compatible with py_binary.
+"""
+
+load(
+  "//docker:build.bzl",
+  _build_attrs="attrs",
+  _build_outputs="outputs",
+  _build_implementation="implementation",
+)
+
+load("//docker:pull.bzl", "docker_pull")
+
+def _dep_layer_impl(ctx):
+  """Appends a layer for a single dependencies runfiles."""
+
+  return _build_implementation(
+    ctx,
+    # We put the files from dependency layers into a binary-agnostic
+    # path to increase the likelihood of layer sharing across images,
+    # then we symlink them into the appropriate place in the app layer.
+    # This references the binary package because the file paths are
+    # relative to it, and normalized by the tarball package.
+    directory="/app/" + ctx.label.package,
+    files=list(ctx.attr.dep.default_runfiles.files),
+    symlinks={
+      # Handle empty files by linking to /dev/null
+      "/app/" + empty: "/dev/null"
+      for empty in ctx.attr.dep.default_runfiles.empty_filenames
+    }
+  )
+
+_dep_layer = rule(
+    attrs = _build_attrs + {
+	# The base image on which to overlay the dependency layers.
+        "base": attr.label(default = Label("@py_image_base//image")),
+	# The dependency whose runfiles we're appending.
+        "dep": attr.label(mandatory = True),
+
+        # Override the defaults.
+        "data_path": attr.string(default = "."),
+        "directory": attr.string(default = "/app"),
+    },
+    executable = True,
+    outputs = _build_outputs,
+    implementation = _dep_layer_impl,
+)
+
+def _app_layer_impl(ctx):
+  """Appends the app layer with all remaining runfiles."""
+
+  # Compute the set of runfiles that have been made available
+  # in our base image.
+  available = set()
+  for dep in ctx.attr.layers:
+    available += [f.short_path for f in dep.default_runfiles.files]
+    available += [f for f in dep.default_runfiles.empty_filenames]
+
+  # The name of the binary target for which we are populating
+  # this application layer.
+  basename = ctx.attr.binary.label.name
+  binary_name = "/".join([
+    "/app",
+    ctx.label.package,
+    basename
+  ])
+
+  # Empty filenames are relative to this base.
+  base_directory = "/".join([
+    binary_name + ".runfiles",
+    ctx.workspace_name,
+  ])
+  # All of the files are included with paths relative to
+  # this directory.
+  directory = "/".join([base_directory, ctx.label.package])
+
+  # Compute the set of remaining runfiles to include into the
+  # application layer.
+  files = [f for f in ctx.attr.binary.default_runfiles.files
+           if f.short_path not in available]
+
+  empty_files = [f for f in ctx.attr.binary.default_runfiles.empty_filenames
+                 if f not in available]
+
+  # For each of the runfiles we aren't including directly into
+  # the application layer, link to their binary-agnostic
+  # location from the runfiles path.
+  symlinks = {
+    binary_name: directory + "/" + basename
+  } + {
+    directory + "/" + input: "/app/" + input
+    for input in available
+  } + {
+    # Handle empty files by linking to /dev/null
+    base_directory + "/" + empty: "/dev/null"
+    for empty in empty_files
+  }
+
+  return _build_implementation(
+    ctx, files=files,
+    # Use entrypoint so we can easily add arguments when the resulting
+    # image is `docker run ...`.
+    # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
+    # we should use the "exec" (list) form of entrypoint.
+    entrypoint=['/usr/bin/python', binary_name],
+    directory=directory, symlinks=symlinks)
+
+_app_layer = rule(
+    attrs = _build_attrs + {
+        # The py_binary target for which we are synthesizing an image.
+        "binary": attr.label(mandatory = True),
+	# The full list of dependencies that have their own layers
+        # factored into our base.
+        "layers": attr.label_list(),
+	# The base image on which to overlay the dependency layers.
+        "base": attr.label(default = Label("@py_image_base//image")),
+
+        # Override the defaults.
+        "data_path": attr.string(default = "."),
+        "workdir": attr.string(default = "/app"),
+    },
+    executable = True,
+    outputs = _build_outputs,
+    implementation = _app_layer_impl,
+)
+
+def repositories():
+  excludes = native.existing_rules().keys()
+  if "py_image_base" not in excludes:
+    docker_pull(
+      name = "py_image_base",
+      registry = "gcr.io",
+      repository = "distroless/python2.7",
+      # 'latest' circa 2017-07-21
+      digest = "sha256:9c839437f182e4d93cb908b3177f72954a91893bd7120ec121846b69fc1cca4a",
+    )
+
+def py_image(name, deps=[], layers=[], **kwargs):
+  """Constructs a Docker image wrapping a py_binary target.
+
+  Args:
+    **kwargs: See py_binary.
+  """
+  binary_name = name + ".binary"
+
+  # TODO(mattmoor): Consider using par_binary instead, so that
+  # a single target can be used for all three.
+  native.py_binary(name=binary_name, deps=deps + layers, **kwargs)
+
+  index = 0
+  base = None # Makes us use ctx.attr.base
+  for dep in layers:
+    this_name = "%s.%d" % (name, index)
+    _dep_layer(name=this_name, base=base, dep=dep)
+    base = this_name
+    index += 1
+
+  _app_layer(name=name, base=base, binary=binary_name, layers=layers)
+

--- a/docker/contrib/python/image.bzl
+++ b/docker/contrib/python/image.bzl
@@ -17,139 +17,11 @@ The signature of this rule is compatible with py_binary.
 """
 
 load(
-    "//docker:build.bzl",
-    _build_attrs = "attrs",
-    _build_implementation = "implementation",
-    _build_outputs = "outputs",
+    "//docker/contrib/common:lang-image.bzl",
+    "dep_layer",
+    "app_layer",
 )
 load("//docker:pull.bzl", "docker_pull")
-
-def _dep_layer_impl(ctx):
-  """Appends a layer for a single dependency's runfiles."""
-
-  return _build_implementation(
-    ctx,
-    # We put the files from dependency layers into a binary-agnostic
-    # path to increase the likelihood of layer sharing across images,
-    # then we symlink them into the appropriate place in the app layer.
-    # This references the binary package because the file paths are
-    # relative to it, and normalized by the tarball package.
-    directory=ctx.attr.directory + "/" + ctx.label.package,
-    files=list(ctx.attr.dep.default_runfiles.files),
-    symlinks={
-      # Handle empty files by linking to /dev/null
-      # TODO(mattmoor): This doesn't work in Python3,
-      # so investigate how to properly create empty files.
-      #   bazelbuild/bazel#1458
-      #   http://bugs.python.org/issue28425
-      ctx.attr.directory + "/" + empty: "/dev/null"
-      for empty in ctx.attr.dep.default_runfiles.empty_filenames
-    }
-  )
-
-_dep_layer = rule(
-    attrs = _build_attrs + {
-        # The base image on which to overlay the dependency layers.
-        "base": attr.label(default = Label("@py_image_base//image")),
-        # The dependency whose runfiles we're appending.
-        "dep": attr.label(mandatory = True),
-
-        # Override the defaults.
-        # https://github.com/bazelbuild/bazel/issues/2176
-        "data_path": attr.string(default = "."),
-        "directory": attr.string(default = "/app"),
-    },
-    executable = True,
-    outputs = _build_outputs,
-    implementation = _dep_layer_impl,
-)
-
-def _app_layer_impl(ctx):
-  """Appends the app layer with all remaining runfiles."""
-
-  # Compute the set of runfiles that have been made available
-  # in our base image.
-  available = set()
-  for dep in ctx.attr.layers:
-    available += [f.short_path for f in dep.default_runfiles.files]
-    available += [f for f in dep.default_runfiles.empty_filenames]
-
-  # The name of the binary target for which we are populating
-  # this application layer.
-  basename = ctx.attr.binary.label.name
-  binary_name = "/".join([
-    ctx.attr.directory,
-    ctx.label.package,
-    basename
-  ])
-
-  # Empty filenames are relative to this base.
-  base_directory = "/".join([
-    binary_name + ".runfiles",
-    ctx.workspace_name,
-  ])
-  # All of the files are included with paths relative to
-  # this directory.
-  directory = "/".join([base_directory, ctx.label.package])
-
-  # Compute the set of remaining runfiles to include into the
-  # application layer.
-  files = [f for f in ctx.attr.binary.default_runfiles.files
-           # It is notable that this assumes that our version of
-	   # this runfile matches that of the dependency.  It is
-	   # not clear at this time whether that is an invariant
-	   # broadly in Bazel.
-           if f.short_path not in available]
-
-  empty_files = [f for f in ctx.attr.binary.default_runfiles.empty_filenames
-                 if f not in available]
-
-  # For each of the runfiles we aren't including directly into
-  # the application layer, link to their binary-agnostic
-  # location from the runfiles path.
-  symlinks = {
-    binary_name: directory + "/" + basename
-  } + {
-    directory + "/" + input: ctx.attr.directory + "/" + input
-    for input in available
-  } + {
-    # Handle empty files by linking to /dev/null
-    # TODO(mattmoor): This doesn't work in Python3,
-    # so investigate how to properly create empty files.
-    #   bazelbuild/bazel#1458
-    #   http://bugs.python.org/issue28425
-    base_directory + "/" + empty: "/dev/null"
-    for empty in empty_files
-  }
-
-  return _build_implementation(
-    ctx, files=files,
-    # Use entrypoint so we can easily add arguments when the resulting
-    # image is `docker run ...`.
-    # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
-    # we should use the "exec" (list) form of entrypoint.
-    entrypoint=['/usr/bin/python', binary_name],
-    directory=directory, symlinks=symlinks)
-
-_app_layer = rule(
-    attrs = _build_attrs + {
-        # The py_binary target for which we are synthesizing an image.
-        "binary": attr.label(mandatory = True),
-        # The full list of dependencies that have their own layers
-        # factored into our base.
-        "layers": attr.label_list(),
-        # The base image on which to overlay the dependency layers.
-        "base": attr.label(default = Label("@py_image_base//image")),
-
-        # Override the defaults.
-        "data_path": attr.string(default = "."),
-        "workdir": attr.string(default = "/app"),
-        "directory": attr.string(default = "/app"),
-    },
-    executable = True,
-    outputs = _build_outputs,
-    implementation = _app_layer_impl,
-)
 
 def repositories():
   excludes = native.existing_rules().keys()
@@ -166,7 +38,8 @@ def py_image(name, deps=[], layers=[], **kwargs):
   """Constructs a Docker image wrapping a py_binary target.
 
   Args:
-    layers: Augments "deps" with dependencies that should be put into their own layers.
+    layers: Augments "deps" with dependencies that should be put into
+           their own layers.
     **kwargs: See py_binary.
   """
   binary_name = name + ".binary"
@@ -184,11 +57,12 @@ def py_image(name, deps=[], layers=[], **kwargs):
   # is placed configurable.
   index = 0
   # TODO(mattmoor): Consider making the base configurable.
-  base = None # Makes us use ctx.attr.base
+  base = "@py_image_base//image"
   for dep in layers:
     this_name = "%s.%d" % (name, index)
-    _dep_layer(name=this_name, base=base, dep=dep)
+    dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
     index += 1
 
-  _app_layer(name=name, base=base, binary=binary_name, layers=layers)
+  app_layer(name=name, base=base, entrypoint=['/usr/bin/python'],
+            binary=binary_name, layers=layers)

--- a/docker/contrib/python/image.bzl
+++ b/docker/contrib/python/image.bzl
@@ -55,7 +55,7 @@ _dep_layer = rule(
         "dep": attr.label(mandatory = True),
 
         # Override the defaults.
-	# https://github.com/bazelbuild/bazel/issues/2176
+        # https://github.com/bazelbuild/bazel/issues/2176
         "data_path": attr.string(default = "."),
         "directory": attr.string(default = "/app"),
     },

--- a/docker/contrib/with-defaults.bzl
+++ b/docker/contrib/with-defaults.bzl
@@ -73,4 +73,3 @@ _docker_defaults = repository_rule(
 def docker_defaults(**kwargs):
   """Creates a version of docker_push with the specified defaults."""
   _docker_defaults(**kwargs)
-  

--- a/docker/docker.bzl
+++ b/docker/docker.bzl
@@ -15,7 +15,7 @@
 
 # Alias docker_build and docker_bundle for now, so folks can move to
 # referencing this before it becomes the source of truth.
-load(":build.bzl", "docker_build")
+load(":build.bzl", "docker_build", "build")
 load(":bundle.bzl", "docker_bundle")
 
 # Expose the docker_import rule.
@@ -26,6 +26,10 @@ load(":pull.bzl", "docker_pull")
 
 # Expose the docker_push rule.
 load(":push.bzl", "docker_push")
+
+docker = struct(
+    build = build,
+)
 
 # The release of the github.com/google/containerregistry to consume.
 CONTAINERREGISTRY_RELEASE = "v0.0.12"

--- a/docker/filetype.bzl
+++ b/docker/filetype.bzl
@@ -13,7 +13,10 @@
 # limitations under the License.
 """Filetype constants."""
 
-tgz = [".tar.gz", ".tgz"]
+tgz = [
+    ".tar.gz",
+    ".tgz",
+]
 
 # Filetype to restrict inputs
 tar = [

--- a/docker/push.bzl
+++ b/docker/push.bzl
@@ -24,7 +24,7 @@ load(
 load(
     ":layers.bzl",
     _get_layers = "get_from_target",
-    _layer_tools = "tools"
+    _layer_tools = "tools",
 )
 
 def _impl(ctx):

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -344,13 +344,13 @@ load(
 )
 
 docker_bundle(
-   name = "bundle_to_push",
-   images = {
-     "us.gcr.io/convoy-adapter/bazel-test/{BUILD_USER}:foo": ":with_env",
-     "eu.gcr.io/convoy-adapter/bazel-test/{BUILD_USER}:bar": ":with_double_env",
-     "asia.gcr.io/convoy-adapter/bazel-test/{BUILD_USER}:baz": ":with_user",
-   },
-   stamp = True
+    name = "bundle_to_push",
+    images = {
+        "us.gcr.io/convoy-adapter/bazel-test/{BUILD_USER}:foo": ":with_env",
+        "eu.gcr.io/convoy-adapter/bazel-test/{BUILD_USER}:bar": ":with_double_env",
+        "asia.gcr.io/convoy-adapter/bazel-test/{BUILD_USER}:baz": ":with_user",
+    },
+    stamp = True,
 )
 
 docker_pushall(
@@ -395,10 +395,10 @@ PAUSE_CONFIG = "2b58359142b094165abfc9ad9c327c453a3eaa624d0c5ee8f0ed1ab50483603b
 
 genrule(
     name = "pause_config",
+    srcs = [":pause.tar"],
+    outs = ["pause_config.json"],
     cmd = ("tar xOf $(location :pause.tar) %s " +
            "> $(location :pause_config.json)") % PAUSE_CONFIG,
-    outs = ["pause_config.json"],
-    srcs = [":pause.tar"],
 )
 
 PAUSE_LAYERS = [
@@ -408,16 +408,16 @@ PAUSE_LAYERS = [
 
 [genrule(
     name = "extract_%s" % id,
+    srcs = [":pause.tar"],
+    outs = ["%s.tar.gz" % id],
     cmd = ("tar xOf $(location :pause.tar) %s/layer.tar " +
            "| gzip -n > $(location :%s.tar.gz)") % (id, id),
-    outs = ["%s.tar.gz" % id],
-    srcs = [":pause.tar"],
 ) for id in PAUSE_LAYERS]
 
 docker_import(
-   name = "pause_piecemeal",
-   config = ":pause_config.json",
-   layers = ["%s.tar.gz" % x for x in PAUSE_LAYERS],
+    name = "pause_piecemeal",
+    config = ":pause_config.json",
+    layers = ["%s.tar.gz" % x for x in PAUSE_LAYERS],
 )
 
 load(
@@ -433,8 +433,8 @@ py_library(
 py_image(
     name = "py_image",
     srcs = ["py_image.py"],
-    main = "py_image.py",
     layers = [
-        ":py_image_library"
+        ":py_image_library",
     ],
+    main = "py_image.py",
 )

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -461,7 +461,7 @@ cc_image(
 
 load(
     "//docker/contrib/java:image.bzl",
-    # "java_image",
+    "java_image",
     "war_image",
 )
 
@@ -470,13 +470,11 @@ java_library(
     srcs = ["Library.java"],
 )
 
-# TODO(mattmoor): Make this java_image
-java_binary(
+java_image(
     name = "java_image",
     srcs = ["Binary.java"],
+    layers = [":java_image_library"],
     main_class = "examples.images.Binary",
-    # TODO(mattmoor): Make this layers.
-    deps = [":java_image_library"],
 )
 
 war_image(

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -438,3 +438,21 @@ py_image(
     ],
     main = "py_image.py",
 )
+
+load(
+    "//docker/contrib/cc:image.bzl",
+    "cc_image",
+)
+
+cc_library(
+    name = "cc_image_library",
+    srcs = ["cc_image_library.cc"],
+    hdrs = ["cc_image_library.h"],
+)
+
+cc_image(
+    name = "cc_image",
+    srcs = ["cc_image.cc"],
+    # This creates an empty layer, due to linking.
+    layers = [":cc_image_library"],
+)

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -458,3 +458,32 @@ cc_image(
     # This creates an empty layer, due to linking.
     layers = [":cc_image_library"],
 )
+
+load(
+    "//docker/contrib/java:image.bzl",
+    # "java_image",
+    "war_image",
+)
+
+java_library(
+    name = "java_image_library",
+    srcs = ["Library.java"],
+)
+
+# TODO(mattmoor): Make this java_image
+java_binary(
+    name = "java_image",
+    srcs = ["Binary.java"],
+    main_class = "examples.images.Binary",
+    # TODO(mattmoor): Make this layers.
+    deps = [":java_image_library"],
+)
+
+war_image(
+    name = "war_image",
+    srcs = ["Servlet.java"],
+    layers = [
+        ":java_image_library",
+        "@javax_servlet_api//jar:jar",
+    ],
+)

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -468,7 +468,7 @@ load(
 java_library(
     name = "java_image_library",
     srcs = ["Library.java"],
-    deps = ["@com_google_guava_guava//jar"]
+    deps = ["@com_google_guava_guava//jar"],
 )
 
 java_image(

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -419,3 +419,22 @@ docker_import(
    config = ":pause_config.json",
    layers = ["%s.tar.gz" % x for x in PAUSE_LAYERS],
 )
+
+load(
+    "//docker/contrib/python:image.bzl",
+    "py_image",
+)
+
+py_library(
+    name = "py_image_library",
+    srcs = ["py_image_library.py"],
+)
+
+py_image(
+    name = "py_image",
+    srcs = ["py_image.py"],
+    main = "py_image.py",
+    layers = [
+        ":py_image_library"
+    ],
+)

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -343,6 +343,8 @@ load(
     docker_pushall = "docker_push",
 )
 
+# This bundles up a bunch of images into a single tarball,
+# which is pushed as a unit below.
 docker_bundle(
     name = "bundle_to_push",
     images = {

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -468,6 +468,7 @@ load(
 java_library(
     name = "java_image_library",
     srcs = ["Library.java"],
+    deps = ["@com_google_guava_guava//jar"]
 )
 
 java_image(

--- a/docker/testdata/Binary.java
+++ b/docker/testdata/Binary.java
@@ -1,0 +1,23 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples.images;
+
+import examples.Library;
+
+public class Binary {
+    public static void main(String[] args) {
+        System.out.println(Library.SayHello());
+    }
+}

--- a/docker/testdata/Library.java
+++ b/docker/testdata/Library.java
@@ -14,8 +14,11 @@
 
 package examples;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+
 public class Library {
     public static String SayHello() {
-	return "Hello World";
+	return Joiner.on(" ").join(ImmutableList.of("Hello", "World"));
     }
 }

--- a/docker/testdata/Library.java
+++ b/docker/testdata/Library.java
@@ -1,0 +1,21 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples;
+
+public class Library {
+    public static String SayHello() {
+	return "Hello World";
+    }
+}

--- a/docker/testdata/Servlet.java
+++ b/docker/testdata/Servlet.java
@@ -1,0 +1,37 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples.images;
+
+import examples.Library;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+// Based on the GAE Flexible Hello World sample.
+@WebServlet(name = "helloworld", value = "")
+@SuppressWarnings("serial")
+public class Servlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+      PrintWriter out = resp.getWriter();
+      out.println(Library.SayHello());
+  }
+}

--- a/docker/testdata/cc_image.cc
+++ b/docker/testdata/cc_image.cc
@@ -1,0 +1,20 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "docker/testdata/cc_image_library.h"
+
+int main() {
+  SayHello();
+  return 0;
+}

--- a/docker/testdata/cc_image_library.cc
+++ b/docker/testdata/cc_image_library.cc
@@ -1,0 +1,21 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include "docker/testdata/cc_image_library.h"
+
+void SayHello() {
+  std::cout << "Hello World" << std::endl;
+}

--- a/docker/testdata/cc_image_library.h
+++ b/docker/testdata/cc_image_library.h
@@ -1,0 +1,15 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+void SayHello();

--- a/docker/testdata/py_image.py
+++ b/docker/testdata/py_image.py
@@ -1,0 +1,25 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from docker.testdata import py_image_library
+
+def main():
+  print 'First: %d' % py_image_library.fn(1)
+  print 'Second: %d' % py_image_library.fn(2)
+  print 'Third: %d' % py_image_library.fn(3)
+  print 'Fourth: %d' % py_image_library.fn(4)
+
+
+if __name__ == '__main__':
+  main()

--- a/docker/testdata/py_image.py
+++ b/docker/testdata/py_image.py
@@ -15,10 +15,10 @@
 from docker.testdata import py_image_library
 
 def main():
-  print 'First: %d' % py_image_library.fn(1)
-  print 'Second: %d' % py_image_library.fn(2)
-  print 'Third: %d' % py_image_library.fn(3)
-  print 'Fourth: %d' % py_image_library.fn(4)
+  print('First: %d' % py_image_library.fn(1))
+  print('Second: %d' % py_image_library.fn(2))
+  print('Third: %d' % py_image_library.fn(3))
+  print('Fourth: %d' % py_image_library.fn(4))
 
 
 if __name__ == '__main__':

--- a/docker/testdata/py_image_library.py
+++ b/docker/testdata/py_image_library.py
@@ -1,0 +1,17 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def fn(what_comes_in):
+  return what_comes_in + 3

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -213,13 +213,12 @@ function test_cc_image() {
   docker run -ti --rm bazel/docker/testdata:cc_image
 }
 
-# TODO(mattmoor):
-# function test_java_image() {
-#   cd "${ROOT}"
-#   clear_docker
-#   bazel run docker/testdata:java_image
-#   docker run -ti --rm bazel/docker/testdata:java_image
-# }
+function test_java_image() {
+  cd "${ROOT}"
+  clear_docker
+  bazel run docker/testdata:java_image
+  docker run -ti --rm bazel/docker/testdata:java_image
+}
 
 function test_war_image() {
   cd "${ROOT}"
@@ -241,5 +240,5 @@ test_bazel_run_docker_bundle_incremental
 test_bazel_run_docker_import_incremental
 test_py_image
 test_cc_image
-# TODO(mattmoor): test_java_image
+test_java_image
 test_war_image

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -120,6 +120,20 @@ function test_bazel_run_docker_import_incremental() {
   done
 }
 
+function test_py_image() {
+  cd "${ROOT}"
+  clear_docker
+  bazel run docker/testdata:py_image
+  docker run -ti --rm bazel/docker/testdata:py_image
+}
+
+function test_cc_image() {
+  cd "${ROOT}"
+  clear_docker
+  bazel run docker/testdata:cc_image
+  docker run -ti --rm bazel/docker/testdata:cc_image
+}
+
 test_top_level
 test_bazel_run_docker_build_clean
 test_bazel_run_docker_bundle_clean
@@ -127,3 +141,5 @@ test_bazel_run_docker_import_clean
 test_bazel_run_docker_build_incremental
 test_bazel_run_docker_bundle_incremental
 test_bazel_run_docker_import_incremental
+test_py_image
+test_cc_image


### PR DESCRIPTION
This change is a first-cut at attempting a `foo_image` rule that directly assembles a Docker image compatible with `foo_binary`, but leveraging a sharded archive format (vs. a mono-archive format like [PAR](https://github.com/google/subpar) or "deploy JAR")

The advantage of the sharded archive format is simple:  **We want to translate build-time incrementality into redeployment incrementality.**

By enabling the partitioning of dependencies into their own layers, in a binary agnostic fashion, we enable:
1. sharing of those dependencies across different images that depend on them
1. no republishing of those dependencies' layers when they haven't changed
1. no repulling unchanged dependencies' layers

In this model, what gets repushed/repulled can be made a direct function of Bazel's library-level incrementality.