### PR TITLE
Support external binaries in lang_image rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ registry interactions.
 
 ## Language Rules
 
-* [cc_image](#cc_image) ([signature](
-https://docs.bazel.build/versions/master/be/c-cpp.html#cc_binary))
-* [go_image](#go_image) ([signature](
-https://github.com/bazelbuild/rules_go#go_binary))
 * [py_image](#py_image) ([signature](
 https://docs.bazel.build/versions/master/be/python.html#py_binary))
 * [py3_image](#py3_image) ([signature](
@@ -55,10 +51,17 @@ https://docs.bazel.build/versions/master/be/java.html#java_library))
 https://github.com/bazelbuild/rules_scala#scala_binary))
 * [groovy_image](#groovy_image) ([signature](
 https://github.com/bazelbuild/rules_groovy#groovy_binary))
+* [cc_image](#cc_image) ([signature](
+https://docs.bazel.build/versions/master/be/c-cpp.html#cc_binary))
+* [go_image](#go_image) ([signature](
+https://github.com/bazelbuild/rules_go#go_binary))
 * [rust_image](#rust_image) ([signature](
 https://github.com/bazelbuild/rules_rust#rust_binary))
 * [d_image](#d_image) ([signature](
 https://github.com/bazelbuild/rules_d#d_binary))
+
+It is notable that: `cc_image`, `go_image`, `rust_image`, and `d_image`
+also allow you to specify an external binary target.
 
 ### Overview
 
@@ -286,6 +289,26 @@ cc_image(
     name = "cc_image",
     srcs = ["cc_image.cc"],
     deps = [":cc_image_library"],
+)
+```
+
+### cc_image (external binary)
+
+To use `cc_image` (or `go_image`, `d_image`, `rust_image) with an external
+`cc_binary` (or the like) target, then your `BUILD` file should instead look
+like:
+```python
+load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
+
+cc_binary(
+    name = "cc_binary",
+    srcs = ["cc_binary.cc"],
+    deps = [":cc_library"],
+)
+
+cc_image(
+    name = "cc_image",
+    binary = ":cc_binary",
 )
 ```
 

--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -58,20 +58,23 @@ DEFAULT_BASE = select({
     "//conditions:default": "@cc_image_base//image",
 })
 
-def cc_image(name, base=None, deps=[], layers=[], **kwargs):
+def cc_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   """Constructs a container image wrapping a cc_binary target.
 
   Args:
+    binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     **kwargs: See cc_binary.
   """
-  binary_name = name + ".binary"
-
   if layers:
     print("cc_image does not benefit from layers=[], got: %s" % layers)
 
-  native.cc_binary(name=binary_name, deps=deps + layers, **kwargs)
+  if not binary:
+    binary = name + ".binary"
+    native.cc_binary(name=binary, deps=deps + layers, **kwargs)
+  elif deps:
+    fail("kwarg does nothing when binary is specified", "deps")
 
   index = 0
   base = base or DEFAULT_BASE
@@ -82,5 +85,5 @@ def cc_image(name, base=None, deps=[], layers=[], **kwargs):
     index += 1
 
   visibility = kwargs.get('visibility', None)
-  app_layer(name=name, base=base, binary=binary_name, layers=layers,
+  app_layer(name=name, base=base, binary=binary, layers=layers,
             visibility=visibility)

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -31,20 +31,23 @@ load("@io_bazel_rules_d//d:d.bzl", "d_binary")
 def repositories():
   _repositories()
 
-def d_image(name, base=None, deps=[], layers=[], **kwargs):
+def d_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   """Constructs a container image wrapping a d_binary target.
 
   Args:
+    binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     **kwargs: See d_binary.
   """
-  binary_name = name + "_binary"
-
   if layers:
     print("d_image does not benefit from layers=[], got: %s" % layers)
 
-  d_binary(name=binary_name, deps=deps + layers, **kwargs)
+  if not binary:
+    binary = name + "_binary"
+    d_binary(name=binary, deps=deps + layers, **kwargs)
+  elif deps:
+    fail("kwarg does nothing when binary is specified", "deps")
 
   index = 0
   base = base or DEFAULT_BASE
@@ -55,5 +58,5 @@ def d_image(name, base=None, deps=[], layers=[], **kwargs):
     index += 1
 
   visibility = kwargs.get('visibility', None)
-  app_layer(name=name, base=base, binary=binary_name, layers=layers,
+  app_layer(name=name, base=base, binary=binary, layers=layers,
             visibility=visibility)

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -63,19 +63,22 @@ DEFAULT_BASE = select({
     "//conditions:default": "@go_image_base//image",
 })
 
-def go_image(name, base=None, deps=[], layers=[], **kwargs):
+def go_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   """Constructs a container image wrapping a go_binary target.
 
   Args:
+    binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into their own layers.
     **kwargs: See go_binary.
   """
-  binary_name = name + ".binary"
-
   if layers:
     print("go_image does not benefit from layers=[], got: %s" % layers)
 
-  go_binary(name=binary_name, deps=deps + layers, **kwargs)
+  if not binary:
+    binary = name + ".binary"
+    go_binary(name=binary, deps=deps + layers, **kwargs)
+  elif deps:
+    fail("kwarg does nothing when binary is specified", "deps")
 
   index = 0
   base = base or DEFAULT_BASE
@@ -86,5 +89,5 @@ def go_image(name, base=None, deps=[], layers=[], **kwargs):
     index += 1
 
   visibility = kwargs.get('visibility', None)
-  app_layer(name=name, base=base, binary=binary_name, layers=layers,
+  app_layer(name=name, base=base, binary=binary, layers=layers,
             visibility=visibility)

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -31,20 +31,23 @@ load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
 def repositories():
   _repositories()
 
-def rust_image(name, base=None, deps=[], layers=[], **kwargs):
+def rust_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   """Constructs a container image wrapping a rust_binary target.
 
   Args:
+    binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     **kwargs: See rust_binary.
   """
-  binary_name = name + "_binary"
-
   if layers:
     print("rust_image does not benefit from layers=[], got: %s" % layers)
 
-  rust_binary(name=binary_name, deps=deps + layers, **kwargs)
+  if not binary:
+    binary = name + "_binary"
+    rust_binary(name=binary, deps=deps + layers, **kwargs)
+  elif deps:
+    fail("kwarg does nothing when binary is specified", "deps")
 
   index = 0
   base = base or DEFAULT_BASE
@@ -55,5 +58,5 @@ def rust_image(name, base=None, deps=[], layers=[], **kwargs):
     index += 1
 
   visibility = kwargs.get('visibility', None)
-  app_layer(name=name, base=base, binary=binary_name, layers=layers,
+  app_layer(name=name, base=base, binary=binary, layers=layers,
             visibility=visibility)

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -535,6 +535,17 @@ cc_image(
     layers = [":cc_image_library"],
 )
 
+cc_binary(
+    name = "cc_binary",
+    srcs = ["cc_image.cc"],
+    deps = [":cc_image_library"],
+)
+
+cc_image(
+    name = "cc_binary_as_image",
+    binary = ":cc_binary",
+)
+
 load(
     "//java:image.bzl",
     "java_image",

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -180,6 +180,12 @@ function test_cc_image() {
   EXPECT_CONTAINS "$(bazel run "$@" testdata:cc_image)" "Hello World"
 }
 
+function test_cc_binary_as_image() {
+  cd "${ROOT}"
+  clear_docker
+  EXPECT_CONTAINS "$(bazel run "$@" testdata:cc_binary_as_image)" "Hello World"
+}
+
 function test_go_image() {
   cd "${ROOT}"
   clear_docker
@@ -266,6 +272,8 @@ test_py_image -c opt
 test_py_image -c dbg
 test_cc_image -c opt
 test_cc_image -c dbg
+test_cc_binary_as_image -c opt
+test_cc_binary_as_image -c dbg
 test_go_image -c opt
 test_go_image -c dbg
 test_go_image_busybox


### PR DESCRIPTION
This applies to cc, rust, d, and go (none of which benefit appreciable from layering).