### PR TITLE
Expose base and outputs to be overriden.

### DIFF
--- a/container/bundle.bzl
+++ b/container/bundle.bzl
@@ -31,8 +31,6 @@ def _container_bundle_impl(ctx):
   # Compute the set of layers from the image_targets.
   image_target_dict = _string_to_label(
       ctx.attr.image_targets, ctx.attr.image_target_strings)
-  image_files_dict = _string_to_label(
-      ctx.files.image_targets, ctx.attr.image_target_strings)
 
   images = {}
   runfiles = []
@@ -42,7 +40,7 @@ def _container_bundle_impl(ctx):
 
     target = ctx.attr.images[unresolved_tag]
 
-    l = _get_layers(ctx, image_target_dict[target], image_files_dict[target])
+    l = _get_layers(ctx, image_target_dict[target])
     images[tag] = l
     runfiles += [l.get('config')]
     runfiles += [l.get('config_digest')]

--- a/container/flatten.bzl
+++ b/container/flatten.bzl
@@ -22,7 +22,7 @@ load(
 def _impl(ctx):
   """Core implementation of container_flatten."""
 
-  image = _get_layers(ctx, ctx.attr.image, ctx.files.image)
+  image = _get_layers(ctx, ctx.attr.image)
 
   # Leverage our efficient intermediate representation to push.
   legacy_base_arg = []

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -82,10 +82,10 @@ load(
     _serialize_dict = "dict_to_associative_list",
 )
 
-def _get_base_config(ctx):
+def _get_base_config(ctx, base):
   if ctx.files.base:
     # The base is the first layer in container_parts if provided.
-    l = _get_layers(ctx, ctx.attr.base, ctx.files.base)
+    l = _get_layers(ctx, ctx.attr.base, ctx.files.base, base)
     return l.get("config")
 
 def _image_config(ctx, layer_names, entrypoint=None, cmd=None, env=None, base_config=None, layer_name=None):
@@ -160,13 +160,15 @@ def _repository_name(ctx):
   # the v2 registry specification.
   return _join_path(ctx.attr.repository, ctx.label.package)
 
-def _impl(ctx, files=None, file_map=None, empty_files=None, empty_dirs=None,
-          directory=None, entrypoint=None, cmd=None, symlinks=None, output=None,
-          env=None, layers=None, debs=None, tars=None):
+def _impl(ctx, base=None, files=None, file_map=None, empty_files=None,
+          empty_dirs=None, directory=None, entrypoint=None, cmd=None,
+          symlinks=None, env=None, layers=None, debs=None, tars=None,
+          output_executable=None, output_image=None, output_layer=None):
   """Implementation for the container_image rule.
 
   Args:
     ctx: The bazel rule context
+    base: File, overrides ctx.attr.base and ctx.files.base[0]
     files: File list, overrides ctx.files.files
     file_map: Dict[str, File], defaults to {}
     empty_files: str list, overrides ctx.attr.empty_files
@@ -175,15 +177,19 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, empty_dirs=None,
     entrypoint: str List, overrides ctx.attr.entrypoint
     cmd: str List, overrides ctx.attr.cmd
     symlinks: str Dict, overrides ctx.attr.symlinks
-    output: File to use as output for script to load docker image
     env: str Dict, overrides ctx.attr.env
     layers: label List, overrides ctx.attr.layers
     debs: File list, overrides ctx.files.debs
     tars: File list, overrides ctx.files.tars
+    output_executable: File to use as output for script to load docker image
+    output_image: File, overrides ctx.outputs.out
+    output_layer: File, overrides ctx.outputs.layer
   """
-  entrypoint=entrypoint or ctx.attr.entrypoint
-  cmd=cmd or ctx.attr.cmd
-  output = output or ctx.outputs.executable
+  entrypoint = entrypoint or ctx.attr.entrypoint
+  cmd = cmd or ctx.attr.cmd
+  output_executable = output_executable or ctx.outputs.executable
+  output_image = output_image or ctx.outputs.out
+  output_layer = output_layer or ctx.outputs.layer
 
   # composite a layer from the container_image rule attrs,
   image_layer = _layer.implementation(ctx=ctx, files=files,
@@ -201,7 +207,7 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, empty_dirs=None,
   # Get the layers and shas from our base.
   # These are ordered as they'd appear in the v2.2 config,
   # so they grow at the end.
-  parent_parts = _get_layers(ctx, ctx.attr.base, ctx.files.base)
+  parent_parts = _get_layers(ctx, ctx.attr.base, ctx.files.base, base)
   zipped_layers = parent_parts.get("zipped_layer", []) + [layer.zipped_layer for layer in layers]
   shas = parent_parts.get("blobsum", [])  + [layer.blob_sum for layer in layers]
   unzipped_layers = parent_parts.get("unzipped_layer", []) + [layer.unzipped_layer for layer in layers]
@@ -209,7 +215,7 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, empty_dirs=None,
   diff_ids = parent_parts.get("diff_id", []) + layer_diff_ids
 
   # Get the config for the base layer
-  config_file = _get_base_config(ctx)
+  config_file = _get_base_config(ctx, base)
   # Generate the new config layer by layer, using the attributes specified and the diff_id
   for i, layer in enumerate(layers):
     config_file, config_digest = _image_config(
@@ -248,16 +254,16 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, empty_dirs=None,
       tag_name: container_parts
   }
 
-  _incr_load(ctx, images, output,
+  _incr_load(ctx, images, output_executable,
              run=not ctx.attr.legacy_run_behavior,
              run_flags=ctx.attr.docker_run_flags)
-  _assemble_image(ctx, images, ctx.outputs.out)
+  _assemble_image(ctx, images, output_image)
 
   runfiles = ctx.runfiles(
       files = unzipped_layers + diff_ids + [config_file, config_digest] +
       ([container_parts["legacy"]] if container_parts["legacy"] else []))
   return struct(runfiles = runfiles,
-                files = depset([ctx.outputs.layer]),
+                files = depset([output_layer]),
                 container_parts = container_parts)
 
 _attrs = dict(_layer.attrs.items() + {

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -85,7 +85,7 @@ load(
 def _get_base_config(ctx, base):
   if ctx.files.base:
     # The base is the first layer in container_parts if provided.
-    l = _get_layers(ctx, ctx.attr.base, ctx.files.base, base)
+    l = _get_layers(ctx, ctx.attr.base, base)
     return l.get("config")
 
 def _image_config(ctx, layer_names, entrypoint=None, cmd=None, env=None, base_config=None, layer_name=None):
@@ -207,7 +207,7 @@ def _impl(ctx, base=None, files=None, file_map=None, empty_files=None,
   # Get the layers and shas from our base.
   # These are ordered as they'd appear in the v2.2 config,
   # so they grow at the end.
-  parent_parts = _get_layers(ctx, ctx.attr.base, ctx.files.base, base)
+  parent_parts = _get_layers(ctx, ctx.attr.base, base)
   zipped_layers = parent_parts.get("zipped_layer", []) + [layer.zipped_layer for layer in layers]
   shas = parent_parts.get("blobsum", [])  + [layer.blob_sum for layer in layers]
   unzipped_layers = parent_parts.get("unzipped_layer", []) + [layer.unzipped_layer for layer in layers]

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -163,7 +163,7 @@ def _repository_name(ctx):
 def _impl(ctx, base=None, files=None, file_map=None, empty_files=None,
           empty_dirs=None, directory=None, entrypoint=None, cmd=None,
           symlinks=None, env=None, layers=None, debs=None, tars=None,
-          output_executable=None, output_image=None, output_layer=None):
+          output_executable=None, output_tarball=None, output_layer=None):
   """Implementation for the container_image rule.
 
   Args:
@@ -182,13 +182,13 @@ def _impl(ctx, base=None, files=None, file_map=None, empty_files=None,
     debs: File list, overrides ctx.files.debs
     tars: File list, overrides ctx.files.tars
     output_executable: File to use as output for script to load docker image
-    output_image: File, overrides ctx.outputs.out
+    output_tarball: File, overrides ctx.outputs.out
     output_layer: File, overrides ctx.outputs.layer
   """
   entrypoint = entrypoint or ctx.attr.entrypoint
   cmd = cmd or ctx.attr.cmd
   output_executable = output_executable or ctx.outputs.executable
-  output_image = output_image or ctx.outputs.out
+  output_tarball = output_tarball or ctx.outputs.out
   output_layer = output_layer or ctx.outputs.layer
 
   # composite a layer from the container_image rule attrs,
@@ -257,7 +257,7 @@ def _impl(ctx, base=None, files=None, file_map=None, empty_files=None,
   _incr_load(ctx, images, output_executable,
              run=not ctx.attr.legacy_run_behavior,
              run_flags=ctx.attr.docker_run_flags)
-  _assemble_image(ctx, images, output_image)
+  _assemble_image(ctx, images, output_tarball)
 
   runfiles = ctx.runfiles(
       files = unzipped_layers + diff_ids + [config_file, config_digest] +

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -30,9 +30,6 @@ load(
 )
 load(
     "//container:layer_tools.bzl",
-    _assemble_image = "assemble",
-    _get_layers = "get_from_target",
-    _incr_load = "incremental_load",
     _layer_tools = "tools",
 )
 load(

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -107,8 +107,7 @@ LayerInfo = provider(fields = [
 ])
 
 def _impl(ctx, files=None, file_map=None, empty_files=None, empty_dirs=None,
-          directory=None, symlinks=None, output=None, debs=None, tars=None,
-          env=None):
+          directory=None, symlinks=None, debs=None, tars=None, env=None):
   """Implementation for the container_layer rule.
 
   Args:

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -36,15 +36,15 @@ def _extract_layers(ctx, artifact):
       "legacy": artifact,
   }
 
-def get_from_target(ctx, attr_target, file_target, overriding_file_target=None):
-  if overriding_file_target:
-    return _extract_layers(ctx, overriding_file_target)
+def get_from_target(ctx, attr_target, file_target=None):
+  if file_target:
+    return _extract_layers(ctx, file_target)
   elif hasattr(attr_target, "container_parts"):
     return attr_target.container_parts
   else:
-    if not file_target:
+    if not hasattr(attr_target, "files"):
       return {}
-    target = file_target[0]
+    target = attr_target.files.to_list()[0]
     return _extract_layers(ctx, target)
 
 def assemble(ctx, images, output, stamp=False):

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -36,8 +36,10 @@ def _extract_layers(ctx, artifact):
       "legacy": artifact,
   }
 
-def get_from_target(ctx, attr_target, file_target):
-  if hasattr(attr_target, "container_parts"):
+def get_from_target(ctx, attr_target, file_target, overriding_file_target=None):
+  if overriding_file_target:
+    return _extract_layers(ctx, overriding_file_target)
+  elif hasattr(attr_target, "container_parts"):
     return attr_target.container_parts
   else:
     if not file_target:
@@ -61,7 +63,7 @@ def assemble(ctx, images, output, stamp=False):
 
     for i in range(0, len(image["diff_id"])):
       args += [
-          "--layer=" + 
+          "--layer=" +
           "@" + image["diff_id"][i].path +
           "=@" + image["blobsum"][i].path +
           # No @, not resolved through utils, always filename.

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -36,7 +36,7 @@ def _impl(ctx):
   if ctx.attr.stamp:
     stamp_inputs = [ctx.info_file, ctx.version_file]
 
-  image = _get_layers(ctx, ctx.attr.image, ctx.files.image)
+  image = _get_layers(ctx, ctx.attr.image)
 
   stamp_arg = " ".join(["--stamp-info-file=%s" % _get_runfile_path(ctx, f) for f in stamp_inputs])
 


### PR DESCRIPTION
This adds capability to override base and outputs of
_container.image.implementation(ctx, ...) from another rule's
implementation.