### PR TITLE
The lang image rules like go_image did not propagate tags

### DIFF
--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -83,5 +83,6 @@ def cc_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
     base = this_name
 
   visibility = kwargs.get('visibility', None)
+  tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility)
+            visibility=visibility, tags=tags)

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -56,5 +56,6 @@ def d_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
     base = this_name
 
   visibility = kwargs.get('visibility', None)
+  tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility)
+            visibility=visibility, tags=tags)

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -87,5 +87,6 @@ def go_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
     base = this_name
 
   visibility = kwargs.get('visibility', None)
+  tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility)
+            visibility=visibility, tags=tags)

--- a/groovy/image.bzl
+++ b/groovy/image.bzl
@@ -66,9 +66,11 @@ def groovy_image(name, base=None, main_class=None,
     index += 1
 
   visibility = kwargs.get('visibility', None)
+  tags = kwargs.get('tags', None)
   jar_app_layer(name=name, base=base, binary=binary_name,
-                 main_class=main_class, jvm_flags=jvm_flags,
-                 deps=deps, jar_layers=layers, visibility=visibility)
+                main_class=main_class, jvm_flags=jvm_flags,
+                deps=deps, jar_layers=layers, visibility=visibility,
+                tags=tags)
 
 def repositories():
   _repositories()

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -352,5 +352,6 @@ def war_image(name, base=None, deps=[], layers=[], **kwargs):
     base = this_name
 
   visibility = kwargs.get('visibility', None)
+  tags = kwargs.get('tags', None)
   _war_app_layer(name=name, base=base, library=library_name, jar_layers=layers,
-                 visibility=visibility)
+                 visibility=visibility, tags=tags)

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -129,7 +129,9 @@ def nodejs_image(name, base=None, data=[], layers=[],
     base = this_name
 
   visibility = kwargs.get('visibility', None)
+  tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, entrypoint=['sh', '-c'],
             # Node.JS hates symlinks.
             agnostic_dep_layout=False,
-            binary=binary_name, lang_layers=layers, visibility=visibility)
+            binary=binary_name, lang_layers=layers, visibility=visibility,
+            tags=tags)

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -81,5 +81,7 @@ def py_image(name, base=None, deps=[], layers=[], **kwargs):
     base = this_name
 
   visibility = kwargs.get('visibility', None)
+  tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, entrypoint=['/usr/bin/python'],
-            binary=binary_name, lang_layers=layers, visibility=visibility)
+            binary=binary_name, lang_layers=layers, visibility=visibility,
+            tags=tags)

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -81,5 +81,7 @@ def py3_image(name, base=None, deps=[], layers=[], **kwargs):
     base = this_name
 
   visibility = kwargs.get('visibility', None)
+  tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, entrypoint=['/usr/bin/python'],
-            binary=binary_name, lang_layers=layers, visibility=visibility)
+            binary=binary_name, lang_layers=layers, visibility=visibility,
+            tags=tags)

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -56,5 +56,6 @@ def rust_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
     base = this_name
 
   visibility = kwargs.get('visibility', None)
+  tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility)
+            visibility=visibility, tags=tags)

--- a/scala/image.bzl
+++ b/scala/image.bzl
@@ -53,10 +53,11 @@ def scala_image(name, base=None, main_class=None,
     base = this_name
 
   visibility = kwargs.get('visibility', None)
+  tags = kwargs.get('tags', None)
   jar_app_layer(name=name, base=base, binary=binary_name,
                  main_class=main_class, jvm_flags=jvm_flags,
                  deps=deps, runtime_deps=runtime_deps, jar_layers=layers,
-                 visibility=visibility)
+                 visibility=visibility, tags=tags)
 
 def repositories():
   _repositories()

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -752,6 +752,10 @@ go_image(
     name = "go_image",
     srcs = ["main.go"],
     importpath = "github.com/bazelbuild/rules_docker/docker/testdata",
+    tags = [
+        "tag1",
+        "tag2",
+    ],
 )
 
 load("//rust:image.bzl", "rust_image")

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -55,7 +55,7 @@ function EXPECT_NOT_CONTAINS() {
 }
 
 function stop_containers() {
-  docker rm -f $(docker ps -aq) > /dev/null 2>&1 || /bin/true || /usr/bin/true
+  docker rm -f $(docker ps -aq) > /dev/null 2>&1 || builtin true
 }
 
 # Clean up any containers [before] we start.

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -29,6 +29,13 @@ function CONTAINS() {
   echo "${complete}" | grep -Fsq -- "${substring}"
 }
 
+function NOT_CONTAINS() {
+  local complete="${1}"
+  local substring="${2}"
+
+  echo "${complete}" | grep -Fsqv -- "${substring}"
+}
+
 function EXPECT_CONTAINS() {
   local complete="${1}"
   local substring="${2}"
@@ -38,8 +45,17 @@ function EXPECT_CONTAINS() {
   CONTAINS "${complete}" "${substring}" || fail "$message"
 }
 
+function EXPECT_NOT_CONTAINS() {
+  local complete="${1}"
+  local substring="${2}"
+  local message="${3:-Expected '${substring}' found in '${complete}'}"
+
+  echo Checking "$1" does not contain "$2"
+  NOT_CONTAINS "${complete}" "${substring}" || fail "$message"
+}
+
 function stop_containers() {
-  docker rm -f $(docker ps -aq) > /dev/null 2>&1 || /bin/true
+  docker rm -f $(docker ps -aq) > /dev/null 2>&1 || /bin/true || /usr/bin/true
 }
 
 # Clean up any containers [before] we start.
@@ -200,6 +216,15 @@ function test_go_image_busybox() {
   EXPECT_CONTAINS "$(docker run -ti --rm --entrypoint=sh bazel/testdata:go_image -c \"echo aa${number}bb\")" "aa${number}bb"
 }
 
+function test_go_image_with_tags() {
+  cd "${ROOT}"
+  EXPECT_CONTAINS "$(bazel query //testdata:go_image)" "//testdata:go_image"
+  EXPECT_CONTAINS "$(bazel query 'attr(tags, tag1, //testdata:go_image)')" "//testdata:go_image"
+  EXPECT_CONTAINS "$(bazel query 'attr(tags, tag2, //testdata:go_image)')" "//testdata:go_image"
+  EXPECT_NOT_CONTAINS "$(bazel query 'attr(tags, other_tag, //testdata:go_image)')" "//testdata:go_image"
+  echo yay
+}
+
 function test_java_image() {
   cd "${ROOT}"
   clear_docker
@@ -289,6 +314,7 @@ test_cc_binary_as_image -c dbg
 test_go_image -c opt
 test_go_image -c dbg
 test_go_image_busybox
+test_go_image_with_tags
 test_java_image -c opt
 test_java_image -c dbg
 test_java_sandwich_image -c opt


### PR DESCRIPTION
https://github.com/bazelbuild/rules_docker/issues/269

The lang image rules like `go_image` did not propagate tags
through to the `lang_image` rule so one could not use
build_tag_filters correctly (since there was always an
untagged image rule that depended on the binary rule
to be excluded).