### PR TITLE
using different output name to avoid errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,12 +463,27 @@ modified sample from the `distroless` repository:
 ```python
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
-# Create a passwd file with a nonroot user and uid.
-passwd_file(
-    name = "passwd",
+# Create a passwd file with a root and nonroot user and uid.
+passwd_entry(
+    username = "root",
+    uid = 0,
+    gid = 0,
+    name = "root_user",
+)
+
+passwd_entry(
+    username = "nonroot",
     info = "nonroot",
     uid = 1002,
-    username = "nonroot",
+    name = "nonroot_user",
+)
+
+passwd_file(
+    name = "passwd",
+    entries = [
+        ":root_user",
+        ":nonroot_user",
+    ],
 )
 
 # Create a tar file containing the created passwd file

--- a/container/BUILD
+++ b/container/BUILD
@@ -101,6 +101,7 @@ TEST_TARGETS = [
     "link_with_files_base",
     "build_with_tag",
     "with_passwd",
+    "with_group",
     "gen_image",
     "data_path_image",
     "no_data_path_image",

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -281,7 +281,7 @@ class ImageTest(unittest.TestCase):
 
   def test_with_passwd(self):
     with TestImage('with_passwd') as img:
-      self.assertDigest(img, '0d373a037dd30a8c37e61f4b40db6c7b55a47d0cdc8688e3679da64f8d4667df')
+      self.assertDigest(img, '27149ceaab154631346209b42c9494708210901fbb6e9f88cb9370fb51f30999')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './etc', './etc/passwd'])
 
@@ -289,7 +289,19 @@ class ImageTest(unittest.TestCase):
       with tarfile.open(fileobj=buf, mode='r') as layer:
         content = layer.extractfile('./etc/passwd').read()
         self.assertEqual(
-          'foobar:x:1234:2345:myusernameinfo:/myhomedir:/myshell\n', content)
+          'root:x:0:0:Root:/root:/rootshell\nfoobar:x:1234:2345:myusernameinfo:/myhomedir:/myshell\n',
+          content)
+
+  def test_with_group(self):
+    with TestImage('with_group') as img:
+      self.assertDigest(img, 'd6384ee5db847e2c8a9e941d78c10bec987aa9cbd4b5b84847e20336ec09d49c')
+      self.assertEqual(1, len(img.fs_layers()))
+      self.assertTopLayerContains(img, ['.', './etc', './etc/group'])
+
+      buf = cStringIO.StringIO(img.blob(img.fs_layers()[0]))
+      with tarfile.open(fileobj=buf, mode='r') as layer:
+        content = layer.extractfile('./etc/group').read()
+        self.assertEqual('root:x:0:\nfoobar:x:2345:foo,bar,baz\n', content)
 
   def test_py_image(self):
     with TestImage('py_image') as img:

--- a/contrib/group.bzl
+++ b/contrib/group.bzl
@@ -1,0 +1,63 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GroupFileContentProvider = provider(fields = [
+    "groupname",
+    "gid",
+    "users",
+])
+
+def _group_entry_impl(ctx):
+  """Creates a passwd_file_content_provider containing a single entry."""
+  return [GroupFileContentProvider(
+      groupname = ctx.attr.groupname,
+      gid = ctx.attr.gid,
+      users = ctx.attr.users,
+  )]
+
+def _group_file_impl(ctx):
+  f = "".join(
+      ["%s:x:%s:%s\n" % (
+          entry[GroupFileContentProvider].groupname,
+          entry[GroupFileContentProvider].gid,
+          ",".join(entry[GroupFileContentProvider].users))
+       for entry in ctx.attr.entries])
+  ctx.file_action(
+      output = ctx.outputs.out,
+      content = f,
+      executable=False,
+  )
+
+group_entry = rule(
+    attrs = {
+        "groupname": attr.string(mandatory = True),
+        "gid": attr.int(default = 1000),
+        "users": attr.string_list(),
+    },
+    implementation = _group_entry_impl,
+)
+
+group_file = rule(
+    attrs = {
+        "entries": attr.label_list(
+            allow_empty = False,
+            providers = [GroupFileContentProvider],
+        ),
+    },
+    executable = False,
+    outputs = {
+        "out": "%{name}",
+    },
+    implementation = _group_file_impl,
+)

--- a/contrib/passwd.bzl
+++ b/contrib/passwd.bzl
@@ -12,24 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def _impl(ctx):
-  """Core implementation of passwd_file."""
+PasswdFileContentProvider = provider(
+    fields = [
+        "username",
+        "uid",
+        "gid",
+        "info",
+        "home",
+        "shell",
+        "name",
+    ],
+)
 
-  f = "%s:x:%s:%s:%s:%s:%s\n" % (
-      ctx.attr.username,
-      ctx.attr.uid,
-      ctx.attr.gid,
-      ctx.attr.info,
-      ctx.attr.home,
-      ctx.attr.shell
-  )
+def _passwd_entry_impl(ctx):
+  """Creates a passwd_file_content_provider containing a single entry."""
+  return [PasswdFileContentProvider(
+      username = ctx.attr.username,
+      uid = ctx.attr.uid,
+      gid = ctx.attr.gid,
+      info = ctx.attr.info,
+      home = ctx.attr.home,
+      shell = ctx.attr.shell,
+      name = ctx.attr.name,
+  )]
+
+def _passwd_file_impl(ctx):
+  """Core implementation of passwd_file."""
+  f = "".join(["%s:x:%s:%s:%s:%s:%s\n" % (
+      entry[PasswdFileContentProvider].username,
+      entry[PasswdFileContentProvider].uid,
+      entry[PasswdFileContentProvider].gid,
+      entry[PasswdFileContentProvider].info,
+      entry[PasswdFileContentProvider].home,
+      entry[PasswdFileContentProvider].shell) for entry in ctx.attr.entries])
   ctx.file_action(
       output = ctx.outputs.out,
       content = f,
-      executable=False
+      executable=False,
   )
 
-passwd_file = rule(
+passwd_entry = rule(
     attrs = {
         "username": attr.string(mandatory = True),
         "uid": attr.int(default = 1000),
@@ -38,9 +60,19 @@ passwd_file = rule(
         "home": attr.string(default = "/home"),
         "shell": attr.string(default = "/bin/bash"),
     },
+    implementation = _passwd_entry_impl,
+)
+
+passwd_file = rule(
+    attrs = {
+        "entries": attr.label_list(
+            allow_empty = False,
+            providers = [PasswdFileContentProvider],
+        ),
+    },
     executable = False,
     outputs = {
         "out": "%{name}",
     },
-    implementation = _impl,
+    implementation = _passwd_file_impl,
 )

--- a/contrib/passwd.bzl
+++ b/contrib/passwd.bzl
@@ -45,11 +45,9 @@ def _passwd_file_impl(ctx):
       entry[PasswdFileContentProvider].info,
       entry[PasswdFileContentProvider].home,
       entry[PasswdFileContentProvider].shell) for entry in ctx.attr.entries])
-  ctx.file_action(
-      output = ctx.outputs.out,
-      content = f,
-      executable=False,
-  )
+  passwd_file  = ctx.actions.declare_file(ctx.label.name)
+  ctx.actions.write(output=passwd_file, content=f)
+  return DefaultInfo(files=depset([passwd_file]))
 
 passwd_entry = rule(
     attrs = {
@@ -71,8 +69,5 @@ passwd_file = rule(
         ),
     },
     executable = False,
-    outputs = {
-        "out": "passwd",
-    },
     implementation = _passwd_file_impl,
 )

--- a/contrib/passwd.bzl
+++ b/contrib/passwd.bzl
@@ -72,7 +72,7 @@ passwd_file = rule(
     },
     executable = False,
     outputs = {
-        "out": "%{name}",
+        "out": "%{name}.passwd",
     },
     implementation = _passwd_file_impl,
 )

--- a/contrib/passwd.bzl
+++ b/contrib/passwd.bzl
@@ -72,7 +72,7 @@ passwd_file = rule(
     },
     executable = False,
     outputs = {
-        "out": "%{name}.passwd",
+        "out": "passwd",
     },
     implementation = _passwd_file_impl,
 )

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -401,16 +401,34 @@ oci_pushall(
     bundle = ":bundle_to_push",
 )
 
-load("//contrib:passwd.bzl", "passwd_file")
+load("//contrib:passwd.bzl", "passwd_entry", "passwd_file")
 
-passwd_file(
-    name = "passwd",
+passwd_entry(
+    name = "root_user",
+    gid = 0,
+    home = "/root",
+    info = "Root",
+    shell = "/rootshell",
+    uid = 0,
+    username = "root",
+)
+
+passwd_entry(
+    name = "foobar_user",
     gid = 2345,
     home = "/myhomedir",
     info = "myusernameinfo",
     shell = "/myshell",
     uid = 1234,
     username = "foobar",
+)
+
+passwd_file(
+    name = "passwd",
+    entries = [
+        ":root_user",
+        ":foobar_user",
+    ],
 )
 
 pkg_tar(
@@ -423,6 +441,45 @@ pkg_tar(
 container_image(
     name = "with_passwd",
     tars = [":passwd_tar"],
+)
+
+load("//contrib:group.bzl", "group_entry", "group_file")
+
+group_entry(
+    name = "root_group",
+    gid = 0,
+    groupname = "root",
+)
+
+group_entry(
+    name = "foobar_group",
+    gid = 2345,
+    groupname = "foobar",
+    users = [
+        "foo",
+        "bar",
+        "baz",
+    ],
+)
+
+group_file(
+    name = "group",
+    entries = [
+        ":root_group",
+        ":foobar_group",
+    ],
+)
+
+pkg_tar(
+    name = "group_tar",
+    srcs = [":group"],
+    mode = "0644",
+    package_dir = "etc",
+)
+
+container_image(
+    name = "with_group",
+    tars = [":group_tar"],
 )
 
 container_image(


### PR DESCRIPTION
This commit fixes bazelbuild/rules_docker#218 by appending ".passwd" to the output file, making it different from the name. This was the suggested solution by @mattmoor.