### PR TITLE
Expand location for args and symlink data dependencies

### DIFF
--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -85,4 +85,4 @@ def cc_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   visibility = kwargs.get('visibility', None)
   tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility, tags=tags, args=kwargs.get("args"))
+            visibility=visibility, tags=tags, args=kwargs.get("args"), data=kwargs.get("data"))

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -58,4 +58,4 @@ def d_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   visibility = kwargs.get('visibility', None)
   tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility, tags=tags, args=kwargs.get("args"))
+            visibility=visibility, tags=tags, args=kwargs.get("args"), data=kwargs.get("data"))

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -89,4 +89,4 @@ def go_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   visibility = kwargs.get('visibility', None)
   tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility, tags=tags, args=kwargs.get("args"))
+            visibility=visibility, tags=tags, args=kwargs.get("args"), data=kwargs.get("data"))

--- a/groovy/image.bzl
+++ b/groovy/image.bzl
@@ -70,7 +70,7 @@ def groovy_image(name, base=None, main_class=None,
   jar_app_layer(name=name, base=base, binary=binary_name,
                 main_class=main_class, jvm_flags=jvm_flags,
                 deps=deps, jar_layers=layers, visibility=visibility,
-                tags=tags, args=kwargs.get("args"))
+                tags=tags, args=kwargs.get("args"), data=kwargs.get("data"))
 
 def repositories():
   _repositories()

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -212,6 +212,7 @@ jar_app_layer = rule(
         # https://github.com/bazelbuild/bazel/issues/2176
         "data_path": attr.string(default = "."),
         "legacy_run_behavior": attr.bool(default = False),
+        "data": attr.label_list(cfg="data", allow_files=True),
     }.items()),
     executable = True,
     outputs = _container.image.outputs,
@@ -248,7 +249,7 @@ def java_image(name, base=None, main_class=None,
   jar_app_layer(name=name, base=base, binary=binary_name,
                  main_class=main_class, jvm_flags=jvm_flags,
                  deps=deps, runtime_deps=runtime_deps, jar_layers=layers,
-                 visibility=visibility, args=kwargs.get("args"))
+                 visibility=visibility, args=kwargs.get("args"), data=kwargs.get("data"))
 
 def _war_dep_layer_impl(ctx):
   """Appends a layer for a single dependency's runfiles."""

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -207,18 +207,17 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     # root, since they may be accessed via either path.
     _external_dir(ctx): _runfiles_dir(ctx),
   })
+
   for data in ctx.attr.data:
-    print(data.label.name)
     loc = ctx.expand_location('$(location :' + data.label.name + ')', ctx.attr.data)
     data_path = "/".join([
       ctx.attr.directory,
       ctx.label.package,
       data.label.name
-  ])
+    ])
     symlinks[data_path] = '/'.join([_runfiles_dir(ctx), '__main__', loc])
-  args = [ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.args]
 
-  print(symlinks)
+  args = [ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.args]
 
   return _container.image.implementation(
     ctx,

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -247,6 +247,7 @@ app_layer = rule(
         "workdir": attr.string(default = "/app"),
         "directory": attr.string(default = "/app"),
         "legacy_run_behavior": attr.bool(default = False),
+        "data": attr.string_list(default = []),
     }.items()),
     executable = True,
     outputs = _container.image.outputs,

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -207,6 +207,10 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     # root, since they may be accessed via either path.
     _external_dir(ctx): _runfiles_dir(ctx),
   })
+  for data in ctx.attr.data:
+    symlinks['/'.join(_runfiles_dir(ctx), '__main__', ctx.expand_location(data, ctx.attr.data))] = _runfiles_dir(ctx)
+  # for data in ctx.attr.data:
+  #   symlinks["/app/" + data] = _final_file_path(ctx, data)
   args = [ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.args]
 
   return _container.image.implementation(

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -208,6 +208,8 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     _external_dir(ctx): _runfiles_dir(ctx),
   })
 
