### PR TITLE
Run push commands in push-all in parallel

### DIFF
--- a/docker/contrib/push-all.bzl
+++ b/docker/contrib/push-all.bzl
@@ -72,9 +72,9 @@ def _impl(ctx):
 
   ctx.file_action(
     content = "\n".join(["#!/bin/bash -e"] + [
-      command.short_path
+      command.short_path + "&"
       for command in scripts
-    ]),
+    ] + ["wait"]),
     output = ctx.outputs.executable,
     executable=True,
   )


### PR DESCRIPTION
Simple PR to perform push-all in parallel.
Not super stoked about more reliance on bash (is there a better way to to this that means there's no bash usage? maybe building a bin for multi pushing or updating `google/containerregistry` to accept multiple images).

However this works for now and reduces push time for ~25 (unchanged) images from ~45 seconds to ~3 seconds.