### PR TITLE
Remove tar from passwd_file

### DIFF
--- a/container/image_test.py
+++ b/container/image_test.py
@@ -281,7 +281,7 @@ class ImageTest(unittest.TestCase):
 
   def test_with_passwd(self):
     with TestImage('with_passwd') as img:
-      self.assertDigest(img, '9fd1e04ef3070dc98b3b305e9e6091fd9e5fbf4a36d0928b5798a2d9ec2508ba')
+      self.assertDigest(img, '0d373a037dd30a8c37e61f4b40db6c7b55a47d0cdc8688e3679da64f8d4667df')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './etc', './etc/passwd'])
 

--- a/contrib/passwd.bzl
+++ b/contrib/passwd.bzl
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-
 def _impl(ctx):
   """Core implementation of passwd_file."""
 
@@ -30,21 +28,6 @@ def _impl(ctx):
       content = f,
       executable=False
   )
-  build_tar = ctx.executable.build_tar
-  args = [
-      "--output=" + ctx.outputs.tar.path,
-      "--file=%s=/etc/passwd" % ctx.outputs.out.path
-  ]
-  arg_file = ctx.new_file(ctx.attr.name + ".args")
-  ctx.file_action(arg_file, "\n".join(args))
-
-  ctx.action(
-      executable = build_tar,
-      arguments = ["--flagfile=" + arg_file.path],
-      inputs = [ctx.outputs.out, arg_file],
-      outputs = [ctx.outputs.tar],
-      use_default_shell_env = True
-  )
 
 passwd_file = rule(
     attrs = {
@@ -54,17 +37,10 @@ passwd_file = rule(
         "info": attr.string(default = "user"),
         "home": attr.string(default = "/home"),
         "shell": attr.string(default = "/bin/bash"),
-        "build_tar": attr.label(
-            default = Label("@bazel_tools//tools/build_defs/pkg:build_tar"),
-            cfg = "host",
-            executable = True,
-            allow_files = True,
-        ),
     },
     executable = False,
     outputs = {
-        "out": "%{name}.passwd",
-        "tar": "%{name}.passwd.tar",
+        "out": "%{name}",
     },
     implementation = _impl,
 )

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 package(default_visibility = ["//visibility:public"])
 
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load(
     "//container:container.bzl",
     "container_bundle",
@@ -405,7 +406,7 @@ oci_pushall(
 load("//contrib:passwd.bzl", "passwd_file")
 
 passwd_file(
-    name = "testpasswd",
+    name = "passwd",
     gid = 2345,
     home = "/myhomedir",
     info = "myusernameinfo",
@@ -414,9 +415,16 @@ passwd_file(
     username = "foobar",
 )
 
+pkg_tar(
+    name = "passwd_tar",
+    srcs = [":passwd"],
+    mode = "0644",
+    package_dir = "etc",
+)
+
 container_image(
     name = "with_passwd",
-    tars = [":testpasswd.passwd.tar"],
+    tars = [":passwd_tar"],
 )
 
 container_image(


### PR DESCRIPTION
This PR is replacing https://github.com/bazelbuild/rules_docker/pull/190
As per the comments, this PR is removing the tar