### PR TITLE
Bump httplib2 library to 0.11.3 for DigiCert

### DIFF
--- a/container/container.bzl
+++ b/container/container.bzl
@@ -66,7 +66,6 @@ def repositories():
   # once transitive workspace instantiation lands.
   if "httplib2" not in excludes:
     # TODO(mattmoor): Is there a clean way to override?
-
     native.new_http_archive(
       name = "httplib2",
       url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.11.3",

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -66,6 +66,7 @@ def repositories():
   # once transitive workspace instantiation lands.
   if "httplib2" not in excludes:
     # TODO(mattmoor): Is there a clean way to override?
+
     native.new_http_archive(
       name = "httplib2",
       url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.11.3",

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -65,6 +65,7 @@ def repositories():
   # TODO(mattmoor): Remove all of this (copied from google/containerregistry)
   # once transitive workspace instantiation lands.
   if "httplib2" not in excludes:
+    
     # TODO(mattmoor): Is there a clean way to override?
     native.new_http_archive(
       name = "httplib2",

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -68,9 +68,9 @@ def repositories():
     # TODO(mattmoor): Is there a clean way to override?
     native.new_http_archive(
       name = "httplib2",
-      url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.10.3",
-      sha256 = "d1bee28a68cc665c451c83d315e3afdbeb5391f08971dcc91e060d5ba16986f1",
-      strip_prefix = "httplib2-0.10.3/python2/httplib2/",
+      url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.11.3",
+      sha256 = "d9f568c183d1230f271e9c60bd99f3f2b67637c3478c9068fea29f7cca3d911f",
+      strip_prefix = "httplib2-0.11.3/python2/httplib2/",
       type = "tar.gz",
       build_file_content = """
 py_library(


### PR DESCRIPTION
Per https://github.com/httplib2/httplib2/pull/91  Which adds the DigiCert Global Root G2 serial to cacert.txt  Without this push_image() fails to registries trusted by the DigiCert CA.  @mattmoor 