### PR TITLE
allow override of `tars` for docker_build extensions

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -114,8 +114,8 @@ def _build_layer(ctx, files=None, file_map=None, empty_files=None,
   args += ["--file=%s=%s" % (f.path, magic_path(ctx, f)) for f in files]
   args += ["--file=%s=%s" % (f.path, path) for (path, f) in file_map.items()]
   args += ["--empty_file=%s" % f for f in empty_files or []]
-  args += ["--tar=" + f.path for f in tars if f.path.endswith(".tar")]
-  args += ["--deb=" + f.path for f in debs if f.path.endswith(".deb")]
+  args += ["--tar=" + f.path for f in tars]
+  args += ["--deb=" + f.path for f in debs]
   for k in symlinks:
     if ':' in k:
       fail("The source of a symlink cannot contain ':', got: %s" % k)

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -94,7 +94,7 @@ def magic_path(ctx, f):
     return f.basename
 
 def _build_layer(ctx, files=None, file_map=None, empty_files=None,
-                 directory=None, symlinks=None, debs=None):
+                 directory=None, symlinks=None, debs=None, tars=None):
   """Build the current layer for appending it the base layer.
 
   Args:
@@ -114,7 +114,7 @@ def _build_layer(ctx, files=None, file_map=None, empty_files=None,
   args += ["--file=%s=%s" % (f.path, magic_path(ctx, f)) for f in files]
   args += ["--file=%s=%s" % (f.path, path) for (path, f) in file_map.items()]
   args += ["--empty_file=%s" % f for f in empty_files or []]
-  args += ["--tar=" + f.path for f in ctx.files.tars]
+  args += ["--tar=" + f.path for f in tars if f.path.endswith(".tar")]
   args += ["--deb=" + f.path for f in debs if f.path.endswith(".deb")]
   for k in symlinks:
     if ':' in k:
@@ -127,7 +127,7 @@ def _build_layer(ctx, files=None, file_map=None, empty_files=None,
   ctx.action(
       executable = build_layer,
       arguments = ["--flagfile=" + arg_file.path],
-      inputs = files + file_map.values() + ctx.files.tars + debs + [arg_file],
+      inputs = files + file_map.values() + tars + debs + [arg_file],
       outputs = [layer],
       use_default_shell_env=True,
       mnemonic="ImageLayer"
@@ -217,7 +217,8 @@ def _repository_name(ctx):
   return _join_path(ctx.attr.repository, ctx.label.package)
 
 def _impl(ctx, files=None, file_map=None, empty_files=None, directory=None,
-          entrypoint=None, cmd=None, symlinks=None, output=None, env=None, debs=None):
+          entrypoint=None, cmd=None, symlinks=None, output=None, env=None,
+          debs=None, tars=None):
   """Implementation for the container_image rule.
 
   Args:
@@ -232,6 +233,7 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, directory=None,
     output: File to use as output for script to load docker image
     env: str Dict, overrides ctx.attr.env
     debs: File list, overrides ctx.files.debs
+    tars: File list, overrides ctx.files.tars
   """
 
   file_map = file_map or {}
@@ -244,11 +246,13 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, directory=None,
   output = output or ctx.outputs.executable
   env = env or ctx.attr.env
   debs = debs or ctx.files.debs
+  tars = tars or ctx.files.tars
 
   # Generate the unzipped filesystem layer, and its sha256 (aka diff_id).
   unzipped_layer, diff_id = _build_layer(ctx, files=files, file_map=file_map,
                                          empty_files=empty_files,
-                                         directory=directory, symlinks=symlinks, debs=debs)
+                                         directory=directory, symlinks=symlinks,
+                                         debs=debs, tars=tars)
 
   # Generate the zipped filesystem layer, and its sha256 (aka blob sum)
   zipped_layer, blob_sum = _zip_layer(ctx, unzipped_layer)


### PR DESCRIPTION
We need to override `tars` attr in addition to `debs` attr.