### PR TITLE
Update gcr.io/distroless digests.

### DIFF
--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2017-11-17 12:25 -0500
-    "debug": "sha256:a9dde7b572769587072b2af3956ed2a073223e865aab15290d3585787e613e1a",
-    # "gcr.io/distroless/cc:latest" circa 2017-11-17 12:25 -0500
+    # "gcr.io/distroless/cc:debug" circa 2017-12-07 17:48 -0500
+    "debug": "sha256:d3fe07be221200e6a7c9981545da4394cd6177ab80012da65a858069bd374bb9",
+    # "gcr.io/distroless/cc:latest" circa 2017-12-07 17:48 -0500
     "latest": "sha256:7a52af4e4f09c905f2264c99ec75f65481fd132454f3ff4dd06962c99c7dab6e",
 }

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2017-11-17 12:25 -0500
-    "debug": "sha256:f4fcf7c98bb83dd79deafd590ea0c774aebe386d4486a926f05078689a48c2b7",
-    # "gcr.io/distroless/base:latest" circa 2017-11-17 12:25 -0500
+    # "gcr.io/distroless/base:debug" circa 2017-12-07 17:48 -0500
+    "debug": "sha256:2a4edff9a50ea5c0aa40cf3c99206b9e8efe6ca131f774f2c279e22762e90792",
+    # "gcr.io/distroless/base:latest" circa 2017-12-07 17:48 -0500
     "latest": "sha256:bef8d030c7f36dfb73a8c76137616faeea73ac5a8495d535f27c911d0db77af3",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2017-11-17 12:25 -0500
-    "debug": "sha256:51f368384b96711a2b541dd74f79cbe26b897f5ee5854194e719d9682a0fc1ab",
-    # "gcr.io/distroless/java:latest" circa 2017-11-17 12:25 -0500
-    "latest": "sha256:0965d0dfe2ef58f063d0818fd595aa7eb973fa59cd410c6ed935503b38ff920d",
+    # "gcr.io/distroless/java:debug" circa 2017-12-07 17:49 -0500
+    "debug": "sha256:61dc3d88cac3362e29130a630bdf21be1b663ae54fa671e46b6d73054e87646a",
+    # "gcr.io/distroless/java:latest" circa 2017-12-07 17:49 -0500
+    "latest": "sha256:7bde7029b0ca01fbf7dfcf4bbce879705711112ed66f9f981209d7d1422cbea2",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2017-11-17 12:25 -0500
-    "debug": "sha256:0b765ee8e9c8b2b3fca8588c06f3d3ef5bf669140b3cb8095628ae4e54682002",
-    # "gcr.io/distroless/java/jetty:latest" circa 2017-11-17 12:25 -0500
-    "latest": "sha256:7bceb33e33f3954ea0b57fa46d8777ff297d5bb445c47adf0d60b0ad1d26ada6",
+    # "gcr.io/distroless/java/jetty:debug" circa 2017-12-07 17:49 -0500
+    "debug": "sha256:514da00aeeefccdd3f514b77505366c92fffac2791467164ed52b2db92228484",
+    # "gcr.io/distroless/java/jetty:latest" circa 2017-12-07 17:49 -0500
+    "latest": "sha256:f623f87da1e3e1e9802b20f8f7e84af4791493b5d051d0c62014683054add6d7",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2017-11-17 12:25 -0500
-    "debug": "sha256:b483e6badb8a00c835ee5e4b74325a6ded51a348509ad8308bcad515fd02631e",
-    # "gcr.io/distroless/python2.7:latest" circa 2017-11-17 12:25 -0500
-    "latest": "sha256:0c8e07564ffd60807765009d4e7f2d0530db0f60a312701837eae256e0e0bd2d",
+    # "gcr.io/distroless/python2.7:debug" circa 2017-12-07 17:48 -0500
+    "debug": "sha256:bcc4820cd633a461b6570b81cce3e73d6b169bb847d1f68112289a73da5abf02",
+    # "gcr.io/distroless/python2.7:latest" circa 2017-12-07 17:48 -0500
+    "latest": "sha256:32904fecb9aa09d347dc8b76d2ffc4cc4fc183a9e026b0dbdd01254b4dfd2d86",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2017-11-17 12:25 -0500
-    "debug": "sha256:94cbf1b244a166d0e1cf7dad6cadd1005de4ac45d0654328d9d1829535974524",
-    # "gcr.io/distroless/python3:latest" circa 2017-11-17 12:25 -0500
-    "latest": "sha256:541aac5dedf977acf596464363c9197c539c9192408497b37bcad7d5b7a076bc",
+    # "gcr.io/distroless/python3:debug" circa 2017-12-07 17:49 -0500
+    "debug": "sha256:b85549147ef95174e03da6f54693fe96c533d3ae1a505db7cdd428bdac8ccffd",
+    # "gcr.io/distroless/python3:latest" circa 2017-12-07 17:49 -0500
+    "latest": "sha256:db2582d604778faf02fefb7089b8ce9f1e6fa62dda04eb3a4c510c31cc1d2799",
 }


### PR DESCRIPTION
Updating the `gcr.io/distroless` DIGESTS via [`./update-deps.sh`](https://github.com/bazelbuild/rules_docker/blob/master/update_deps.sh).

My motivation is to get a version of the python 2.7. with `libssl.so.1.1`. This is present in the latest image but not in the version current specified in DIGESTS. I can update the PR to just include the Python 2.7 DIGESTS changes, if that is preferable.