### PR TITLE
Make non-hermetic gzip/gunzip more portable

### DIFF
--- a/container/container.bzl
+++ b/container/container.bzl
@@ -33,6 +33,32 @@ CONTAINERREGISTRY_RELEASE = "v0.0.26"
 # Updated around 1/22/2018.
 STRUCTURE_TEST_COMMIT = "b97925142b1a09309537e648ade11b4af47ff7ad"
 
+_local_tool_build_template = """
+sh_binary(
+    name = "{name}",
+    srcs = ["bin/{name}"],
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _local_tool(repository_ctx):
+    rctx = repository_ctx
+    realpath = rctx.which(rctx.name)
+    rctx.symlink(realpath, "bin/%s" % rctx.name)
+    rctx.file(
+        "WORKSPACE",
+        'workspace(name = "{}")\n'.format(rctx.name),
+    )
+    rctx.file(
+        "BUILD",
+        _local_tool_build_template.format(name = rctx.name),
+    )
+
+local_tool = repository_rule(
+    local = True,
+    implementation = _local_tool,
+)
+
 def repositories():
     """Download dependencies of container rules."""
     excludes = native.existing_rules().keys()
@@ -166,4 +192,9 @@ py_library(
             name = "bazel_skylib",
             remote = "https://github.com/bazelbuild/bazel-skylib.git",
             tag = "0.2.0",
+        )
+
+    if "gzip" not in excludes:
+        local_tool(
+            name = "gzip",
         )

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -53,6 +53,7 @@ load(
 load(
     "//skylib:zip.bzl",
     _gzip = "gzip",
+    _zip_tools = "tools",
 )
 load(
     "//skylib:label.bzl",
@@ -365,7 +366,7 @@ _attrs = dict(_layer.attrs.items() + {
         executable = True,
         allow_files = True,
     ),
-}.items() + _hash_tools.items() + _layer_tools.items())
+}.items() + _hash_tools.items() + _layer_tools.items() + _zip_tools.items())
 
 _outputs = _layer.outputs + {
     "out": "%{name}.tar",

--- a/container/import.bzl
+++ b/container/import.bzl
@@ -27,6 +27,7 @@ load(
     "//skylib:zip.bzl",
     _gunzip = "gunzip",
     _gzip = "gzip",
+    _zip_tools = "tools",
 )
 load(
     "//container:layer_tools.bzl",
@@ -131,7 +132,7 @@ container_import = rule(
         "config": attr.label(allow_files = [".json"]),
         "layers": attr.label_list(allow_files = tar_filetype + tgz_filetype),
         "repository": attr.string(default = "bazel"),
-    }.items() + _hash_tools.items() + _layer_tools.items()),
+    }.items() + _hash_tools.items() + _layer_tools.items() + _zip_tools.items()),
     executable = True,
     outputs = {
         "out": "%{name}.tar",

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -27,6 +27,7 @@ load(
 load(
     "//skylib:zip.bzl",
     _gzip = "gzip",
+    _zip_tools = "tools",
 )
 load(
     "//container:layer_tools.bzl",
@@ -208,7 +209,7 @@ _layer_attrs = dict({
         executable = True,
         allow_files = True,
     ),
-}.items() + _hash_tools.items() + _layer_tools.items())
+}.items() + _hash_tools.items() + _layer_tools.items() + _zip_tools.items())
 
 _layer_outputs = {
     "layer": "%{name}-layer.tar",

--- a/skylib/zip.bzl
+++ b/skylib/zip.bzl
@@ -17,8 +17,8 @@ def gzip(ctx, artifact):
     """Create an action to compute the gzipped artifact."""
     out = ctx.new_file(artifact.basename + ".gz")
     ctx.action(
-        command = "gzip -n < %s > %s" % (artifact.path, out.path),
-        inputs = [artifact],
+        command = "%s -n < %s > %s" % (ctx.executable.gzip.path, artifact.path, out.path),
+        inputs = [artifact, ctx.executable.gzip],
         outputs = [out],
         mnemonic = "GZIP",
     )
@@ -28,11 +28,18 @@ def gunzip(ctx, artifact):
     """Create an action to compute the gunzipped artifact."""
     out = ctx.new_file(artifact.basename + ".nogz")
     ctx.action(
-        command = "gunzip < %s > %s" % (artifact.path, out.path),
-        inputs = [artifact],
+        command = "%s -d < %s > %s" % (ctx.executable.gzip.path, artifact.path, out.path),
+        inputs = [artifact, ctx.executable.gzip],
         outputs = [out],
         mnemonic = "GUNZIP",
     )
     return out
 
-tools = {}
+tools = {
+    "gzip": attr.label(
+        allow_files = True,
+        cfg = "host",
+        default = Label("@gzip//:gzip"),
+        executable = True,
+    ),
+}


### PR DESCRIPTION
This ought to make the gzip and gunzip actions work on systems where the gzip binary is in a path that would not normally show up in the action sandbox.

For example, on NixOS the gzip binary is typically at `/run/current-system/sw/bin/gzip` (or possibly elsewhere if a user has installed it into their own profile).  While these locations are definitely present in `$PATH`, Bazel does not normally make them available in execution sandboxes.

There should be no noticeable difference on any system where these rules were already working; this change broadens support and makes the non-hermetic steps explicit.