### PR TITLE
Allow classpath to be passed as a file.

### DIFF
--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -783,7 +783,8 @@ function test_java_image() {
 ./app/docker/
 ./app/docker/testdata/
 ./app/docker/testdata/java_image.binary
-./app/docker/testdata/java_image.binary.jar'
+./app/docker/testdata/java_image.binary.jar
+./app/docker/testdata/java_image.classpath'
 }
 
 function test_war_image() {


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/rules_docker/issues/120