### PR TITLE
Fix py3 debug image install error

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ cc_image(
 To use `py_image`, add the following to `WORKSPACE`:
 
 ```python
+# You may use "@io_bazel_rules_docker//python3:image.bzl" here if using 
+# the py3 rules. (see below)
 load(
     "@io_bazel_rules_docker//python:image.bzl",
     _py_image_repos = "repositories",

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -45,7 +45,7 @@ def repositories():
     )
   if "py_debug_image_base" not in excludes:
     container_pull(
-      name = "py_debug_image_base",
+      name = "py3_debug_image_base",
       registry = "gcr.io",
       repository = "distroless/python3",
       digest = DIGESTS["debug"],

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -43,7 +43,7 @@ def repositories():
       repository = "distroless/python3",
       digest = DIGESTS["latest"],
     )
-  if "py_debug_image_base" not in excludes:
+  if "py3_debug_image_base" not in excludes:
     container_pull(
       name = "py3_debug_image_base",
       registry = "gcr.io",


### PR DESCRIPTION
When using the py3 image in debug mode (via `-c dbg`) the image fails to load due to what looks like a typo. This pull request fixes that bug.

I've also added a note to the readme for py3 users, to call out that they will need to use the images from the "python3" package instead of the "python" package - what is probably a common gotcha.