### PR TITLE
Fix groovy_image crash on recent bazel versions

### DIFF
--- a/groovy/image.bzl
+++ b/groovy/image.bzl
@@ -49,7 +49,7 @@ def groovy_image(name, base=None, main_class=None,
     deps = deps + [binary_name + "-lib"]
 
   # This always belongs in a separate layer.
-  layers += ["//external:groovy"]
+  layers = layers + ["//external:groovy"]
 
   native.java_binary(
       name = binary_name,


### PR DESCRIPTION
The layers object is frozen so attempts to modify it will result in a crash.

This will happen if it is called without settint the layer parameter.
```
groovy_image(
    name = "hello",
    srcs = glob(["Application.groovy"]),
    main_class = "example.Application",
)
```

All test cases are currently called with the layer parameter set and thus avoid triggering this behaviour.
Unfortunately, the example in the readme does not have it and is currently failing.