### PR TITLE
Apply lang image visibility to underlying image targets.

### DIFF
--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -81,4 +81,6 @@ def cc_image(name, base=None, deps=[], layers=[], **kwargs):
     base = this_name
     index += 1
 
-  app_layer(name=name, base=base, binary=binary_name, layers=layers)
+  visibility = kwargs.get('visibility', None)
+  app_layer(name=name, base=base, binary=binary_name, layers=layers,
+            visibility=visibility)

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -54,4 +54,6 @@ def d_image(name, base=None, deps=[], layers=[], **kwargs):
     base = this_name
     index += 1
 
-  app_layer(name=name, base=base, binary=binary_name, layers=layers)
+  visibility = kwargs.get('visibility', None)
+  app_layer(name=name, base=base, binary=binary_name, layers=layers,
+            visibility=visibility)

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -85,4 +85,6 @@ def go_image(name, base=None, deps=[], layers=[], **kwargs):
     base = this_name
     index += 1
 
-  app_layer(name=name, base=base, binary=binary_name, layers=layers)
+  visibility = kwargs.get('visibility', None)
+  app_layer(name=name, base=base, binary=binary_name, layers=layers,
+            visibility=visibility)

--- a/groovy/image.bzl
+++ b/groovy/image.bzl
@@ -49,6 +49,7 @@ def groovy_image(name, base=None, deps=[], layers=[], **kwargs):
       files=[":" + binary_name + "_deploy.jar"],
       entrypoint=["/usr/bin/java", "-jar", "/" + binary_name + "_deploy.jar"],
       legacy_run_behavior = False,
+      visibility=kwargs.get('visibility', None),
   )
 
 def repositories():

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -232,9 +232,11 @@ def java_image(name, base=None, main_class=None,
     base = this_name
     index += 1
 
+  visibility = kwargs.get('visibility', None)
   _jar_app_layer(name=name, base=base, binary=binary_name,
                  main_class=main_class, jvm_flags=jvm_flags,
-                 deps=deps, runtime_deps=runtime_deps, layers=layers)
+                 deps=deps, runtime_deps=runtime_deps, layers=layers,
+                 visibility=visibility)
 
 def _war_dep_layer_impl(ctx):
   """Appends a layer for a single dependency's runfiles."""
@@ -333,4 +335,6 @@ def war_image(name, base=None, deps=[], layers=[], **kwargs):
     base = this_name
     index += 1
 
-  _war_app_layer(name=name, base=base, library=library_name, layers=layers)
+  visibility = kwargs.get('visibility', None)
+  _war_app_layer(name=name, base=base, library=library_name, layers=layers,
+                 visibility=visibility)

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -87,5 +87,6 @@ def py_image(name, base=None, deps=[], layers=[], **kwargs):
     base = this_name
     index += 1
 
+  visibility = kwargs.get('visibility', None)
   app_layer(name=name, base=base, entrypoint=['/usr/bin/python'],
-            binary=binary_name, layers=layers)
+            binary=binary_name, layers=layers, visibility=visibility)

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -54,4 +54,6 @@ def rust_image(name, base=None, deps=[], layers=[], **kwargs):
     base = this_name
     index += 1
 
-  app_layer(name=name, base=base, binary=binary_name, layers=layers)
+  visibility = kwargs.get('visibility', None)
+  app_layer(name=name, base=base, binary=binary_name, layers=layers,
+            visibility=visibility)

--- a/scala/image.bzl
+++ b/scala/image.bzl
@@ -49,6 +49,7 @@ def scala_image(name, base=None, deps=[], layers=[], **kwargs):
       files=[":" + binary_name + "_deploy.jar"],
       entrypoint=["/usr/bin/java", "-jar", "/" + binary_name + "_deploy.jar"],
       legacy_run_behavior = False,
+      visibility=kwargs.get('visibility', None),
   )
 
 def repositories():


### PR DESCRIPTION
It is currently not possible to reference a language specific image target from another package even with the correct `visibility` set. The cause of this is that the language specific image macros do not pass the visibility attribute to the generated image targets. This PR passes visibility down to the image targets.