+  args = [ctx.expand_location(arg) for arg in args]
+
   return _container.image.implementation(
     ctx,
     # We use all absolute paths.
@@ -217,7 +219,6 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     # image is `docker run ...`.
     # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
     # we should use the "exec" (list) form of entrypoint.
-    args = [ctx.expand_location(arg) for arg in args]
     entrypoint=ctx.attr.entrypoint + [_binary_name(ctx)] + args)
 
 app_layer = rule(

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -209,8 +209,13 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
   })
   for data in ctx.attr.data:
     print(data.label.name)
-    loc = ctx.expand_location('$(location ' + data.label.name + ')', ctx.attr.data)
-    symlinks[_runfiles_dir(ctx) + "/" + loc.rpartition("/")[-1]] = '/'.join([_runfiles_dir(ctx), '__main__', loc])
+    loc = ctx.expand_location('$(location :' + data.label.name + ')', ctx.attr.data)
+    data_path = "/".join([
+      ctx.attr.directory,
+      ctx.label.package,
+      data.label.name
+  ])
+    symlinks[data_path] = '/'.join([_runfiles_dir(ctx), '__main__', loc])
   args = [ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.args]
 
   print(symlinks)

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -208,7 +208,8 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     _external_dir(ctx): _runfiles_dir(ctx),
   })
   for data in ctx.attr.data:
-    loc = ctx.expand_location('$(location ' + str(data.label) + ')', ctx.attr.data)
+    print(data.label.name)
+    loc = ctx.expand_location('$(location ' + data.label.name + ')', ctx.attr.data)
     symlinks[_runfiles_dir(ctx) + "/" + loc.rpartition("/")[-1]] = '/'.join([_runfiles_dir(ctx), '__main__', loc])
   args = [ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.args]
 

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -217,7 +217,8 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     # image is `docker run ...`.
     # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
     # we should use the "exec" (list) form of entrypoint.
-    entrypoint=ctx.attr.entrypoint + [_binary_name(ctx)] + ctx.attr.args)
+    args = [ctx.expand_location(arg) for arg in args]
+    entrypoint=ctx.attr.entrypoint + [_binary_name(ctx)] + args)
 
 app_layer = rule(
     attrs = dict(_container.image.attrs.items() + {

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -208,9 +208,7 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     _external_dir(ctx): _runfiles_dir(ctx),
   })
   for data in ctx.attr.data:
-    symlinks['/'.join(_runfiles_dir(ctx), '__main__', ctx.expand_location(str(data), ctx.attr.data))] = _runfiles_dir(ctx)
-  # for data in ctx.attr.data:
-  #   symlinks["/app/" + data] = _final_file_path(ctx, data)
+    symlinks['/'.join([_runfiles_dir(ctx), '__main__', ctx.expand_location('$(location ' + str(data.label) + ')', ctx.attr.data)])] = _runfiles_dir(ctx)
   args = [ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.args]
 
   return _container.image.implementation(

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -247,6 +247,8 @@ app_layer = rule(
         "workdir": attr.string(default = "/app"),
         "directory": attr.string(default = "/app"),
         "legacy_run_behavior": attr.bool(default = False),
+        "args": attr.string_list(default = []),
+        "data": attr.string_list(default = []),
     }.items()),
     executable = True,
     outputs = _container.image.outputs,

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -208,8 +208,11 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     _external_dir(ctx): _runfiles_dir(ctx),
   })
   for data in ctx.attr.data:
-    symlinks['/'.join([_runfiles_dir(ctx), '__main__', ctx.expand_location('$(location ' + str(data.label) + ')', ctx.attr.data)])] = _runfiles_dir(ctx)
+    loc = ctx.expand_location('$(location ' + str(data.label) + ')', ctx.attr.data)
+    symlinks[_runfiles_dir(ctx) + "/" + loc.rpartition("/")[-1]] = '/'.join([_runfiles_dir(ctx), '__main__', loc])
   args = [ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.args]
+
+  print(symlinks)
 
   return _container.image.implementation(
     ctx,

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -208,7 +208,7 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     _external_dir(ctx): _runfiles_dir(ctx),
   })
 
