### PR TITLE
Link to docs at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Travis CI | Bazel CI
 
 ## Rules
 
-* [docker_build](#docker_build)
-* [docker_bundle](#docker_bundle)
+* [docker_build](#docker_build-1) ([example](#docker_build))
+* [docker_bundle](#docker_bundle-1) ([example](#docker_bundle))
 * [docker_import](#docker_import)
-* [docker_pull](#docker_pull)
-* [docker_push](#docker_push)
+* [docker_pull](#docker_pull-1) ([example](#docker_pull))
+* [docker_push](#docker_push-1) ([example](#docker_push))
 
 ## Overview
 


### PR DESCRIPTION
Currently, these links go to the examples, and you have to scroll down to find the full docs.