### PR TITLE
Use Python-friendly dict merging

### DIFF
--- a/container/bundle.bzl
+++ b/container/bundle.bzl
@@ -64,7 +64,7 @@ def _container_bundle_impl(ctx):
       stamp = ctx.attr.stamp)
 
 container_bundle_ = rule(
-    attrs = {
+    attrs = dict({
         "images": attr.string_dict(),
         # Implicit dependencies.
         "image_targets": attr.label_list(allow_files = True),
@@ -73,7 +73,7 @@ container_bundle_ = rule(
             default = False,
             mandatory = False,
         ),
-    } + _layer_tools,
+    }.items() + _layer_tools.items()),
     executable = True,
     outputs = {
         "out": "%{name}.tar",

--- a/container/flatten.bzl
+++ b/container/flatten.bzl
@@ -57,7 +57,7 @@ def _impl(ctx):
   return struct()
 
 container_flatten = rule(
-    attrs = {
+    attrs = dict({
         "image": attr.label(
             allow_files = [".tar"],
             single_file = True,
@@ -69,7 +69,7 @@ container_flatten = rule(
             executable = True,
             allow_files = True,
         ),
-    } + _layer_tools,
+    }.items() + _layer_tools.items()),
     outputs = {
         "filesystem": "%{name}.tar",
         "metadata": "%{name}.json",

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -305,7 +305,7 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, directory=None,
                 files = depset([ctx.outputs.layer]),
                 container_parts = container_parts)
 
-_attrs = {
+_attrs = dict({
     "base": attr.label(allow_files = container_filetype),
     "data_path": attr.string(),
     "directory": attr.string(default = "/"),
@@ -346,7 +346,7 @@ _attrs = {
         executable = True,
         allow_files = True,
     ),
-} + _hash_tools + _layer_tools
+}.items() + _hash_tools.items() + _layer_tools.items())
 
 _outputs = {
     "out": "%{name}.tar",

--- a/container/import.bzl
+++ b/container/import.bzl
@@ -121,11 +121,11 @@ def _container_import_impl(ctx):
                 container_parts = container_parts)
 
 container_import = rule(
-    attrs = {
+    attrs = dict({
         "config": attr.label(allow_files = [".json"]),
         "layers": attr.label_list(allow_files = tar_filetype + tgz_filetype),
         "repository": attr.string(default = "bazel"),
-    } + _hash_tools + _layer_tools,
+    }.items() + _hash_tools.items() + _layer_tools.items()),
     executable = True,
     outputs = {
         "out": "%{name}.tar",

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -84,7 +84,7 @@ def _impl(ctx):
   list(ctx.attr._pusher.default_runfiles.files)))
 
 container_push = rule(
-    attrs = {
+    attrs = dict({
         "image": attr.label(
             allow_files = [".tar"],
             single_file = True,
@@ -115,7 +115,7 @@ container_push = rule(
             default = False,
             mandatory = False,
         ),
-    } + _layer_tools,
+    }.items() + _layer_tools.items()),
     executable = True,
     implementation = _impl,
 )


### PR DESCRIPTION
Whereas Skylark currently allows dictA + dictB, since Python
interpretation is used for testing Skylark rules, use
dict(dictA.items() + dictB.items()) which will work in both Skylark and
Python. Support for the former is likely going to be removed from
Skylark support at some point.