### PR TITLE
Use 'authentication' instead of 'authorization'

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ These work with both `container_image`, `container_bundle`, and the
 `container_bundle`, the image name will be `bazel/my/image:helloworld`.
 For `container_bundle`, it will apply the tags you have specified.
 
-## Authorization
+## Authentication
 
 You can use these rules to access private images using standard Docker
 authentication methods.  e.g. to utilize the [Google Container Registry](


### PR DESCRIPTION
It looks like this section is about how to authenticate with a docker registry.

Apologies @mattmoor I keep seeing this (and linking to it) and it seemed worth fixing XD