### PR TITLE
Fix the runfiles path of the subcommands of push-all.bzl

### DIFF
--- a/docker/contrib/push-all.bzl
+++ b/docker/contrib/push-all.bzl
@@ -82,7 +82,7 @@ def _impl(ctx):
     template = ctx.file._all_tpl,
     substitutions = {
       "%{push_statements}": "\n".join([
-        _get_runfile_path(ctx, command) + "&"
+        "PYTHON_RUNFILES=${RUNFILES} " + _get_runfile_path(ctx, command) + "&"
         for command in scripts
       ]),
     },


### PR DESCRIPTION
Without this push-all silently fails because "wait" is not checking exit statuses.

I will open an issue to track that, but wanted to fix the breakage from my recent change first.