### PR TITLE
use debs param in the _build_layer function

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -127,7 +127,7 @@ def _build_layer(ctx, files=None, file_map=None, empty_files=None,
   ctx.action(
       executable = build_layer,
       arguments = ["--flagfile=" + arg_file.path],
-      inputs = files + file_map.values() + ctx.files.tars + ctx.files.debs + [arg_file],
+      inputs = files + file_map.values() + ctx.files.tars + debs + [arg_file],
       outputs = [layer],
       use_default_shell_env=True,
       mnemonic="ImageLayer"


### PR DESCRIPTION
This change should have been included in 
https://github.com/bazelbuild/rules_docker/pull/208