### PR TITLE
Fix build icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Travis CI | Bazel CI
 :---: | :---:
-[![Build Status](https://travis-ci.org/bazelbuild/rules_docker.svg?branch=master)](https://travis-ci.org/bazelbuild/rules_docker) | [![Build Status](https://ci.bazel.io/buildStatus/icon?job=rules_docker)](https://ci.bazel.io/job/rules_docker)
+[![Build Status](https://travis-ci.org/bazelbuild/rules_docker.svg?branch=master)](https://travis-ci.org/bazelbuild/rules_docker) | [![Build Status](https://ci.bazel.build/buildStatus/icon?job=rules_docker)](https://ci.bazel.build/job/rules_docker)
 
 ## Basic Rules
 


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel-website/issues/94 for cause of breakage.