### PR TITLE
Python all the things

### DIFF
--- a/docker/contrib/push-all.bzl
+++ b/docker/contrib/push-all.bzl
@@ -81,7 +81,7 @@ def _impl(ctx):
 
   return struct(runfiles = ctx.runfiles(files = [
     ctx.executable._pusher
-  ] + stamp_inputs + runfiles))
+  ] + stamp_inputs + runfiles + list(ctx.attr._pusher.default_runfiles.files)))
 
 docker_push = rule(
     attrs = {
@@ -92,7 +92,7 @@ docker_push = rule(
             allow_files = True,
         ),
         "_pusher": attr.label(
-            default = Label("@pusher//file"),
+            default = Label("@containerregistry//:pusher"),
             cfg = "host",
             executable = True,
             allow_files = True,

--- a/docker/docker.bzl
+++ b/docker/docker.bzl
@@ -47,15 +47,6 @@ def docker_repositories():
       executable = True,
     )
 
-  if "pusher" not in excludes:
-    native.http_file(
-      name = "pusher",
-      url = ("https://storage.googleapis.com/containerregistry-releases/" +
-             CONTAINERREGISTRY_RELEASE + "/pusher.par"),
-      sha256 = "a1dca5bd0cc762a13b94d84d9e3ea3d99280da83a49aea2e4681c68788af9c99",
-      executable = True,
-    )
-
   if "containerregistry" not in excludes:
     native.git_repository(
       name = "containerregistry",

--- a/docker/pull.bzl
+++ b/docker/pull.bzl
@@ -18,6 +18,19 @@ Bazel rule for downloading base images without a Docker client to
 construct new images with docker_build.
 """
 
+def _python(repository_ctx):
+  if "BAZEL_PYTHON" in repository_ctx.os.environ:
+    return repository_ctx.os.environ.get("BAZEL_PYTHON")
+
+  python_path = repository_ctx.which("python")
+  if not python_path:
+    python_path = repository_ctx.which("python.exe")
+  if python_path:
+    return python_path
+
+  fail("rules_docker requires a python interpreter installed. " +
+       "Please set BAZEL_PYTHON, or put it on your path.")
+
 def _impl(repository_ctx):
   """Core implementation of docker_pull."""
 
@@ -37,6 +50,7 @@ docker_import(
 """)
 
   args = [
+      _python(repository_ctx),
       repository_ctx.path(repository_ctx.attr._puller),
       "--directory", repository_ctx.path("image")
   ]

--- a/docker/push.bzl
+++ b/docker/push.bzl
@@ -75,7 +75,8 @@ def _impl(ctx):
       ctx.executable._pusher,
       image["config"]
   ] + image.get("blobsum", []) + image.get("zipped_layer", []) +
-  stamp_inputs +  ([image["legacy"]] if image.get("legacy") else [])))
+  stamp_inputs + ([image["legacy"]] if image.get("legacy") else []) +
+  list(ctx.attr._pusher.default_runfiles.files)))
 
 _docker_push = rule(
     attrs = {
@@ -93,7 +94,7 @@ _docker_push = rule(
             allow_files = True,
         ),
         "_pusher": attr.label(
-            default = Label("@pusher//file"),
+            default = Label("@containerregistry//:pusher"),
             cfg = "host",
             executable = True,
             allow_files = True,


### PR DESCRIPTION
Switch to explicitly invoking Python when invoking PAR files in WORKSPACE phase.

Switch to consuming `py_binary` targets when invoking Python tooling in BUILD phase.

This is all working towards making rules_docker more portable, but doesn't completely resolve [this](https://github.com/bazelbuild/rules_docker/issues/136)