### PR TITLE
Remove unused logic from incremental_load script

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -28,22 +28,6 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 DOCKER="${DOCKER:-docker}"
 
-function list_diffids() {
-  for image in $("${DOCKER}" images -aq 2> /dev/null);
-  do
-    for entry in $("${DOCKER}" inspect -f '{{json .RootFS.Layers}}' "${image}");
-    do
-      echo -n $entry | python -mjson.tool | grep sha256 | cut -d'"' -f 2 | cut -d':' -f 2
-    done
-  done
-}
-
-# Fetch the diff ids of the layers loaded in the docker daemon already
-IMAGES=$(list_diffids | sort | uniq)
-IMAGE_LEN=$(for i in $IMAGES; do echo -n $i | wc -c; done | sort -g | head -1 | xargs)
-
-[ -n "$IMAGE_LEN" ] || IMAGE_LEN=64
-
 # Create temporary files in which to record things to clean up.
 TEMP_FILES="$(mktemp -t 2>/dev/null || mktemp -t 'rules_docker_files')"
 TEMP_IMAGES="$(mktemp -t 2>/dev/null || mktemp -t 'rules_docker_images')"


### PR DESCRIPTION
Removing the unused logic speeds up image loading significantly.

Fixes #200.