### PR TITLE
Run the container when `bazel run` on an image.

### DIFF
--- a/docker/build.bzl
+++ b/docker/build.bzl
@@ -282,7 +282,8 @@ def _impl(ctx, files=None, empty_files=None, directory=None,
       tag_name: docker_parts
   }
 
-  _incr_load(ctx, images, ctx.outputs.executable)
+  _incr_load(ctx, images, ctx.outputs.executable,
+             run=not ctx.attr.legacy_run_behavior)
   _assemble_image(ctx, images, ctx.outputs.out)
 
   runfiles = ctx.runfiles(
@@ -300,6 +301,8 @@ _attrs = {
     "debs": attr.label_list(allow_files = deb_filetype),
     "files": attr.label_list(allow_files = True),
     "legacy_repository_naming": attr.bool(default = False),
+    # TODO(mattmoor): Default this to False.
+    "legacy_run_behavior": attr.bool(default = True),
     "mode": attr.string(default = "0555"),  # 0555 == a+rx
     "symlinks": attr.string_dict(),
     "entrypoint": attr.string_list(),

--- a/docker/build.bzl
+++ b/docker/build.bzl
@@ -283,7 +283,8 @@ def _impl(ctx, files=None, empty_files=None, directory=None,
   }
 
   _incr_load(ctx, images, ctx.outputs.executable,
-             run=not ctx.attr.legacy_run_behavior)
+             run=not ctx.attr.legacy_run_behavior,
+             run_flags=ctx.attr.docker_run_flags)
   _assemble_image(ctx, images, ctx.outputs.out)
 
   runfiles = ctx.runfiles(
@@ -303,6 +304,7 @@ _attrs = {
     "legacy_repository_naming": attr.bool(default = False),
     # TODO(mattmoor): Default this to False.
     "legacy_run_behavior": attr.bool(default = True),
+    "docker_run_flags": attr.string(),
     "mode": attr.string(default = "0555"),  # 0555 == a+rx
     "symlinks": attr.string_dict(),
     "entrypoint": attr.string_list(),

--- a/docker/contrib/common/lang-image.bzl
+++ b/docker/contrib/common/lang-image.bzl
@@ -132,6 +132,7 @@ app_layer = rule(
         "data_path": attr.string(default = "."),
         "workdir": attr.string(default = "/app"),
         "directory": attr.string(default = "/app"),
+        "legacy_run_behavior": attr.bool(default = False),
     },
     executable = True,
     outputs = _docker.build.outputs,

--- a/docker/contrib/java/image.bzl
+++ b/docker/contrib/java/image.bzl
@@ -158,6 +158,7 @@ _jar_app_layer = rule(
         "directory": attr.string(default = "/app"),
         # https://github.com/bazelbuild/bazel/issues/2176
         "data_path": attr.string(default = "."),
+        "legacy_run_behavior": attr.bool(default = False),
     },
     executable = True,
     outputs = _docker.build.outputs,
@@ -232,6 +233,7 @@ _war_app_layer = rule(
         "directory": attr.string(default = "/jetty/webapps/ROOT/WEB-INF/lib"),
         # WE WANT PATHS FLATTENED
         # "data_path": attr.string(default = "."),
+        "legacy_run_behavior": attr.bool(default = False),
     },
     executable = True,
     outputs = _docker.build.outputs,
@@ -240,6 +242,14 @@ _war_app_layer = rule(
 
 def war_image(name, base=None, deps=[], layers=[], **kwargs):
   """Builds a Docker image overlaying the java_library as an exploded WAR.
+
+  TODO(mattmoor): For `bazel run` of this to be useful, we need to expose
+  a port on a local network interface, or the user will have to use
+  `docker inspect` to get the container's IP every time.
+
+  TODO(mattmoor): For `bazel run` of this to be useful, we need to be able
+  to ctrl-C it and have the container actually terminate.  More information:
+  https://github.com/bazelbuild/bazel/issues/3519
 
   Args:
     layers: Augments "deps" with dependencies that should be put into

--- a/docker/contrib/java/image.bzl
+++ b/docker/contrib/java/image.bzl
@@ -234,6 +234,12 @@ _war_app_layer = rule(
         # WE WANT PATHS FLATTENED
         # "data_path": attr.string(default = "."),
         "legacy_run_behavior": attr.bool(default = False),
+        # Run the container using host networking, so that the service is
+        # available to the developer without having to poke around with
+        # docker inspect.
+        "docker_run_flags": attr.string(
+            default = "-i --rm --network=host"
+        ),
     },
     executable = True,
     outputs = _docker.build.outputs,
@@ -242,10 +248,6 @@ _war_app_layer = rule(
 
 def war_image(name, base=None, deps=[], layers=[], **kwargs):
   """Builds a Docker image overlaying the java_library as an exploded WAR.
-
-  TODO(mattmoor): For `bazel run` of this to be useful, we need to expose
-  a port on a local network interface, or the user will have to use
-  `docker inspect` to get the container's IP every time.
 
   TODO(mattmoor): For `bazel run` of this to be useful, we need to be able
   to ctrl-C it and have the container actually terminate.  More information:

--- a/docker/incremental_load.sh.tpl
+++ b/docker/incremental_load.sh.tpl
@@ -239,5 +239,8 @@ function read_variables() {
 %{tag_statements}
 
 # An optional "docker run" statement for invoking a loaded container.
-# This generated and injected by docker_*.
-%{run_statements}
+# This is not executed if the single argument --norun is passed.
+if [ "a$@" != "a--norun" ]; then
+  # This generated and injected by docker_*.
+  %{run_statements}
+fi

--- a/docker/incremental_load.sh.tpl
+++ b/docker/incremental_load.sh.tpl
@@ -243,4 +243,6 @@ function read_variables() {
 if [ "a$@" != "a--norun" ]; then
   # This generated and injected by docker_*.
   %{run_statements}
+  # Empty if blocks can be problematic.
+  echo > /dev/null
 fi

--- a/docker/incremental_load.sh.tpl
+++ b/docker/incremental_load.sh.tpl
@@ -237,3 +237,7 @@ function read_variables() {
 # List of 'tag_layer' statements for all tags.
 # This generated and injected by docker_*.
 %{tag_statements}
+
+# An optional "docker run" statement for invoking a loaded container.
+# This generated and injected by docker_*.
+%{run_statements}


### PR DESCRIPTION
This makes the `bazel run` behavior on `docker_build` configurable and opts `foo_image` into running the container when the target is `bazel run`.

This does not change the default for `docker_build`, but users can now opt into it via `legacy_run_behavior = False`.