### PR TITLE
Update CI configuration for new Docker support

### DIFF
--- a/.ci/rules_docker.json
+++ b/.ci/rules_docker.json
@@ -1,19 +1,16 @@
 [
-    {
-        "node": "docker",
-        "parameters": {
-            "tests": ["//tests/docker/..."]
-        }
-    },
-    {
-          "variation": "",
-           "configurations": [
-                {"node": "linux-x86_64"},
-                {"node": "ubuntu_16.04-x86_64"},
-                {"node": "darwin-x86_64"}
-           ],
-           "parameters": {
-               "tests": ["//... except //tests/docker/..."]
-           }
+  {
+    "node": "linux-x86_64"
+  },
+  {
+    "node": "ubuntu_16.04-x86_64"
+  },
+  {
+    "node": "darwin-x86_64",
+    "parameters": {
+      "tests": [
+        "//... except //tests/docker/..."
+      ]
     }
+  }
 ]


### PR DESCRIPTION
Bazel's CI removed the explicit "docker" VMs and instead Docker is now available on all Linux VMs.

Update the configuration to run all tests on all Linux VMs.