### PR TITLE
This adds a simple / functional nodejs_image rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ instead of `py_image`.  The other semantics are identical.
 **It is notable that unlike the other image rules, `nodejs_image` is not
 currently using the `gcr.io/distroless/nodejs` image for a handful of reasons.**
 This is a switch we plan to make, when we can manage it.  We are currently
-utilizing the `gcr.io/google-appengine/base` image as our base.
+utilizing the `gcr.io/google-appengine/debian9` image as our base.
 
 To use `nodejs_image`, add the following to `WORKSPACE`:
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -142,3 +142,25 @@ git_repository(
 load("@io_bazel_rules_d//d:d.bzl", "d_repositories")
 
 d_repositories()
+
+git_repository(
+    name = "build_bazel_rules_nodejs",
+    commit = "5c53b46110d13c4c9f22364e96b2d0f55896d7aa",
+    remote = "https://github.com/bazelbuild/rules_nodejs.git",
+)
+
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "npm_install")
+
+node_repositories(package_json = ["//testdata:package.json"])
+
+npm_install(
+    name = "npm_deps",
+    package_json = "//testdata:package.json",
+)
+
+load(
+    "//nodejs:image.bzl",
+    _nodejs_image_repos = "repositories",
+)
+
+_nodejs_image_repos()

--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/cc:debug" circa 2017-12-09 23:07 +0000
     "debug": "sha256:d3fe07be221200e6a7c9981545da4394cd6177ab80012da65a858069bd374bb9",
-    # "gcr.io/distroless/cc:latest" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/cc:latest" circa 2017-12-09 23:07 +0000
     "latest": "sha256:7a52af4e4f09c905f2264c99ec75f65481fd132454f3ff4dd06962c99c7dab6e",
 }

--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -76,13 +76,11 @@ def cc_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   elif deps:
     fail("kwarg does nothing when binary is specified", "deps")
 
-  index = 0
   base = base or DEFAULT_BASE
-  for dep in layers:
+  for index, dep in enumerate(layers):
     this_name = "%s.%d" % (name, index)
     dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
-    index += 1
 
   visibility = kwargs.get('visibility', None)
   app_layer(name=name, base=base, binary=binary, layers=layers,

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -313,6 +313,7 @@ class ImageTest(unittest.TestCase):
         '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata/py_image_library.py',
         '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata/__init__.py',
         '/app/testdata/py_image.binary',
+        '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/external',
       ])
 
       # Check the library layer, which is one below our application layer.
@@ -341,6 +342,9 @@ class ImageTest(unittest.TestCase):
         '/app',
         '/app/testdata',
         '/app/testdata/cc_image.binary',
+        '/app/testdata/cc_image.binary.runfiles',
+        '/app/testdata/cc_image.binary.runfiles/io_bazel_rules_docker',
+        '/app/testdata/cc_image.binary.runfiles/io_bazel_rules_docker/external',
       ])
 
       # The linker pulls the object files into the final binary,

--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -38,8 +38,7 @@ def _impl(ctx):
 
   scripts = []
   runfiles = []
-  index = 0
-  for tag in images:
+  for index, tag in enumerate(images.keys()):
     image = images[tag]
     # Leverage our efficient intermediate representation to push.
     legacy_base_arg = ""
@@ -77,7 +76,6 @@ def _impl(ctx):
 
     scripts += [out]
     runfiles += [out]
