### PR TITLE
Avoid passing an empty list for deps, when there are no deps.

### DIFF
--- a/docker/contrib/java/image.bzl
+++ b/docker/contrib/java/image.bzl
@@ -175,7 +175,11 @@ def java_image(name, base=None, main_class=None, deps=[], layers=[], **kwargs):
   binary_name = name + ".binary"
 
   native.java_binary(name=binary_name, main_class=main_class,
-                     deps=deps + layers, **kwargs)
+                     # If the rule is turning a JAR built with java_library into
+                     # a binary, then it will appear in runtime_deps.  We are
+                     # not allowed to pass deps (even []) if there is no srcs
+                     # kwarg.
+                     deps=(deps + layers) or None, **kwargs)
 
   index = 0
   base = base or "@java_image_base//image"

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -478,6 +478,18 @@ java_image(
     main_class = "examples.images.Binary",
 )
 
+java_library(
+    name = "java_bin_as_lib",
+    srcs = ["Binary.java"],
+    deps = [":java_image_library"],
+)
+
+java_image(
+    name = "java_bin_as_lib_image",
+    runtime_deps = [":java_bin_as_lib"],
+    main_class = "examples.images.Binary",
+)
+
 war_image(
     name = "war_image",
     srcs = ["Servlet.java"],

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -220,6 +220,13 @@ function test_java_image() {
   docker run -ti --rm bazel/docker/testdata:java_image
 }
 
+function test_java_bin_as_lib_image() {
+  cd "${ROOT}"
+  clear_docker
+  bazel run docker/testdata:java_bin_as_lib_image
+  docker run -ti --rm bazel/docker/testdata:java_bin_as_lib_image
+}
+
 function test_war_image() {
   cd "${ROOT}"
   clear_docker
@@ -241,4 +248,5 @@ test_bazel_run_docker_import_incremental
 test_py_image
 test_cc_image
 test_java_image
+test_java_bin_as_lib_image
 test_war_image


### PR DESCRIPTION
This is to avoid an overly strict check in Bazel when a JAR built with java_library is being turned into a binary via runtime_deps + main_class, when there should be no `srcs` or `deps` kwargs.