### PR TITLE
Fix go_image not producing a working image

### DIFF
--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -202,8 +202,7 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
   symlinks += {
     # Create a symlink from our entrypoint to where it will actually be put
     # under runfiles.
-    _binary_name(ctx): "/".join([_reference_dir(ctx),
-                                 ctx.attr.binary.files.to_list()[0].short_path]),
+    _binary_name(ctx): _final_file_path(ctx, ctx.attr.binary.files.to_list()[0]),
     # Create a directory symlink from <workspace>/external to the runfiles
     # root, since they may be accessed via either path.
     _external_dir(ctx): _runfiles_dir(ctx),

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -202,8 +202,8 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
   symlinks += {
     # Create a symlink from our entrypoint to where it will actually be put
     # under runfiles.
-    _binary_name(ctx): "/".join([_reference_dir(ctx), ctx.label.package,
-                                 ctx.attr.binary.label.name]),
+    _binary_name(ctx): "/".join([_reference_dir(ctx),
+                                 ctx.attr.binary.files.to_list()[0].short_path]),
     # Create a directory symlink from <workspace>/external to the runfiles
     # root, since they may be accessed via either path.
     _external_dir(ctx): _runfiles_dir(ctx),

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -222,7 +222,11 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
 app_layer = rule(
     attrs = _container.image.attrs + {
         # The binary target for which we are synthesizing an image.
-        "binary": attr.label(mandatory = True, executable = True, cfg="target"),
+        "binary": attr.label(
+            mandatory = True,
+            executable = True,
+            cfg = "target",
+        ),
         # The full list of dependencies that have their own layers
         # factored into our base.
         "layers": attr.label_list(allow_files = True),

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -202,7 +202,7 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
   symlinks += {
     # Create a symlink from our entrypoint to where it will actually be put
     # under runfiles.
-    _binary_name(ctx): _final_file_path(ctx, ctx.attr.binary.files.to_list()[0]),
+    _binary_name(ctx): _final_file_path(ctx, ctx.executable.binary),
     # Create a directory symlink from <workspace>/external to the runfiles
     # root, since they may be accessed via either path.
     _external_dir(ctx): _runfiles_dir(ctx),
@@ -222,7 +222,7 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
 app_layer = rule(
     attrs = _container.image.attrs + {
         # The binary target for which we are synthesizing an image.
-        "binary": attr.label(mandatory = True),
+        "binary": attr.label(mandatory = True, executable = True, cfg="target"),
         # The full list of dependencies that have their own layers
         # factored into our base.
         "layers": attr.label_list(allow_files = True),


### PR DESCRIPTION
Using binary file path directly instead of guessing with label name.

Fixes #262

I was thinking there should be some more error checking because I access binary [0]. But binary is required so it might be ok. Maybe changing it to `executable=true` or `allow_single_file` would be good? Then it could be accessed using `ctx.files` or `ctx.executables`.