-  args = [ctx.expand_location(arg) for arg in args]
+  args = [ctx.expand_location(arg) for arg in ctx.attr.args]
 
   return _container.image.implementation(
     ctx,

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -207,7 +207,6 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     # root, since they may be accessed via either path.
     _external_dir(ctx): _runfiles_dir(ctx),
   })
-
   args = [ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.args]
 
   return _container.image.implementation(
@@ -247,7 +246,7 @@ app_layer = rule(
         "workdir": attr.string(default = "/app"),
         "directory": attr.string(default = "/app"),
         "legacy_run_behavior": attr.bool(default = False),
-        "data": attr.string_list(default = []),
+        "data": attr.label_list(cfg="data", allow_files=True),
     }.items()),
     executable = True,
     outputs = _container.image.outputs,

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -208,7 +208,7 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     _external_dir(ctx): _runfiles_dir(ctx),
   })
 
-  args = [ctx.expand_location(arg) for arg in ctx.attr.args]
+  args = [ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.args]
 
   return _container.image.implementation(
     ctx,

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -247,8 +247,6 @@ app_layer = rule(
         "workdir": attr.string(default = "/app"),
         "directory": attr.string(default = "/app"),
         "legacy_run_behavior": attr.bool(default = False),
-        "args": attr.string_list(default = []),
-        "data": attr.string_list(default = []),
     }.items()),
     executable = True,
     outputs = _container.image.outputs,

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -208,7 +208,7 @@ def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
     _external_dir(ctx): _runfiles_dir(ctx),
   })
   for data in ctx.attr.data:
-    symlinks['/'.join(_runfiles_dir(ctx), '__main__', ctx.expand_location(data, ctx.attr.data))] = _runfiles_dir(ctx)
+    symlinks['/'.join(_runfiles_dir(ctx), '__main__', ctx.expand_location(str(data), ctx.attr.data))] = _runfiles_dir(ctx)
   # for data in ctx.attr.data:
   #   symlinks["/app/" + data] = _final_file_path(ctx, data)
   args = [ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.args]

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -130,8 +130,9 @@ def nodejs_image(name, base=None, data=[], layers=[],
 
   visibility = kwargs.get('visibility', None)
   tags = kwargs.get('tags', None)
+  print(data)
   app_layer(name=name, base=base, entrypoint=['sh', '-c'],
             # Node.JS hates symlinks.
             agnostic_dep_layout=False,
             binary=binary_name, lang_layers=layers, visibility=visibility,
-            tags=tags, args=kwargs.get("args"))
+            tags=tags, args=kwargs.get("args"), data=data)

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -87,4 +87,4 @@ def py_image(name, base=None, deps=[], layers=[], **kwargs):
   tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, entrypoint=['/usr/bin/python'],
             binary=binary_name, lang_layers=layers, visibility=visibility,
-            tags=tags, args=kwargs.get("args"))
+            tags=tags, args=kwargs.get("args"), data=kwargs.get("data")

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -87,4 +87,4 @@ def py_image(name, base=None, deps=[], layers=[], **kwargs):
   tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, entrypoint=['/usr/bin/python'],
             binary=binary_name, lang_layers=layers, visibility=visibility,
-            tags=tags, args=kwargs.get("args"), data=kwargs.get("data")
+            tags=tags, args=kwargs.get("args"), data=kwargs.get("data"))

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -87,4 +87,4 @@ def py3_image(name, base=None, deps=[], layers=[], **kwargs):
   tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, entrypoint=['/usr/bin/python'],
             binary=binary_name, lang_layers=layers, visibility=visibility,
-            tags=tags, args=kwargs.get("args"))
+            tags=tags, args=kwargs.get("args"), data=kwargs.get("data"))

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -58,4 +58,4 @@ def rust_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
   visibility = kwargs.get('visibility', None)
   tags = kwargs.get('tags', None)
   app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility, tags=tags, args=kwargs.get("args"))
+            visibility=visibility, tags=tags, args=kwargs.get("args"), data=kwargs.get("data"))

