### PR TITLE
Use /usr/bin/env bash for more portable shebang lines

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/container/push-tag.sh.tpl
+++ b/container/push-tag.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/container/testenv.sh
+++ b/container/testenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/contrib/push-all.sh.tpl
+++ b/contrib/push-all.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/structure-test.sh.tpl
+++ b/contrib/structure-test.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-
+#!/usr/bin/env bash
+set -e
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/update_deps.sh
+++ b/update_deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
There are still systems widely in use where bash does not exist at /bin/bash (e.g. NixOS), or where /bin/bash is an extremely outdated version of bash (MacOS).  Using /usr/bin/env to find it increases
portability.  It's not hermetic, but /bin/bash was already not hermetic.