### PR TITLE
container_image produce container_layer provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1418,7 +1418,7 @@ container_image(name, base, data_path, directory, files, legacy_repository_namin
       <td><code>layers</code></td>
       <td>
         <code>Label list, optional</code>
-        <p>List of `container_layer` or `container_image` targets. </p>
+        <p>List of `container_layer` targets. </p>
         <p>The data from each `container_layer` or `container_image` without base will be part of produced container image, and the environment variable will be available in the image as well.</p>
       </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -1418,8 +1418,8 @@ container_image(name, base, data_path, directory, files, legacy_repository_namin
       <td><code>layers</code></td>
       <td>
         <code>Label list, optional</code>
-        <p>List of `container_layer` targets. </p>
-        <p>The data from each `container_layer` will be part of container image, and the environment variable will be available in the image as well.</p>
+        <p>List of `container_layer` or `container_image` targets. </p>
+        <p>The data from each `container_layer` or `container_image` without base will be part of produced container image, and the environment variable will be available in the image as well.</p>
       </td>
     </tr>
     <tr>

--- a/container/BUILD
+++ b/container/BUILD
@@ -97,6 +97,8 @@ TEST_TARGETS = [
     "with_env",
     "layers_with_env",
     "with_double_env",
+    "with_image_layer",
+    "image_layer",
     "with_label",
     "with_double_label",
     "with_stamp_label",

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -68,6 +68,7 @@ load(
 load(
     "//container:layer.bzl",
     "LayerInfo",
+    "container_layer_",
     _layer = "layer",
 )
 load(
@@ -259,8 +260,7 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, empty_dirs=None,
 
   return struct(runfiles = runfiles,
                 files = depset([ctx.outputs.layer]),
-                container_parts = container_parts,
-                providers = [image_layer[0]])
+                container_parts = container_parts)
 
 _attrs = dict(_layer.attrs.items() + {
     "base": attr.label(allow_files = container_filetype),
@@ -443,6 +443,10 @@ def container_image(**kwargs):
   loaded (an internal detail).  The expectation is that the images produced
   by these rules will be uploaded using the 'docker_push' rule below.
 
+  Also, this rule generates a `container_layer` target which can be reference
+  in the `layers` attr as `name.top_layer`. It is the layer generated from
+  `container_image` attrs only.
+
   Args:
     **kwargs: See above.
   """
@@ -458,3 +462,10 @@ def container_image(**kwargs):
   if "entrypoint" in kwargs:
     kwargs["entrypoint"] = _validate_command("entrypoint", kwargs["entrypoint"])
   container_image_(**kwargs)
+  # Also create a "name.top_layer" container_layer target
+  top_layer_attrs = {}
+  for key in _layer.attrs.keys():
+    if key in kwargs:
+      top_layer_attrs[key] = kwargs[key]
+  top_layer_attrs["name"] = kwargs["name"] + ".top_layer"
+  container_layer_(**top_layer_attrs)

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -254,9 +254,11 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, directory=None,
   runfiles = ctx.runfiles(
       files = unzipped_layers + diff_ids + [config_file, config_digest] +
       ([container_parts["legacy"]] if container_parts["legacy"] else []))
+
   return struct(runfiles = runfiles,
                 files = depset([ctx.outputs.layer]),
-                container_parts = container_parts)
+                container_parts = container_parts,
+                providers = [image_layer[0]])
 
 _attrs = dict(_layer.attrs.items() + {
     "base": attr.label(allow_files = container_filetype),

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -193,6 +193,19 @@ class ImageTest(unittest.TestCase):
       self.assertEqual(3, len(img.fs_layers()))
       self.assertConfigEqual(img, 'Env', ['PATH=$PATH:/tmp/a:/tmp/b:/tmp/c', 'a=b', 'x=y'])
 
+  def test_with_image_layer(self):
+    with TestImage('with_image_layer') as img:
+      self.assertEqual(3, len(img.fs_layers()))
+      self.assertTopLayerContains(img, [
+        './asdf', './usr', './usr/bin',
+        './usr/bin/miraclegrow'])
+      self.assertLayerNContains(img, 1, ['.', './three', './three/three'])
+      self.assertLayerNContains(img, 2, [
+          './usr', './usr/bin', './usr/bin/unremarkabledeath'])
+      self.assertDigest(img, '12d220f4bed50f46265be8d4ee8b8c34bd8e228383f6cbbbc2cd4fb473edbdda')
+      self.assertEqual(3, len(img.fs_layers()))
+      self.assertConfigEqual(img, 'Env', ['PATH=$PATH:/tmp/a:/tmp/b:/tmp/c', 'a=b', 'x=y'])
+
   def test_dummy_repository(self):
     # We allow users to specify an alternate repository name instead of 'bazel/'
     # to prefix their image names.

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -64,7 +64,7 @@ def build_layer(ctx, files=None, file_map=None, empty_files=None,
                 tars=None):
   """Build the current layer for appending it to the base layer"""
   layer = ctx.outputs.layer
-  build_layer_exec = ctx.executable.build_layer
+  build_layer_exec = ctx.executable._build_layer
   args = [
       "--output=" + layer.path,
       "--directory=" + directory,
@@ -167,7 +167,7 @@ _layer_attrs = dict({
     # Implicit/Undocumented dependencies.
     "empty_files": attr.string_list(),
     "empty_dirs": attr.string_list(),
-    "build_layer": attr.label(
+    "_build_layer": attr.label(
         default = Label("//container:build_tar"),
         cfg = "host",
         executable = True,

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -124,8 +124,10 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, directory=None,
   empty_files = empty_files or ctx.attr.empty_files
   directory = directory or ctx.attr.directory
   symlinks = symlinks or ctx.attr.symlinks
+  env = env or ctx.attr.env
   debs = debs or ctx.files.debs
   tars = tars or ctx.files.tars
+
 
   # Generate the unzipped filesystem layer, and its sha256 (aka diff_id)
   unzipped_layer, diff_id = build_layer(ctx, files=files, file_map=file_map,
@@ -145,7 +147,7 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, directory=None,
                     blob_sum=blob_sum,
                     unzipped_layer=unzipped_layer,
                     diff_id=diff_id,
-                    env=env or ctx.attr.env)]
+                    env=env)]
 
 _layer_attrs = dict({
     "data_path": attr.string(),

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -369,7 +369,7 @@ container_image(
         "PATH": "$PATH:/tmp/b:/tmp/c",
         "x": "y",
     },
-    layers = [":image_layer"],
+    layers = [":image_layer.top_layer"],
     tars = ["two.tar"],
 )
 

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -362,6 +362,28 @@ container_image(
     files = ["foo"],
 )
 
+container_image(
+    name = "with_image_layer",
+    base = ":tar_base",
+    env = {
+        "PATH": "$PATH:/tmp/b:/tmp/c",
+        "x": "y",
+    },
+    layers = [":image_layer"],
+    tars = ["two.tar"],
+)
+
+container_image(
+    name = "image_layer",
+    base = ":tar_base",
+    directory = "/three",
+    env = {
+        "PATH": "$PATH:/tmp/a",
+        "a": "b",
+    },
+    tars = ["three.tar"],
+)
+
 # We should get a warning when we build/run this.
 docker_push(
     name = "push_inadvertent_legacy_base",


### PR DESCRIPTION
* The LayerInfo provider produced by the container_image attrs will be
returned as provider as well

* This enables composible container_images:

```python
container_image(
    name = "B",
    ...
    layers = [":A"],
)

container_image(
    name = "A",
    ...
)
```

Tested:
- unit test: one container_image depends on another