### PR TITLE
Rename set to depset

### DIFF
--- a/docker/build.bzl
+++ b/docker/build.bzl
@@ -227,7 +227,7 @@ def _docker_build_impl(ctx):
       files = unzipped_layers + diff_ids + [config_file, config_digest] +
       ([docker_parts["legacy"]] if docker_parts["legacy"] else []))
   return struct(runfiles = runfiles,
-                files = set([ctx.outputs.layer]),
+                files = depset([ctx.outputs.layer]),
                 docker_parts = docker_parts)
 
 docker_build_ = rule(
@@ -411,7 +411,7 @@ def docker_build(**kwargs):
     if reserved in kwargs:
       fail("reserved for internal use by docker_build macro", attr=reserved)
   if "labels" in kwargs:
-    files = sorted(set([v[1:] for v in kwargs["labels"].values() if v[0] == "@"]))
+    files = sorted({v[1:]: None for v in kwargs["labels"].values() if v[0] == "@"}.keys())
     kwargs["label_files"] = files
     kwargs["label_file_strings"] = files
   if "entrypoint" in kwargs:

--- a/docker/bundle.bzl
+++ b/docker/bundle.bzl
@@ -59,7 +59,7 @@ def _docker_bundle_impl(ctx):
 
   return struct(runfiles = ctx.runfiles(
       files = (stamp_files + runfiles)),
-      files = set(),
+      files = depset(),
       docker_images = images,
       stamp = ctx.attr.stamp)
 
@@ -101,9 +101,10 @@ def docker_bundle(**kwargs):
   for reserved in ["image_targets", "image_target_strings"]:
     if reserved in kwargs:
       fail("reserved for internal use by docker_bundle macro", attr=reserved)
-      
+
   if "images" in kwargs:
-    kwargs["image_targets"] = list(set(kwargs["images"].values()))
-    kwargs["image_target_strings"] = list(set(kwargs["images"].values()))
+    values = {value: None for value in kwargs["images"].values()}.keys()
+    kwargs["image_targets"] = values
+    kwargs["image_target_strings"] = values
 
   docker_bundle_(**kwargs)

--- a/docker/import.bzl
+++ b/docker/import.bzl
@@ -96,7 +96,7 @@ def _docker_import_impl(ctx):
                [docker_parts["config"],
                 docker_parts["config_digest"]]))
   return struct(runfiles = runfiles,
-                files = set([ctx.outputs.out]),
+                files = depset([ctx.outputs.out]),
                 docker_parts = docker_parts)
 
 docker_import_ = rule(


### PR DESCRIPTION
`set` is a deprecated alias of `depset` and will be removed soon.

Also, they are not hashsets, if you need a hashset you can use a dict with empty values.