-    index += 1
 
   ctx.template_action(
     template = ctx.file._all_tpl,

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -49,13 +49,11 @@ def d_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   elif deps:
     fail("kwarg does nothing when binary is specified", "deps")
 
-  index = 0
   base = base or DEFAULT_BASE
-  for dep in layers:
+  for index, dep in enumerate(layers):
     this_name = "%s_%d" % (name, index)
     dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
-    index += 1
 
   visibility = kwargs.get('visibility', None)
   app_layer(name=name, base=base, binary=binary, layers=layers,

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2017-12-07 17:48 -0500
+    # "gcr.io/distroless/base:debug" circa 2017-12-09 23:05 +0000
     "debug": "sha256:2a4edff9a50ea5c0aa40cf3c99206b9e8efe6ca131f774f2c279e22762e90792",
-    # "gcr.io/distroless/base:latest" circa 2017-12-07 17:48 -0500
+    # "gcr.io/distroless/base:latest" circa 2017-12-09 23:05 +0000
     "latest": "sha256:bef8d030c7f36dfb73a8c76137616faeea73ac5a8495d535f27c911d0db77af3",
 }

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/base:debug" circa 2017-12-09 23:07 +0000
     "debug": "sha256:2a4edff9a50ea5c0aa40cf3c99206b9e8efe6ca131f774f2c279e22762e90792",
-    # "gcr.io/distroless/base:latest" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/base:latest" circa 2017-12-09 23:07 +0000
     "latest": "sha256:bef8d030c7f36dfb73a8c76137616faeea73ac5a8495d535f27c911d0db77af3",
 }

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -80,13 +80,11 @@ def go_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   elif deps:
     fail("kwarg does nothing when binary is specified", "deps")
 
-  index = 0
   base = base or DEFAULT_BASE
-  for dep in layers:
+  for index, dep in enumerate(layers):
     this_name = "%s.%d" % (name, index)
     dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
