### PR TITLE
Update deps

### DIFF
--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2017-10-10 04:09 +0000
-    "debug": "sha256:21e38594fa41bf10526184c097f3c32ce10932c0944ac3780534bf2ad2c0d320",
-    # "gcr.io/distroless/cc:latest" circa 2017-10-10 04:09 +0000
-    "latest": "sha256:69efccbe4d1318955a884a7b85c192804d0d5df7da00cc5be193a177f6f5cee1",
+    # "gcr.io/distroless/cc:debug" circa 2017-11-08 11:56 +0100
+    "debug": "sha256:00090b91948b978d08f24ede2348408312a18225331507b7abed404f94fd902a",
+    # "gcr.io/distroless/cc:latest" circa 2017-11-08 11:56 +0100
+    "latest": "sha256:19f896ce5d0018a854e355c3d8d1a82041ad460ad8930da889c73b408e02f0b5",
 }

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2017-10-10 04:09 +0000
-    "debug": "sha256:fa2c87f23ce19665607fe43c701f0496fef87a5dbcf821c2ae64bfe415247822",
-    # "gcr.io/distroless/base:latest" circa 2017-10-10 04:09 +0000
+    # "gcr.io/distroless/base:debug" circa 2017-11-08 11:56 +0100
+    "debug": "sha256:d512c1059c142631fffecc437e9d13ba25b63ddb400ce0ac0d431d3528633d5f",
+    # "gcr.io/distroless/base:latest" circa 2017-11-08 11:56 +0100
     "latest": "sha256:4a8979a768c3ef8d0a8ed8d0af43dc5920be45a51749a9c611d178240f136eb4",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2017-10-10 04:10 +0000
-    "debug": "sha256:8155042bd06f028f452831bf25a21ad608308ae0868d28c667d66fa86d7103ca",
-    # "gcr.io/distroless/java:latest" circa 2017-10-10 04:10 +0000
-    "latest": "sha256:fa924e6904c4bb79c26996b5e8a9b37e9c392b5754b36b2bfafea2a36720ceeb",
+    # "gcr.io/distroless/java:debug" circa 2017-11-08 11:56 +0100
+    "debug": "sha256:9651c088fb09c34d790cfbf323b72cd261976a344947c78c149eb70eb6efe98d",
+    # "gcr.io/distroless/java:latest" circa 2017-11-08 11:56 +0100
+    "latest": "sha256:9607dd1cbdfa1149ae775c137c6864c944e3c9f64cb55dde38b3922d9d4e5a46",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2017-10-10 04:10 +0000
-    "debug": "sha256:93a701b4152061f784ecaed2cddd19214ea84079f607a23360f39293214cd20f",
-    # "gcr.io/distroless/java/jetty:latest" circa 2017-10-10 04:10 +0000
-    "latest": "sha256:9969e4cf3b485181bf6d3de1df06bb518d79ff45e2ba70e4cb87ca48b31db2a0",
+    # "gcr.io/distroless/java/jetty:debug" circa 2017-11-08 11:56 +0100
+    "debug": "sha256:90f6a24343a6bfef07196fa6e559b97f9d3d81b8a769c808be527494bc8aa716",
+    # "gcr.io/distroless/java/jetty:latest" circa 2017-11-08 11:56 +0100
+    "latest": "sha256:5cb5e98cd5f310a509f00fff8b45450727350b35b7db4a1654d034365536ea9e",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2017-10-10 04:10 +0000
-    "debug": "sha256:e17d365160da5d6a27bdccb7d00e98a8eb8ece2a3ad8721f39ec3f2b2083bb9a",
-    # "gcr.io/distroless/python2.7:latest" circa 2017-10-10 04:10 +0000
-    "latest": "sha256:018229eb4b65acd8e2866da325b68e17f6c3b8e3164ed3c0994523f561c3b44f",
+    # "gcr.io/distroless/python2.7:debug" circa 2017-11-08 11:56 +0100
+    "debug": "sha256:e2b841816df7e1a3fe73c457075e0c368e317e7b36940b459b7156fff868e138",
+    # "gcr.io/distroless/python2.7:latest" circa 2017-11-08 11:56 +0100
+    "latest": "sha256:0ae2591d35d44087743feecbdc5349058c96502132217d8f950452657c48fd27",
 }


### PR DESCRIPTION
This adds libgomp1 to the C++ image, enabling binaries compiled with
-fopenmp.

https://github.com/GoogleCloudPlatform/distroless/pull/118