### PR TITLE
Scala sandwich testing

### DIFF
--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -537,6 +537,13 @@ java_image(
     main_class = "examples.images.Binary",
 )
 
+java_image(
+    name = "java_sandwich_image",
+    srcs = ["Binary.java"],
+    layers = [":scala_image_library"],
+    main_class = "examples.images.Binary",
+)
+
 java_library(
     name = "java_bin_as_lib",
     srcs = ["Binary.java"],
@@ -572,6 +579,13 @@ scala_image(
     srcs = ["Binary.scala"],
     main_class = "examples.images.Binary",
     deps = [":scala_image_library"],
+)
+
+scala_image(
+    name = "scala_sandwich_image",
+    srcs = ["Binary.scala"],
+    main_class = "examples.images.Binary",
+    deps = [":java_image_library"],
 )
 
 load("//groovy:image.bzl", "groovy_image")

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -558,13 +558,20 @@ war_image(
     ],
 )
 
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 load("//scala:image.bzl", "scala_image")
+
+scala_library(
+    name = "scala_image_library",
+    srcs = ["Library.scala"],
+    deps = ["@com_google_guava_guava//jar"],
+)
 
 scala_image(
     name = "scala_image",
     srcs = ["Binary.scala"],
     main_class = "examples.images.Binary",
-    deps = [":java_image_library"],
+    deps = [":scala_image_library"],
 )
 
 load("//groovy:image.bzl", "groovy_image")

--- a/testdata/Library.scala
+++ b/testdata/Library.scala
@@ -1,0 +1,24 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import com.google.common.base.Joiner
+import com.google.common.collect.ImmutableList
+
+object Library {
+    def SayHello(): String = {
+	return Joiner.on(" ").join(ImmutableList.of("Hello", "World"));
+    }
+}

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -200,6 +200,12 @@ function test_java_image() {
   EXPECT_CONTAINS "$(bazel run "$@" testdata:java_image)" "Hello World"
 }
 
+function test_java_sandwich_image() {
+  cd "${ROOT}"
+  clear_docker
+  EXPECT_CONTAINS "$(bazel run "$@" testdata:java_sandwich_image)" "Hello World"
+}
+
 function test_java_bin_as_lib_image() {
   cd "${ROOT}"
   clear_docker
@@ -222,6 +228,12 @@ function test_scala_image() {
   cd "${ROOT}"
   clear_docker
   EXPECT_CONTAINS "$(bazel run "$@" testdata:scala_image)" "Hello World"
+}
+
+function test_scala_sandwich_image() {
+  cd "${ROOT}"
+  clear_docker
+  EXPECT_CONTAINS "$(bazel run "$@" testdata:scala_sandwich_image)" "Hello World"
 }
 
 function test_groovy_image() {
@@ -259,10 +271,14 @@ test_go_image -c dbg
 test_go_image_busybox
 test_java_image -c opt
 test_java_image -c dbg
+test_java_sandwich_image -c opt
+test_java_sandwich_image -c dbg
 test_java_bin_as_lib_image
 test_war_image
 test_scala_image -c opt
 test_scala_image -c dbg
+test_scala_sandwich_image -c opt
+test_scala_sandwich_image -c dbg
 test_groovy_image -c opt
 test_groovy_image -c dbg
 test_rust_image -c opt


### PR DESCRIPTION
This addresses scala/java interdependencies, and adds support for layering `scala_image`s at a fine grain like `java_image`.

Fixes: https://github.com/bazelbuild/rules_docker/issues/224