### PR TITLE
containerregistry v0.0.23 -> v0.0.24

### DIFF
--- a/container/container.bzl
+++ b/container/container.bzl
@@ -26,7 +26,7 @@ container = struct(
 )
 
 # The release of the github.com/google/containerregistry to consume.
-CONTAINERREGISTRY_RELEASE = "v0.0.23"
+CONTAINERREGISTRY_RELEASE = "v0.0.24"
 
 # The release of the container-structure-test repository to use.
 STRUCTURE_TEST_RELEASE = "v0.1.1"
@@ -40,7 +40,7 @@ def repositories():
       name = "puller",
       url = ("https://storage.googleapis.com/containerregistry-releases/" +
              CONTAINERREGISTRY_RELEASE + "/puller.par"),
-      sha256 = "552c682be9a386de1f0e06b61b785a7de3d174c397a08ced64c14321146b9ad4",
+      sha256 = "8348de85ce39753d21ccea1107aea3c0d481656daefa53357bd9788e0cf23265",
       executable = True,
     )
 
@@ -49,7 +49,7 @@ def repositories():
       name = "importer",
       url = ("https://storage.googleapis.com/containerregistry-releases/" +
              CONTAINERREGISTRY_RELEASE + "/importer.par"),
-      sha256 = "2774927203a56b962326bded4fbfb6f23ede3623331649223e7efe9d9f30c9cb",
+      sha256 = "e9b50a5bf0e63b36a0370b7ecbd1cb9df60d656d2155135123e887ff4b222b16",
       executable = True,
     )
 

--- a/container/flatten.bzl
+++ b/container/flatten.bzl
@@ -14,10 +14,6 @@
 """A rule to flatten container images."""
 
 load(
-    "//skylib:path.bzl",
-    _get_runfile_path = "runfile",
-)
-load(
     "//container:layers.bzl",
     _get_layers = "get_from_target",
     _layer_tools = "tools",
@@ -32,7 +28,6 @@ def _impl(ctx):
   legacy_base_arg = []
   legacy_files = []
   if image.get("legacy"):
-
     legacy_files += [image["legacy"]]
     legacy_base_arg = ["--tarball=%s" % image["legacy"].path]
 

--- a/container/flatten.bzl
+++ b/container/flatten.bzl
@@ -70,7 +70,7 @@ container_flatten = rule(
             mandatory = True,
         ),
         "_flattener": attr.label(
-            default = Label("//third_party/py/containerregistry/tools:fast_flatten"),
+            default = Label("@containerregistry//:flatten"),
             cfg = "host",
             executable = True,
             allow_files = True,

--- a/container/flatten.bzl
+++ b/container/flatten.bzl
@@ -32,7 +32,7 @@ def _impl(ctx):
   legacy_base_arg = []
   legacy_files = []
   if image.get("legacy"):
-    # TODO(mattmoor): warn about legacy base.
+
     legacy_files += [image["legacy"]]
     legacy_base_arg = ["--tarball=%s" % image["legacy"].path]
 
@@ -40,16 +40,22 @@ def _impl(ctx):
   digest_args = ["--digest=" + f.path for f in blobsums]
   blobs = image.get("zipped_layer", [])
   layer_args = ["--layer=" + f.path for f in blobs]
+  uncompressed_blobs = image.get("unzipped_layer", [])
+  uncompressed_layer_args = ["--uncompressed_layer=" + f.path for f in uncompressed_blobs]
+  diff_ids = image.get("diff_id", [])
+  diff_id_args = ["--diff_id=%s" % f.path for f in diff_ids]
   config_arg = "--config=%s" % image["config"].path
 
   ctx.action(
       executable = ctx.executable._flattener,
-      arguments = legacy_base_arg + digest_args + layer_args + [
+      arguments = legacy_base_arg + digest_args + layer_args + diff_id_args +
+                  uncompressed_layer_args + [
           config_arg,
           "--filesystem=" + ctx.outputs.filesystem.path,
           "--metadata=" + ctx.outputs.metadata.path,
       ],
-      inputs = blobsums + blobs + [image["config"]] + legacy_files,
+      inputs = blobsums + blobs + uncompressed_blobs + [image["config"]] +
+               legacy_files + diff_ids,
       outputs = [ctx.outputs.filesystem, ctx.outputs.metadata],
       use_default_shell_env=True,
       mnemonic="Flatten"
@@ -64,7 +70,7 @@ container_flatten = rule(
             mandatory = True,
         ),
         "_flattener": attr.label(
-            default = Label("@containerregistry//:flatten"),
+            default = Label("//third_party/py/containerregistry/tools:fast_flatten"),
             cfg = "host",
             executable = True,
             allow_files = True,


### PR DESCRIPTION
puller and importer checksums generated by:
`curl https://storage.googleapis.com/containerregistry-releases/v0.0.24/(puller, importer).par | sha256sum`