### PR TITLE
Allow uncompressed layers in container_import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1278,7 +1278,8 @@ A rule that imports a docker image into our intermediate form.
            appear in the <code>config.json</code>'s layer section, or in the
            order that they appear in <code>docker save</code> tarballs'
            <code>manifest.json</code> <code>Layers</code> field (these may or
-           may not be gzipped).</p>
+           may not be gzipped). Note that the layers should each have a
+           different basename.</p>
       </td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -1273,12 +1273,12 @@ A rule that imports a docker image into our intermediate form.
     <tr>
       <td><code>layers</code></td>
       <td>
-        <p><code>The list of layer `.tar.gz`s; required</code></p>
+        <p><code>The list of layer `.tar`s or `.tar.gz`s; required</code></p>
         <p>The list of layer <code>.tar.gz</code> files in the order they
            appear in the <code>config.json</code>'s layer section, or in the
            order that they appear in <code>docker save</code> tarballs'
-           <code>manifest.json</code> <code>Layers</code> field (although
-           these are gzipped).</p>
+           <code>manifest.json</code> <code>Layers</code> field (these may or
+           may not be gzipped).</p>
       </td>
     </tr>
   </tbody>

--- a/container/BUILD
+++ b/container/BUILD
@@ -112,6 +112,7 @@ TEST_TARGETS = [
     "base_based_warning",
     "cc_based_warning",
     "pause_piecemeal",
+    "pause_piecemeal_gz",
     "py_image",
     "cc_image",
     "java_image",

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -265,6 +265,15 @@ class ImageTest(unittest.TestCase):
       self.assertDigest(img, 'fdd4eeea8ad631006ba52058b2dbf8356adae8dcee16e431e9a407f5ef79d25f')
       self.assertEqual(3, len(img.fs_layers()))
 
+  def test_pause_piecemeal(self):
+    with TestImage('pause_piecemeal') as img:
+      self.assertDigest(img, 'ca362da80137d6e22de45cac9705271c694e63d87d4f98f1485288e83bda7334')
+      self.assertEqual(2, len(img.fs_layers()))
+
+  def test_pause_piecemeal_gz(self):
+    with TestImage('pause_piecemeal_gz') as img:
+      self.assertDigest(img, 'ca362da80137d6e22de45cac9705271c694e63d87d4f98f1485288e83bda7334')
+
   def test_build_with_tag(self):
     with TestBundleImage('build_with_tag', 'gcr.io/build/with:tag') as img:
       self.assertDigest(img, '1db3c9f3076f811a8d311ac6ee88251d621706ba8a80985685023b7e62b6cc14')

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -453,6 +453,14 @@ PAUSE_LAYERS = [
 [genrule(
     name = "extract_%s" % id,
     srcs = [":pause.tar"],
+    outs = ["%s.tar" % id],
+    cmd = ("tar xOf $(location :pause.tar) %s/layer.tar " +
+           "> $(location :%s.tar)") % (id, id),
+) for id in PAUSE_LAYERS]
+
+[genrule(
+    name = "extract_%s_gz" % id,
+    srcs = [":pause.tar"],
     outs = ["%s.tar.gz" % id],
     cmd = ("tar xOf $(location :pause.tar) %s/layer.tar " +
            "| gzip -n > $(location :%s.tar.gz)") % (id, id),
@@ -460,6 +468,12 @@ PAUSE_LAYERS = [
 
 container_import(
     name = "pause_piecemeal",
+    config = ":pause_config.json",
+    layers = ["%s.tar" % x for x in PAUSE_LAYERS],
+)
+
+container_import(
+    name = "pause_piecemeal_gz",
     config = ":pause_config.json",
     layers = ["%s.tar.gz" % x for x in PAUSE_LAYERS],
 )


### PR DESCRIPTION
This allows to let the rule decide if it needs the layers compressed or not. If one form is preferred over the other, it can be documented as such.

An added bonus is that the container_load rule can be made faster by passing on uncompressed layers instead of using python's gzip library. For now, the layers will still be compressed but using the faster gzip from shell.