### PR TITLE
Make testdata public

### DIFF
--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-package(default_visibility = ["//docker:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 load(
     "//docker:docker.bzl",


### PR DESCRIPTION
This enables additional internal tests to build open this testdata.