### PR TITLE
Attempt to fix #363

### DIFF
--- a/container/image_test.py
+++ b/container/image_test.py
@@ -444,7 +444,6 @@ class ImageTest(unittest.TestCase):
         '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker',
         '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata',
         '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata/py_image_library.py',
-        '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata/__init__.py',
         '/app/testdata/py_image.binary',
         '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/external',
       ])
@@ -456,7 +455,6 @@ class ImageTest(unittest.TestCase):
         './app/io_bazel_rules_docker',
         './app/io_bazel_rules_docker/testdata',
         './app/io_bazel_rules_docker/testdata/py_image_library.py',
-        './app/io_bazel_rules_docker/testdata/__init__.py',
       ])
 
   def test_cc_image(self):


### PR DESCRIPTION
Seems like the solution agreed upon in https://github.com/bazelbuild/rules_docker/issues/363 was to simply remove the `__init__.py` files from the list of expected files.