--- a/scala/image.bzl
+++ b/scala/image.bzl
@@ -57,7 +57,7 @@ def scala_image(name, base=None, main_class=None,
   jar_app_layer(name=name, base=base, binary=binary_name,
                  main_class=main_class, jvm_flags=jvm_flags,
                  deps=deps, runtime_deps=runtime_deps, jar_layers=layers,
-                 visibility=visibility, tags=tags, args=kwargs.get("args"))
+                 visibility=visibility, tags=tags, args=kwargs.get("args"), data=kwargs.get("data"))
 
 def repositories():
   _repositories()

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -629,8 +629,10 @@ py_image(
     srcs = ["py_image.py"],
     args = [
         "arg0",
-        "arg1",
+        "$(location :BUILD)",
+        "arg2",
     ],
+    data = [":BUILD"],
     layers = [
         ":py_image_library",
     ],
@@ -652,8 +654,10 @@ py3_image(
     srcs = ["py3_image.py"],
     args = [
         "arg0",
-        "arg1",
+        "$(location :BUILD)",
+        "arg2",
     ],
+    data = [":BUILD"],
     layers = [
         ":py_image_library",
     ],
@@ -681,8 +685,10 @@ cc_image(
     srcs = ["cc_image.cc"],
     args = [
         "arg0",
-        "arg1",
+        "$(location :BUILD)",
+        "arg2",
     ],
+    data = [":BUILD"],
     # This creates an empty layer, due to linking.
     layers = [":cc_image_library"],
 )
@@ -715,8 +721,10 @@ java_image(
     srcs = ["Binary.java"],
     args = [
         "arg0",
-        "arg1",
+        "$(location :BUILD)",
+        "arg2",
     ],
+    data = [":BUILD"],
     jvm_flags = ["-XX:MaxPermSize=128M"],
     layers = [":java_image_library"],
     main_class = "examples.images.Binary",
@@ -764,8 +772,10 @@ scala_image(
     srcs = ["Binary.scala"],
     args = [
         "arg0",
-        "arg1",
+        "$(location :BUILD)",
+        "arg2",
     ],
+    data = [":BUILD"],
     layers = [":scala_image_library"],
     main_class = "examples.images.Binary",
 )
@@ -791,8 +801,10 @@ groovy_image(
     srcs = ["Binary.groovy"],
     args = [
         "arg0",
-        "arg1",
+        "$(location :BUILD)",
+        "arg2",
     ],
+    data = [":BUILD"],
     layers = [":groovy_image_library"],
     main_class = "examples.images.Binary",
 )
@@ -812,8 +824,10 @@ go_image(
     srcs = ["main.go"],
     args = [
         "arg0",
-        "arg1",
+        "$(location :BUILD)",
+        "arg2",
     ],
+    data = [":BUILD"],
     importpath = "github.com/bazelbuild/rules_docker/docker/testdata",
     tags = [
         "tag1",
@@ -828,8 +842,10 @@ rust_image(
     srcs = ["main.rs"],
     args = [
         "arg0",
-        "arg1",
+        "$(location :BUILD)",
+        "arg2",
     ],
+    data = [":BUILD"],
 )
 
 load("//d:image.bzl", "d_image")
@@ -839,7 +855,7 @@ d_image(
     srcs = ["main.d"],
     args = [
         "arg0",
-        "arg1",
+        "arg1"
     ],
 )
 


### PR DESCRIPTION
I was happy to see the recent `args` commit and started using it by wanting to pass in a path to a file the container is depended on via the `data` field. To get the location of this file it is common to use the `$(location ...)` variable which is not supported here. I added support for that but then also noticed that the binary does not have access to that file due to the symlinking. So I also added symlinking for data dependencies and now everything works in our project.

I have not worked much with bzl rules before so especially the symlink adding I added just in a quick way and can probably be done much cleaner. Also there is no test to check the existence of the symlink. If that is something that would be accepted I would be happy to clean this up a bit. Also interestingly enough it seems `d_binary` and `nodejs_binary` are having some problem either with `data` or `location` so these two do currently not support this functionality.