### PR TITLE
Refactor the way we pass files to the core docker_build for foo_image

### DIFF
--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -697,11 +697,12 @@ function test_py_image() {
   check_listing "py_image" "${lib_layer}" \
     './
 ./app/
-./app/docker/
-./app/docker/__init__.py
-./app/docker/testdata/
-./app/docker/testdata/__init__.py
-./app/docker/testdata/py_image_library.py'
+./app/io_bazel_rules_docker/
+./app/io_bazel_rules_docker/docker/
+./app/io_bazel_rules_docker/docker/__init__.py
+./app/io_bazel_rules_docker/docker/testdata/
+./app/io_bazel_rules_docker/docker/testdata/__init__.py
+./app/io_bazel_rules_docker/docker/testdata/py_image_library.py'
 
   check_listing "py_image" "${bin_layer}" \
     './
@@ -721,12 +722,10 @@ function test_py_image() {
 /app/docker/testdata/py_image.binary.runfiles/
 /app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/
 /app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/
+/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/__init__.py
 /app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/
-/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/docker/
-/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/docker/__init__.py
-/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/docker/testdata/
-/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/docker/testdata/__init__.py
-/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/docker/testdata/py_image_library.py'
+/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/__init__.py
+/app/docker/testdata/py_image.binary.runfiles/io_bazel_rules_docker/docker/testdata/py_image_library.py'
 }
 
 function test_cc_image() {

--- a/docker/contrib/common/lang-image.bzl
+++ b/docker/contrib/common/lang-image.bzl
@@ -21,46 +21,88 @@ load(
 load("//docker:pull.bzl", "docker_pull")
 
 def _binary_name(ctx):
+  # For //foo/bar/baz:blah this would translate to
+  # /app/foo/bar/baz/blah
   return "/".join([
       ctx.attr.directory,
       ctx.label.package,
-      ctx.attr.binary.label.name
+      ctx.attr.binary.label.name,
   ])
+
+def _runfiles_dir(ctx):
+  # For @foo//bar/baz:blah this would translate to
+  # /app/bar/baz/blah.runfiles
+  return _binary_name(ctx) + ".runfiles"
 
 # The directory relative to which all ".short_path" paths are relative.
 def _reference_dir(ctx):
-  return "/".join([
-    _binary_name(ctx) + ".runfiles",
-    ctx.workspace_name,
-  ])
+  # For @foo//bar/baz:blah this would translate to
+  # /app/bar/baz/blah.runfiles/foo
+  return "/".join([_runfiles_dir(ctx), ctx.workspace_name])
 
-def _fix_empty_file(ctx, name):
+# The final location that this file needs to exist for the foo_binary target to
+# properly execute.
+def _final_emptyfile_path(ctx, name):
   if not name.startswith('external/'):
+    # Names that don't start with external are relative to our own workspace.
     return _reference_dir(ctx) + "/" + name
+
   # References to workspace-external dependencies, which are identifiable
   # because their path begins with external/, are inconsistent with the
   # form of their File counterparts, whose ".short_form" is relative to
-  #    .../foo.runfiles/workspace-name/
+  #    .../foo.runfiles/workspace-name/  (aka _reference_dir(ctx))
   # whereas we see:
   #    external/foreign-workspace/...
-  # so we "fix" the empty files paths by replacing "external/" with "../"
-  return "../" + name[len("external/"):]
+  # so we "fix" the empty files' paths by removing "external/" and basing them
+  # directly on the runfiles path.
+  return "/".join([_runfiles_dir(ctx), name[len("external/"):]])
+
+# The final location that this file needs to exist for the foo_binary target to
+# properly execute.
+def _final_file_path(ctx, f):
+  return "/".join([_reference_dir(ctx), f.short_path])
+
+# The foo_binary independent location in which we store a particular dependency's
+# file such that it can be shared.
+def _layer_emptyfile_path(ctx, name):
+  if not name.startswith('external/'):
+    # Names that don't start with external are relative to our own workspace.
+    return "/".join([ctx.attr.directory, ctx.workspace_name, name])
+
+  # References to workspace-external dependencies, which are identifiable
+  # because their path begins with external/, are inconsistent with the
+  # form of their File counterparts, whose ".short_form" is relative to
+  #    .../foo.runfiles/workspace-name/  (aka _reference_dir(ctx))
+  # whereas we see:
+  #    external/foreign-workspace/...
+  # so we "fix" the empty files' paths by removing "external/" and basing them
+  # directly on the runfiles path.
+  return "/".join([ctx.attr.directory, name[len("external/"):]])
+
+# The foo_binary independent location in which we store a particular dependency's
+# file such that it can be shared.
+def _layer_file_path(ctx, f):
+  return "/".join([ctx.attr.directory, ctx.workspace_name, f.short_path])
 
 def _dep_layer_impl(ctx):
   """Appends a layer for a single dependency's runfiles."""
 
   return _docker.build.implementation(
     ctx,
+    # We use all absolute paths.
+    directory="/",
     # We put the files from dependency layers into a binary-agnostic
     # path to increase the likelihood of layer sharing across images,
     # then we symlink them into the appropriate place in the app layer.
     # This references the binary package because the file paths are
     # relative to it, and normalized by the tarball package.
-    directory=ctx.attr.directory + "/" + ctx.label.package,
-    files=list(ctx.attr.dep.default_runfiles.files),
+    file_map={
+        _layer_file_path(ctx, f): f
+        for f in ctx.attr.dep.default_runfiles.files
+    },
     empty_files=[
-      ctx.attr.directory + "/" + empty
-      for empty in ctx.attr.dep.default_runfiles.empty_filenames
+        _layer_emptyfile_path(ctx, empty)
+        for empty in ctx.attr.dep.default_runfiles.empty_filenames
     ]
   )
 
@@ -85,62 +127,56 @@ def _app_layer_impl(ctx):
   """Appends the app layer with all remaining runfiles."""
 
   # Compute the set of runfiles that have been made available
-  # in our base image.
-  available = depset()
+  # in our base image, tracking absolute paths.
+  available = {}
   for dep in ctx.attr.layers:
-    available += [f.short_path for f in dep.default_runfiles.files]
-    available += [f for f in dep.default_runfiles.empty_filenames]
-
-  # The name of the binary target for which we are populating
-  # this application layer.
-  basename = ctx.attr.binary.label.name
-  binary_name = _binary_name(ctx)
-
-  # ".short_path" is relative to this directory.
-  base_directory = _reference_dir(ctx)
+    available += {
+        _final_file_path(ctx, f): _layer_file_path(ctx, f)
+        for f in dep.default_runfiles.files
+    }
+    available += {
+        _final_emptyfile_path(ctx, f): _layer_emptyfile_path(ctx, f)
+        for f in dep.default_runfiles.empty_filenames
+    }
 
   # Compute the set of remaining runfiles to include into the
   # application layer.
-  files = [f for f in ctx.attr.binary.default_runfiles.files
-           # It is notable that this assumes that our version of
-	   # this runfile matches that of the dependency.  It is
-	   # not clear at this time whether that is an invariant
-	   # broadly in Bazel.
-           if f.short_path not in available]
+  file_map = {
+    _final_file_path(ctx, f): f
+    for f in ctx.attr.binary.default_runfiles.files
+    # It is notable that this assumes that our version of
+    # this runfile matches that of the dependency.  It is
+    # not clear at this time whether that is an invariant
+    # broadly in Bazel.
+    if _final_file_path(ctx, f) not in available
+  }
 
   empty_files = [
-    _fix_empty_file(ctx, f)
+    _final_emptyfile_path(ctx, f)
     for f in ctx.attr.binary.default_runfiles.empty_filenames
-    if _fix_empty_file(ctx, f) not in available
+    if _final_emptyfile_path(ctx, f) not in available
   ]
 
   # For each of the runfiles we aren't including directly into
   # the application layer, link to their binary-agnostic
   # location from the runfiles path.
-  symlinks = {
-    binary_name: "/".join([base_directory, ctx.label.package, basename])
-  } + {
-    directory + "/" + input: ctx.attr.directory + "/" + input
-    for input in available
-  }
-
-  # Use file_map to lay the files out very explicitly.
-  # All ".short_path" references are expected to be relative to the directory:
-  #   .../foo.runfiles/workspace-name/
-  # which we have in `base_directory`.
-  file_map = {
-      base_directory + "/" + f.short_path: f
-      for f in files
+  symlinks = available + {
+    # Create a symlink from our entrypoint to where it will actually be put
+    # under runfiles.
+    _binary_name(ctx): "/".join([_reference_dir(ctx), ctx.label.package,
+                                 ctx.attr.binary.label.name])
   }
 
   return _docker.build.implementation(
-    ctx, file_map=file_map, empty_files=empty_files,
+    ctx,
+    # We use all absolute paths.
+    directory="/", file_map=file_map,
+    empty_files=empty_files, symlinks=symlinks,
     # Use entrypoint so we can easily add arguments when the resulting
     # image is `docker run ...`.
     # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
     # we should use the "exec" (list) form of entrypoint.
-    entrypoint=ctx.attr.entrypoint + [binary_name],
-    directory="/", symlinks=symlinks)
+    entrypoint=ctx.attr.entrypoint + [_binary_name(ctx)])
 
 app_layer = rule(
     attrs = _docker.build.attrs + {

--- a/docker/contrib/java/image.bzl
+++ b/docker/contrib/java/image.bzl
@@ -48,6 +48,15 @@ load(
     "//docker:docker.bzl",
     _docker = "docker",
 )
+
+# TODO(mattmoor): Rather than continuing to rely on the magic_path nonsense, we
+# should refactor these rules to use files_map like common/lang-image.bzl.  It
+# is less necessary to do this for Java because the directory structure doesn't
+# communicate the namespace of the artifacts like it does in (e.g.) Python.
+# There could still be a bug here if we carefully craft paths such that two
+# different jars get the same path, but that is unlikely to happen in practice
+# making this a largely cosmetic issue w.r.t. the final image's filesystem
+# layout.
 load("//docker:build.bzl", "magic_path")
 
 def _dep_layer_impl(ctx):


### PR DESCRIPTION
This introduces a new (internal-only for now) argument to the `docker_build` implementation that allows rules to pass a dictionary mapping from the path in the filesystem to a Bazel `File` object to place there.

The common `foo_image` implementation now consumes this in the refactored version to fix how files are being laid out.

I [first noticed](https://github.com/bazelbuild/rules_docker/issues/106) this with `java_image`, which still has this problem, but because we can just construct the `--classpath` argument appropriately it isn't really a correctness issue there (so I've punted on fixing this for now, since it's cosmetic).

With these changes, I am finally able to put together a layered Python GRPC example for `rules_k8s`!

Fixes: https://github.com/bazelbuild/rules_docker/issues/139