### PR TITLE
Add example for the Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,15 @@ container_pull(
 ```
 
 This can then be referenced in `BUILD` files as `@base//image`.
+You can also pull images from the Docker Hub:
+
+```python
+container_pull(
+    name = "nginx_base",
+    registry = "registry.hub.docker.com",
+    repository = "library/nginx",
+)
+```
 
 ### container_push
 


### PR DESCRIPTION
It's not at all obvious what `repository` should be set to for the
Docker Hub. Hopefully this example helps people if they need it.