### PR TITLE
Upstream the docker_flatten rule.

### DIFF
--- a/docker/BUILD
+++ b/docker/BUILD
@@ -67,6 +67,7 @@ TEST_DATA = [
     "//docker/testdata:cc_image.tar",
     "//docker/testdata:java_image.tar",
     "//docker/testdata:war_image.tar",
+    "//docker/testdata:flat.tar",
 ]
 
 sh_test(

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -563,6 +563,17 @@ function test_data_path() {
 ./docker/testdata/test/test"
 }
 
+function test_flattened_link_with_files_base() {
+  local test_data="${TEST_DATA_DIR}/flat.tar"
+  local actual_listing=""
+  check_eq "$(tar tf ${test_data})" \
+    "./
+/usr/
+/usr/bin/
+/usr/bin/java
+./foo"
+}
+
 # TODO(mattmoor): Needs a visibility change.
 # function test_extras_with_deb() {
 #   local test_data="${TEST_DATA_DIR}/extras_with_deb.tar"

--- a/docker/docker.bzl
+++ b/docker/docker.bzl
@@ -18,6 +18,9 @@
 load(":build.bzl", "docker_build", "build")
 load(":bundle.bzl", "docker_bundle")
 
+# Expose the docker_flatten rule.
+load(":flatten.bzl", "docker_flatten")
+
 # Expose the docker_import rule.
 load(":import.bzl", "docker_import")
 

--- a/docker/flatten.bzl
+++ b/docker/flatten.bzl
@@ -1,0 +1,78 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A rule to flatten docker_build images."""
+
+load(
+    ":path.bzl",
+    _get_runfile_path = "runfile",
+)
+load(
+    ":layers.bzl",
+    _get_layers = "get_from_target",
+    _layer_tools = "tools",
+)
+
+def _impl(ctx):
+  """Core implementation of docker_flatten."""
+
+  image = _get_layers(ctx, ctx.attr.image, ctx.files.image)
+
+  # Leverage our efficient intermediate representation to push.
+  legacy_base_arg = []
+  legacy_files = []
+  if image.get("legacy"):
+    # TODO(mattmoor): warn about legacy base.
+    legacy_files += [image["legacy"]]
+    legacy_base_arg = ["--tarball=%s" % image["legacy"].path]
+
+  blobsums = image.get("blobsum", [])
+  digest_args = ["--digest=" + f.path for f in blobsums]
+  blobs = image.get("zipped_layer", [])
+  layer_args = ["--layer=" + f.path for f in blobs]
+  config_arg = "--config=%s" % image["config"].path
+
+  ctx.action(
+      executable = ctx.executable._flattener,
+      arguments = legacy_base_arg + digest_args + layer_args + [
+          config_arg,
+          "--filesystem=" + ctx.outputs.filesystem.path,
+          "--metadata=" + ctx.outputs.metadata.path,
+      ],
+      inputs = blobsums + blobs + [image["config"]] + legacy_files,
+      outputs = [ctx.outputs.filesystem, ctx.outputs.metadata],
+      use_default_shell_env=True,
+      mnemonic="Flatten"
+  )
+  return struct()
+
+docker_flatten = rule(
+    attrs = {
+        "image": attr.label(
+            allow_files = [".tar"],
+            single_file = True,
+            mandatory = True,
+        ),
+        "_flattener": attr.label(
+            default = Label("@containerregistry//:flatten"),
+            cfg = "host",
+            executable = True,
+            allow_files = True,
+        ),
+    } + _layer_tools,
+    outputs = {
+        "filesystem": "%{name}.tar",
+        "metadata": "%{name}.json",
+    },
+    implementation = _impl,
+)

--- a/docker/testdata/BUILD
+++ b/docker/testdata/BUILD
@@ -17,6 +17,7 @@ load(
     "//docker:docker.bzl",
     "docker_build",
     "docker_bundle",
+    "docker_flatten",
     "docker_import",
     "docker_push",
 )
@@ -250,6 +251,11 @@ docker_build(
     symlinks = {
         "/usr/bin/java": "/bar",
     },
+)
+
+docker_flatten(
+    name = "flat",
+    image = ":link_with_files_base",
 )
 
 docker_push(


### PR DESCRIPTION
This adds a new rule that takes a `docker_build` image and produces a flattened tarball of the filesystem (`:foo.tar`) and extracts the image's metadata (`:foo.json`).

Fixes: https://github.com/bazelbuild/rules_docker/issues/145