-    index += 1
 
   visibility = kwargs.get('visibility', None)
   app_layer(name=name, base=base, binary=binary, layers=layers,

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -238,13 +238,11 @@ def java_image(name, base=None, main_class=None,
                      deps=(deps + layers) or None, runtime_deps=runtime_deps,
                      jvm_flags=jvm_flags, **kwargs)
 
-  index = 0
   base = base or DEFAULT_JAVA_BASE
-  for dep in layers:
+  for index, dep in enumerate(layers):
     this_name = "%s.%d" % (name, index)
     jar_dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
-    index += 1
 
   visibility = kwargs.get('visibility', None)
   jar_app_layer(name=name, base=base, binary=binary_name,
@@ -353,13 +351,11 @@ def war_image(name, base=None, deps=[], layers=[], **kwargs):
 
   native.java_library(name=library_name, deps=deps + layers, **kwargs)
 
-  index = 0
   base = base or DEFAULT_JETTY_BASE
-  for dep in layers:
+  for index, dep in enumerate(layers):
     this_name = "%s.%d" % (name, index)
     _war_dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
-    index += 1
 
   visibility = kwargs.get('visibility', None)
   _war_app_layer(name=name, base=base, library=library_name, layers=layers,

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -119,6 +119,12 @@ jar_dep_layer = rule(
         # The dependency whose runfiles we're appending.
         "dep": attr.label(mandatory = True),
 
+        # Whether to lay out each dependency in a manner that is agnostic
+        # of the binary in which it is participating.  This can increase
+        # sharing of the dependency's layer across images, but requires a
+        # symlink forest in the app layers.
+        "agnostic_dep_layout": attr.bool(default = True),
+
         # Override the defaults.
         "directory": attr.string(default = "/app"),
         # https://github.com/bazelbuild/bazel/issues/2176
@@ -192,6 +198,12 @@ jar_app_layer = rule(
         # The main class to invoke on startup.
         "main_class": attr.string(mandatory = True),
 
+        # Whether to lay out each dependency in a manner that is agnostic
+        # of the binary in which it is participating.  This can increase
+        # sharing of the dependency's layer across images, but requires a
+        # symlink forest in the app layers.
+        "agnostic_dep_layout": attr.bool(default = True),
+
         # Whether the classpath should be passed as a file.
         "_classpath_as_file": attr.bool(default = False),
 
@@ -256,6 +268,12 @@ _war_dep_layer = rule(
         # The dependency whose runfiles we're appending.
         "dep": attr.label(mandatory = True),
 
+        # Whether to lay out each dependency in a manner that is agnostic
+        # of the binary in which it is participating.  This can increase
+        # sharing of the dependency's layer across images, but requires a
+        # symlink forest in the app layers.
+        "agnostic_dep_layout": attr.bool(default = True),
+
         # Override the defaults.
         "directory": attr.string(default = "/jetty/webapps/ROOT/WEB-INF/lib"),
         # WE WANT PATHS FLATTENED
@@ -295,6 +313,12 @@ _war_app_layer = rule(
         # The base image on which to overlay the dependency layers.
         "base": attr.label(mandatory = True),
         "entrypoint": attr.string_list(default = []),
+
+        # Whether to lay out each dependency in a manner that is agnostic
+        # of the binary in which it is participating.  This can increase
+        # sharing of the dependency's layer across images, but requires a
+        # symlink forest in the app layers.
+        "agnostic_dep_layout": attr.bool(default = True),
 
         # Override the defaults.
         "directory": attr.string(default = "/jetty/webapps/ROOT/WEB-INF/lib"),

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2017-12-07 17:49 -0500
+    # "gcr.io/distroless/java:debug" circa 2017-12-09 23:05 +0000
     "debug": "sha256:61dc3d88cac3362e29130a630bdf21be1b663ae54fa671e46b6d73054e87646a",
-    # "gcr.io/distroless/java:latest" circa 2017-12-07 17:49 -0500
+    # "gcr.io/distroless/java:latest" circa 2017-12-09 23:05 +0000
     "latest": "sha256:7bde7029b0ca01fbf7dfcf4bbce879705711112ed66f9f981209d7d1422cbea2",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/java:debug" circa 2017-12-09 23:07 +0000
     "debug": "sha256:61dc3d88cac3362e29130a630bdf21be1b663ae54fa671e46b6d73054e87646a",
-    # "gcr.io/distroless/java:latest" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/java:latest" circa 2017-12-09 23:07 +0000
     "latest": "sha256:7bde7029b0ca01fbf7dfcf4bbce879705711112ed66f9f981209d7d1422cbea2",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/java/jetty:debug" circa 2017-12-09 23:07 +0000
     "debug": "sha256:514da00aeeefccdd3f514b77505366c92fffac2791467164ed52b2db92228484",
-    # "gcr.io/distroless/java/jetty:latest" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/java/jetty:latest" circa 2017-12-09 23:07 +0000
     "latest": "sha256:f623f87da1e3e1e9802b20f8f7e84af4791493b5d051d0c62014683054add6d7",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2017-12-07 17:49 -0500
+    # "gcr.io/distroless/java/jetty:debug" circa 2017-12-09 23:05 +0000
     "debug": "sha256:514da00aeeefccdd3f514b77505366c92fffac2791467164ed52b2db92228484",
-    # "gcr.io/distroless/java/jetty:latest" circa 2017-12-07 17:49 -0500
+    # "gcr.io/distroless/java/jetty:latest" circa 2017-12-09 23:05 +0000
     "latest": "sha256:f623f87da1e3e1e9802b20f8f7e84af4791493b5d051d0c62014683054add6d7",
 }

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -11,15 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+package(default_visibility = ["//visibility:public"])
 
-# !!!! THIS IS A GENERATED FILE TO NOT EDIT IT BY HAND !!!!
-#
-# To regenerate this file, run ./update_deps.sh from the root of the
-# git repository.
-
-DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2017-12-09 23:05 +0000
-    "debug": "sha256:d3fe07be221200e6a7c9981545da4394cd6177ab80012da65a858069bd374bb9",
-    # "gcr.io/distroless/cc:latest" circa 2017-12-09 23:05 +0000
-    "latest": "sha256:7a52af4e4f09c905f2264c99ec75f65481fd132454f3ff4dd06962c99c7dab6e",
-}
+licenses(["notice"])  # Apache 2.0

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -122,13 +122,11 @@ def nodejs_image(name, base=None, data=[], layers=[],
 
   # TODO(mattmoor): Consider making the directory into which the app
   # is placed configurable.
-  index = 0
   base = base or DEFAULT_BASE
-  for dep in layers:
+  for index, dep in enumerate(layers):
     this_name = "%s.%d" % (name, index)
     _dep_layer(name=this_name, base=base, dep=dep, binary=binary_name)
     base = this_name
-    index += 1
 
   visibility = kwargs.get('visibility', None)
   app_layer(name=name, base=base, entrypoint=['sh', '-c'],

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -1,0 +1,137 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A rule for creating a Node.js container image.
+
+The signature of this rule is compatible with nodejs_binary.
+"""
+
+load(
+    "//lang:image.bzl",
+    "dep_layer_impl",
+    "app_layer",
+)
+load(
+    "//container:container.bzl",
+    "container_pull",
+    _container = "container",
+    _repositories = "repositories",
+)
+
+# Load the resolved digests.
+load(":nodejs.bzl", "DIGESTS")
+
+def repositories():
+  # Call the core "repositories" function to reduce boilerplate.
+  # This is idempotent if folks call it themselves.
+  _repositories()
+
+  excludes = native.existing_rules().keys()
+  if "nodejs_image_base" not in excludes:
+    container_pull(
+      name = "nodejs_image_base",
+      registry = "gcr.io",
+      repository = "google-appengine/base",
+      digest = DIGESTS["latest"],
+    )
+  if "nodejs_debug_image_base" not in excludes:
+    container_pull(
+      name = "nodejs_debug_image_base",
+      registry = "gcr.io",
+      repository = "google-appengine/base",
+      digest = DIGESTS["debug"],
+    )
+
+DEFAULT_BASE = select({
+    "@io_bazel_rules_docker//:fastbuild": "@nodejs_image_base//image",
+    "@io_bazel_rules_docker//:debug": "@nodejs_debug_image_base//image",
+    "@io_bazel_rules_docker//:optimized": "@nodejs_image_base//image",
+    "//conditions:default": "@nodejs_debug_image_base//image",
+})
+
+def _runfiles(dep):
+  return dep.default_runfiles.files + dep.data_runfiles.files + dep.files
+
+def _emptyfiles(dep):
+  return dep.default_runfiles.empty_filenames + dep.data_runfiles.empty_filenames
+
+def _dep_layer_impl(ctx):
+  return dep_layer_impl(ctx, runfiles=_runfiles, emptyfiles=_emptyfiles)
+
+_dep_layer = rule(
+    attrs = _container.image.attrs + {
+        # The base image on which to overlay the dependency layers.
+        "base": attr.label(mandatory = True),
+        # The dependency whose runfiles we're appending.
+        "dep": attr.label(
+            mandatory = True,
+            allow_files = True,
+        ),
+
+        # Whether to lay out each dependency in a manner that is agnostic
+        # of the binary in which it is participating.  This can increase
+        # sharing of the dependency's layer across images, but requires a
+        # symlink forest in the app layers.
+        "agnostic_dep_layout": attr.bool(default = False),
+        # The binary target for which we are synthesizing an image.
+        # This is needed iff agnostic_dep_layout.
+        "binary": attr.label(mandatory = False),
+
+        # Override the defaults.
+        # https://github.com/bazelbuild/bazel/issues/2176
+        "data_path": attr.string(default = "."),
+        "directory": attr.string(default = "/app"),
+    },
+    executable = True,
+    outputs = _container.image.outputs,
+    implementation = _dep_layer_impl,
+)
+
+load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+
+def nodejs_image(name, base=None, data=[], layers=[],
+                 node_modules="//:node_modules", **kwargs):
+  """Constructs a container image wrapping a nodejs_binary target.
+
+  Args:
+    layers: Augments "deps" with dependencies that should be put into
+           their own layers.
+    **kwargs: See nodejs_binary.
+  """
+  binary_name = name + ".binary"
+
+  layers = [
+    # Put the Node binary into its own layer.
+    "@nodejs//:bin/node",
+    # node_modules can get large, it should be in its own layer.
+    node_modules,
+  ] + layers
+
+  nodejs_binary(name=binary_name, node_modules=node_modules,
+                data=data + layers, **kwargs)
+
+  # TODO(mattmoor): Consider making the directory into which the app
+  # is placed configurable.
+  index = 0
+  base = base or DEFAULT_BASE
+  for dep in layers:
+    this_name = "%s.%d" % (name, index)
+    _dep_layer(name=this_name, base=base, dep=dep, binary=binary_name)
+    base = this_name
+    index += 1
+
+  visibility = kwargs.get('visibility', None)
+  app_layer(name=name, base=base, entrypoint=['sh', '-c'],
+            # Node.JS hates symlinks.
+            agnostic_dep_layout=False,
+            binary=binary_name, layers=layers, visibility=visibility)

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -41,14 +41,14 @@ def repositories():
     container_pull(
       name = "nodejs_image_base",
       registry = "gcr.io",
-      repository = "google-appengine/base",
+      repository = "google-appengine/debian9",
       digest = DIGESTS["latest"],
     )
   if "nodejs_debug_image_base" not in excludes:
     container_pull(
       name = "nodejs_debug_image_base",
       registry = "gcr.io",
-      repository = "google-appengine/base",
+      repository = "google-appengine/debian9",
       digest = DIGESTS["debug"],
     )
 

--- a/nodejs/nodejs.bzl
+++ b/nodejs/nodejs.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2017-12-09 23:05 +0000
-    "debug": "sha256:d3fe07be221200e6a7c9981545da4394cd6177ab80012da65a858069bd374bb9",
-    # "gcr.io/distroless/cc:latest" circa 2017-12-09 23:05 +0000
-    "latest": "sha256:7a52af4e4f09c905f2264c99ec75f65481fd132454f3ff4dd06962c99c7dab6e",
+    # "gcr.io/google-appengine/base:debug" circa 2017-12-09 23:05 +0000
+    "debug": "sha256:c2e1aa7b3713c5bc8f4032cc26ff9f616542d105b4d0bcaceeadc8083c9c109e",
+    # "gcr.io/google-appengine/base:latest" circa 2017-12-09 23:05 +0000
+    "latest": "sha256:c2e1aa7b3713c5bc8f4032cc26ff9f616542d105b4d0bcaceeadc8083c9c109e",
 }

--- a/nodejs/nodejs.bzl
+++ b/nodejs/nodejs.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/google-appengine/base:debug" circa 2017-12-09 23:05 +0000
-    "debug": "sha256:c2e1aa7b3713c5bc8f4032cc26ff9f616542d105b4d0bcaceeadc8083c9c109e",
-    # "gcr.io/google-appengine/base:latest" circa 2017-12-09 23:05 +0000
-    "latest": "sha256:c2e1aa7b3713c5bc8f4032cc26ff9f616542d105b4d0bcaceeadc8083c9c109e",
+    # "gcr.io/google-appengine/debian9:debug" circa 2017-12-09 23:07 +0000
+    "debug": "sha256:6c76ed9ff726a1433243c3c2e8806e4f2ef2cbacddaca7c9e15f7d4312b1bb9f",
+    # "gcr.io/google-appengine/debian9:latest" circa 2017-12-09 23:07 +0000
+    "latest": "sha256:6c76ed9ff726a1433243c3c2e8806e4f2ef2cbacddaca7c9e15f7d4312b1bb9f",
 }

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -74,13 +74,11 @@ def py_image(name, base=None, deps=[], layers=[], **kwargs):
 
   # TODO(mattmoor): Consider making the directory into which the app
   # is placed configurable.
-  index = 0
   base = base or DEFAULT_BASE
-  for dep in layers:
+  for index, dep in enumerate(layers):
     this_name = "%s.%d" % (name, index)
     dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
-    index += 1
 
   visibility = kwargs.get('visibility', None)
   app_layer(name=name, base=base, entrypoint=['/usr/bin/python'],

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/python2.7:debug" circa 2017-12-09 23:07 +0000
     "debug": "sha256:bcc4820cd633a461b6570b81cce3e73d6b169bb847d1f68112289a73da5abf02",
-    # "gcr.io/distroless/python2.7:latest" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/python2.7:latest" circa 2017-12-09 23:07 +0000
     "latest": "sha256:32904fecb9aa09d347dc8b76d2ffc4cc4fc183a9e026b0dbdd01254b4dfd2d86",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2017-12-07 17:48 -0500
+    # "gcr.io/distroless/python2.7:debug" circa 2017-12-09 23:05 +0000
     "debug": "sha256:bcc4820cd633a461b6570b81cce3e73d6b169bb847d1f68112289a73da5abf02",
-    # "gcr.io/distroless/python2.7:latest" circa 2017-12-07 17:48 -0500
+    # "gcr.io/distroless/python2.7:latest" circa 2017-12-09 23:05 +0000
     "latest": "sha256:32904fecb9aa09d347dc8b76d2ffc4cc4fc183a9e026b0dbdd01254b4dfd2d86",
 }

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -74,13 +74,11 @@ def py3_image(name, base=None, deps=[], layers=[], **kwargs):
 
   # TODO(mattmoor): Consider making the directory into which the app
   # is placed configurable.
-  index = 0
   base = base or DEFAULT_BASE
-  for dep in layers:
+  for index, dep in enumerate(layers):
     this_name = "%s.%d" % (name, index)
     dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
-    index += 1
 
   visibility = kwargs.get('visibility', None)
   app_layer(name=name, base=base, entrypoint=['/usr/bin/python'],

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2017-12-07 17:49 -0500
+    # "gcr.io/distroless/python3:debug" circa 2017-12-09 23:05 +0000
     "debug": "sha256:b85549147ef95174e03da6f54693fe96c533d3ae1a505db7cdd428bdac8ccffd",
-    # "gcr.io/distroless/python3:latest" circa 2017-12-07 17:49 -0500
+    # "gcr.io/distroless/python3:latest" circa 2017-12-09 23:05 +0000
     "latest": "sha256:db2582d604778faf02fefb7089b8ce9f1e6fa62dda04eb3a4c510c31cc1d2799",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/python3:debug" circa 2017-12-09 23:07 +0000
     "debug": "sha256:b85549147ef95174e03da6f54693fe96c533d3ae1a505db7cdd428bdac8ccffd",
-    # "gcr.io/distroless/python3:latest" circa 2017-12-09 23:05 +0000
+    # "gcr.io/distroless/python3:latest" circa 2017-12-09 23:07 +0000
     "latest": "sha256:db2582d604778faf02fefb7089b8ce9f1e6fa62dda04eb3a4c510c31cc1d2799",
 }

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -49,13 +49,11 @@ def rust_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   elif deps:
     fail("kwarg does nothing when binary is specified", "deps")
 
-  index = 0
   base = base or DEFAULT_BASE
-  for dep in layers:
+  for index, dep in enumerate(layers):
     this_name = "%s_%d" % (name, index)
     dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
-    index += 1
 
   visibility = kwargs.get('visibility', None)
   app_layer(name=name, base=base, binary=binary, layers=layers,

--- a/scala/image.bzl
+++ b/scala/image.bzl
@@ -47,13 +47,11 @@ def scala_image(name, base=None, main_class=None,
                       deps=(deps + layers) or None, runtime_deps=runtime_deps,
                       jvm_flags=jvm_flags, **kwargs)
 
-  index = 0
   base = base or DEFAULT_JAVA_BASE
-  for dep in layers:
+  for index, dep in enumerate(layers):
     this_name = "%s.%d" % (name, index)
     jar_dep_layer(name=this_name, base=base, dep=dep)
     base = this_name
-    index += 1
 
   visibility = kwargs.get('visibility', None)
   jar_app_layer(name=name, base=base, binary=binary_name,

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -647,3 +647,12 @@ d_image(
     name = "d_image",
     srcs = ["main.d"],
 )
+
+load("//nodejs:image.bzl", "nodejs_image")
+
+nodejs_image(
+    name = "nodejs_image",
+    data = [":nodejs_image.js"],
+    entry_point = "io_bazel_rules_docker/testdata/nodejs_image.js",
+    node_modules = "@npm_deps//:node_modules",
+)

--- a/testdata/nodejs_image.js
+++ b/testdata/nodejs_image.js
@@ -1,0 +1,3 @@
+var jsesc = require('jsesc');
+
+console.log(jsesc('Hello World!'));

--- a/testdata/package.json
+++ b/testdata/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "jsesc": "~0.3.0"
+  }
+}

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -260,6 +260,12 @@ function test_d_image() {
   EXPECT_CONTAINS "$(bazel run "$@" testdata:d_image)" "Hello world"
 }
 
+function test_nodejs_image() {
+  cd "${ROOT}"
+  clear_docker
+  EXPECT_CONTAINS "$(bazel run "$@" testdata:nodejs_image)" "Hello World!"
+}
+
 test_top_level
 test_bazel_build_then_run_docker_build_clean
 test_bazel_run_docker_build_clean
@@ -293,3 +299,5 @@ test_rust_image -c opt
 test_rust_image -c dbg
 test_d_image -c opt
 test_d_image -c dbg
+test_nodejs_image -c opt
+test_nodejs_image -c dbg

--- a/tools/update_deps.py
+++ b/tools/update_deps.py
@@ -46,7 +46,10 @@ def main():
 
   debug = docker_name.Tag(str(repo) + ":debug")
   with docker_image.FromRegistry(debug, creds, transport) as img:
-    debug_digest = img.digest()
+    if img.exists():
+      debug_digest = img.digest()
+    else:
+      debug_digest = latest_digest
 
   with open(args.output, 'w') as f:
     f.write("""\

--- a/update_deps.sh
+++ b/update_deps.sh
@@ -22,3 +22,4 @@ bazel run tools:update_deps -- --repository=gcr.io/distroless/python2.7 --output
 bazel run tools:update_deps -- --repository=gcr.io/distroless/python3 --output=$PWD/python3/python3.bzl
 bazel run tools:update_deps -- --repository=gcr.io/distroless/java --output=$PWD/java/java.bzl
 bazel run tools:update_deps -- --repository=gcr.io/distroless/java/jetty --output=$PWD/java/jetty.bzl
+bazel run tools:update_deps -- --repository=gcr.io/google-appengine/base --output=$PWD/nodejs/nodejs.bzl

--- a/update_deps.sh
+++ b/update_deps.sh
@@ -22,4 +22,4 @@ bazel run tools:update_deps -- --repository=gcr.io/distroless/python2.7 --output
 bazel run tools:update_deps -- --repository=gcr.io/distroless/python3 --output=$PWD/python3/python3.bzl
 bazel run tools:update_deps -- --repository=gcr.io/distroless/java --output=$PWD/java/java.bzl
 bazel run tools:update_deps -- --repository=gcr.io/distroless/java/jetty --output=$PWD/java/jetty.bzl
-bazel run tools:update_deps -- --repository=gcr.io/google-appengine/base --output=$PWD/nodejs/nodejs.bzl
+bazel run tools:update_deps -- --repository=gcr.io/google-appengine/debian9 --output=$PWD/nodejs/nodejs.bzl


### PR DESCRIPTION
For now these images are based on gcr.io/google-appengine/base instead of gcr.io/distroless/nodejs for two reasons:
1. The nodejs_binary runfiles includes the node binary, so we need not use a Node.JS base runtime.
1. The generated nodejs_binary entrypoint is currently a bash script, so if/until we can move this logic into our own entrypoint we need a more substantial base runtime.