### PR TITLE
Use imported py3_image target

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,6 +50,13 @@ load(
 
 _py_image_repos()
 
+load(
+    "//python3:image.bzl",
+    _py3_image_repos = "repositories",
+)
+
+_py3_image_repos()
+
 # Have the cc_image dependencies for testing.
 load(
     "//cc:image.bzl",

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -511,7 +511,7 @@ py_image(
 
 load("//python3:image.bzl", "py3_image")
 
-py_image(
+py3_image(
     name = "py3_image",
     srcs = ["py3_image.py"],
     layers = [


### PR DESCRIPTION
Pull #235 included the py3_image in the testdata directory, but didn’t use it.

/cc @mattmoor @hwright