### PR TITLE
Add a `precompress_layers` option to `docker_build()`.

### DIFF
--- a/docker/build.bzl
+++ b/docker/build.bzl
@@ -283,7 +283,8 @@ def _impl(ctx, files=None, empty_files=None, directory=None,
   }
 
   _incr_load(ctx, images, ctx.outputs.executable)
-  _assemble_image(ctx, images, ctx.outputs.out)
+  _assemble_image(ctx, images, ctx.outputs.out,
+                  precompress_layers=ctx.attr.precompress_layers)
 
   runfiles = ctx.runfiles(
       files = unzipped_layers + diff_ids + [config_file, config_digest] +
@@ -311,6 +312,7 @@ _attrs = {
     "volumes": attr.string_list(),
     "workdir": attr.string(),
     "repository": attr.string(default = "bazel"),
+    "precompress_layers": attr.bool(default=False),
     # Implicit/Undocumented dependencies.
     "label_files": attr.label_list(
         allow_files = True,

--- a/docker/join_layers.py
+++ b/docker/join_layers.py
@@ -52,6 +52,9 @@ parser.add_argument('--stamp-info-file', action='append', required=False,
                     help=('If stamping these layers, the list of files from '
                           'which to obtain workspace information'))
 
+parser.add_argument('--precompress', action='store_true', default=False,
+                    help='Precompress layers in the joined tarball.')
+
 
 class FromParts(v2_2_image.DockerImage):
   """This accesses a more efficient on-disk format than FromTarball.
@@ -125,7 +128,8 @@ class FromParts(v2_2_image.DockerImage):
 
 
 def create_bundle(output, tag_to_config, diffid_to_blobsum,
-                  blobsum_to_unzipped, blobsum_to_zipped, blobsum_to_legacy):
+                  blobsum_to_unzipped, blobsum_to_zipped, blobsum_to_legacy,
+                  precompress):
   """Creates a Docker image from a list of layers.
 
   Args:
@@ -134,6 +138,7 @@ def create_bundle(output, tag_to_config, diffid_to_blobsum,
     tag_to_layer: a map from docker_name.Tag to the layer id it references.
     layer_to_tags: a map from the name of the layer tarball as it appears
             in our archives to the list of tags applied to it.
+    precompress: Precompress layers in the joined tarball.
   """
 
   with tarfile.open(output, 'w') as tar:
@@ -148,7 +153,8 @@ def create_bundle(output, tag_to_config, diffid_to_blobsum,
           config, diffid_to_blobsum,
           blobsum_to_unzipped, blobsum_to_zipped, blobsum_to_legacy)
 
-    v2_2_save.multi_image_tarball(tag_to_image, tar)
+    v2_2_save.multi_image_tarball(tag_to_image, tar,
+                                  precompress_layers=precompress)
 
 
 def main():
@@ -212,7 +218,8 @@ def main():
 
   create_bundle(
       args.output, tag_to_config, diffid_to_blobsum,
-      blobsum_to_unzipped, blobsum_to_zipped, blobsum_to_legacy)
+      blobsum_to_unzipped, blobsum_to_zipped, blobsum_to_legacy,
+      args.precompress)
 
 
 if __name__ == '__main__':

--- a/docker/layers.bzl
+++ b/docker/layers.bzl
@@ -45,7 +45,7 @@ def get_from_target(ctx, attr_target, file_target):
     target = file_target[0]
     return _extract_layers(ctx, target)
 
-def assemble(ctx, images, output, stamp=False):
+def assemble(ctx, images, output, stamp=False, precompress_layers=False):
   """Create the full image from the list of layers."""
   args = [
       "--output=" + output.path,
@@ -80,6 +80,8 @@ def assemble(ctx, images, output, stamp=False):
   if stamp:
     args += ["--stamp-info-file=%s" % f.path for f in (ctx.info_file, ctx.version_file)]
     inputs += [ctx.info_file, ctx.version_file]
+  if precompress_layers:
+    args += ["--precompress"]
   ctx.action(
       executable = ctx.executable.join_layers,
       arguments = args,


### PR DESCRIPTION
This is used to move the layer compression from the push stage to the
build stage, where machines usually have more CPU available.

Depends on https://github.com/google/containerregistry/pull/13 because the layer joining is implemented on top of containerregistry's DockerImage logic.