### PR TITLE
Update the Travis base to fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ language: go
 go: 1.10.x
 install: true
 
+services:
+  - docker
+
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: precise
 language:
   - java
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
+dist: trusty
 sudo: required
-dist: precise
-language:
-  - java
+
+os:
+  - linux
+
+python:
+  - "2.7"
+
 jdk:
   - oraclejdk8  # Building Bazel requires JDK8.
+
+language: go
+go: 1.10.x
+install: true
+
 addons:
   apt:
     sources:

--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -31,25 +31,25 @@ load(
 load(":cc.bzl", "DIGESTS")
 
 def repositories():
-  # Call the core "repositories" function to reduce boilerplate.
-  # This is idempotent if folks call it themselves.
-  _repositories()
+    # Call the core "repositories" function to reduce boilerplate.
+    # This is idempotent if folks call it themselves.
+    _repositories()
 
-  excludes = native.existing_rules().keys()
-  if "cc_image_base" not in excludes:
-    container_pull(
-      name = "cc_image_base",
-      registry = "gcr.io",
-      repository = "distroless/cc",
-      digest = DIGESTS["latest"],
-    )
-  if "cc_debug_image_base" not in excludes:
-    container_pull(
-      name = "cc_debug_image_base",
-      registry = "gcr.io",
-      repository = "distroless/cc",
-      digest = DIGESTS["debug"],
-    )
+    excludes = native.existing_rules().keys()
+    if "cc_image_base" not in excludes:
+        container_pull(
+            name = "cc_image_base",
+            registry = "gcr.io",
+            repository = "distroless/cc",
+            digest = DIGESTS["latest"],
+        )
+    if "cc_debug_image_base" not in excludes:
+        container_pull(
+            name = "cc_debug_image_base",
+            registry = "gcr.io",
+            repository = "distroless/cc",
+            digest = DIGESTS["debug"],
+        )
 
 DEFAULT_BASE = select({
     "@io_bazel_rules_docker//:fastbuild": "@cc_image_base//image",
@@ -58,8 +58,8 @@ DEFAULT_BASE = select({
     "//conditions:default": "@cc_image_base//image",
 })
 
-def cc_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
-  """Constructs a container image wrapping a cc_binary target.
+def cc_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+    """Constructs a container image wrapping a cc_binary target.
 
   Args:
     binary: An alternative binary target to use instead of generating one.
@@ -67,22 +67,29 @@ def cc_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
            their own layers.
     **kwargs: See cc_binary.
   """
-  if layers:
-    print("cc_image does not benefit from layers=[], got: %s" % layers)
+    if layers:
+        print("cc_image does not benefit from layers=[], got: %s" % layers)
 
-  if not binary:
-    binary = name + ".binary"
-    native.cc_binary(name=binary, deps=deps + layers, **kwargs)
-  elif deps:
-    fail("kwarg does nothing when binary is specified", "deps")
+    if not binary:
+        binary = name + ".binary"
+        native.cc_binary(name = binary, deps = deps + layers, **kwargs)
+    elif deps:
+        fail("kwarg does nothing when binary is specified", "deps")
 
-  base = base or DEFAULT_BASE
-  for index, dep in enumerate(layers):
-    this_name = "%s.%d" % (name, index)
-    dep_layer(name=this_name, base=base, dep=dep)
-    base = this_name
+    base = base or DEFAULT_BASE
+    for index, dep in enumerate(layers):
+        this_name = "%s.%d" % (name, index)
+        dep_layer(name = this_name, base = base, dep = dep)
+        base = this_name
 
-  visibility = kwargs.get('visibility', None)
-  tags = kwargs.get('tags', None)
-  app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility, tags=tags, args=kwargs.get("args"))
+    visibility = kwargs.get("visibility", None)
+    tags = kwargs.get("tags", None)
+    app_layer(
+        name = name,
+        base = base,
+        binary = binary,
+        lang_layers = layers,
+        visibility = visibility,
+        tags = tags,
+        args = kwargs.get("args"),
+    )

--- a/container/bundle.bzl
+++ b/container/bundle.bzl
@@ -26,40 +26,49 @@ load(
 )
 
 def _container_bundle_impl(ctx):
-  """Implementation for the container_bundle rule."""
+    """Implementation for the container_bundle rule."""
 
-  # Compute the set of layers from the image_targets.
-  image_target_dict = _string_to_label(
-      ctx.attr.image_targets, ctx.attr.image_target_strings)
+    # Compute the set of layers from the image_targets.
+    image_target_dict = _string_to_label(
+        ctx.attr.image_targets,
+        ctx.attr.image_target_strings,
+    )
 
-  images = {}
-  runfiles = []
-  for unresolved_tag in ctx.attr.images:
-    # Allow users to put make variables into the tag name.
-    tag = ctx.expand_make_variables("images", unresolved_tag, {})
+    images = {}
+    runfiles = []
+    for unresolved_tag in ctx.attr.images:
+        # Allow users to put make variables into the tag name.
+        tag = ctx.expand_make_variables("images", unresolved_tag, {})
 
-    target = ctx.attr.images[unresolved_tag]
+        target = ctx.attr.images[unresolved_tag]
 
-    l = _get_layers(ctx, image_target_dict[target])
-    images[tag] = l
-    runfiles += [l.get('config')]
-    runfiles += [l.get('config_digest')]
-    runfiles += l.get('unzipped_layer', [])
-    runfiles += l.get('diff_id', [])
+        l = _get_layers(ctx, image_target_dict[target])
+        images[tag] = l
+        runfiles += [l.get("config")]
+        runfiles += [l.get("config_digest")]
+        runfiles += l.get("unzipped_layer", [])
+        runfiles += l.get("diff_id", [])
 
-  _incr_load(ctx, images, ctx.outputs.executable,
-             stamp=ctx.attr.stamp)
-  _assemble_image(ctx, images, ctx.outputs.out, stamp=ctx.attr.stamp)
+    _incr_load(
+        ctx,
+        images,
+        ctx.outputs.executable,
+        stamp = ctx.attr.stamp,
+    )
+    _assemble_image(ctx, images, ctx.outputs.out, stamp = ctx.attr.stamp)
 
-  stamp_files = []
-  if ctx.attr.stamp:
-    stamp_files = [ctx.info_file, ctx.version_file]
+    stamp_files = []
+    if ctx.attr.stamp:
+        stamp_files = [ctx.info_file, ctx.version_file]
 
-  return struct(runfiles = ctx.runfiles(
-      files = (stamp_files + runfiles)),
-      files = depset(),
-      container_images = images,
-      stamp = ctx.attr.stamp)
+    return struct(
+        runfiles = ctx.runfiles(
+            files = (stamp_files + runfiles),
+        ),
+        files = depset(),
+        container_images = images,
+        stamp = ctx.attr.stamp,
+    )
 
 container_bundle_ = rule(
     attrs = dict({
@@ -91,18 +100,18 @@ container_bundle_ = rule(
 #     }
 #   )
 def container_bundle(**kwargs):
-  """Package several container images into a single tarball.
+    """Package several container images into a single tarball.
 
   Args:
     **kwargs: See above.
   """
-  for reserved in ["image_targets", "image_target_strings"]:
-    if reserved in kwargs:
-      fail("reserved for internal use by container_bundle macro", attr=reserved)
+    for reserved in ["image_targets", "image_target_strings"]:
+        if reserved in kwargs:
+            fail("reserved for internal use by container_bundle macro", attr = reserved)
 
-  if "images" in kwargs:
-    values = {value: None for value in kwargs["images"].values()}.keys()
-    kwargs["image_targets"] = values
-    kwargs["image_target_strings"] = values
+    if "images" in kwargs:
+        values = {value: None for value in kwargs["images"].values()}.keys()
+        kwargs["image_targets"] = values
+        kwargs["image_target_strings"] = values
 
-  container_bundle_(**kwargs)
+    container_bundle_(**kwargs)

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -34,63 +34,64 @@ CONTAINERREGISTRY_RELEASE = "v0.0.26"
 STRUCTURE_TEST_COMMIT = "b97925142b1a09309537e648ade11b4af47ff7ad"
 
 def repositories():
-  """Download dependencies of container rules."""
-  excludes = native.existing_rules().keys()
+    """Download dependencies of container rules."""
+    excludes = native.existing_rules().keys()
 
-  if "puller" not in excludes:
-    native.http_file(
-      name = "puller",
-      url = ("https://storage.googleapis.com/containerregistry-releases/" +
-             CONTAINERREGISTRY_RELEASE + "/puller.par"),
-      sha256 = "42309ba47bb28d1e1b81ef72789dcca396095e191d4f0e49e2e23c297edd27fb",
-      executable = True,
-    )
+    if "puller" not in excludes:
+        native.http_file(
+            name = "puller",
+            url = ("https://storage.googleapis.com/containerregistry-releases/" +
+                   CONTAINERREGISTRY_RELEASE + "/puller.par"),
+            sha256 = "42309ba47bb28d1e1b81ef72789dcca396095e191d4f0e49e2e23c297edd27fb",
+            executable = True,
+        )
 
-  if "importer" not in excludes:
-    native.http_file(
-      name = "importer",
-      url = ("https://storage.googleapis.com/containerregistry-releases/" +
-             CONTAINERREGISTRY_RELEASE + "/importer.par"),
-      sha256 = "0a2490584c96bcf961242364d961859b94926182f20a217754730e7097ea6cde",
-      executable = True,
-    )
+    if "importer" not in excludes:
+        native.http_file(
+            name = "importer",
+            url = ("https://storage.googleapis.com/containerregistry-releases/" +
+                   CONTAINERREGISTRY_RELEASE + "/importer.par"),
+            sha256 = "0a2490584c96bcf961242364d961859b94926182f20a217754730e7097ea6cde",
+            executable = True,
+        )
 
-  if "containerregistry" not in excludes:
-    native.git_repository(
-      name = "containerregistry",
-      remote = "https://github.com/google/containerregistry.git",
-      tag = CONTAINERREGISTRY_RELEASE,
-    )
+    if "containerregistry" not in excludes:
+        native.git_repository(
+            name = "containerregistry",
+            remote = "https://github.com/google/containerregistry.git",
+            tag = CONTAINERREGISTRY_RELEASE,
+        )
 
-  # TODO(mattmoor): Remove all of this (copied from google/containerregistry)
-  # once transitive workspace instantiation lands.
-  if "httplib2" not in excludes:
-    # TODO(mattmoor): Is there a clean way to override?
-    native.new_http_archive(
-      name = "httplib2",
-      url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.10.3",
-      sha256 = "d1bee28a68cc665c451c83d315e3afdbeb5391f08971dcc91e060d5ba16986f1",
-      strip_prefix = "httplib2-0.10.3/python2/httplib2/",
-      type = "tar.gz",
-      build_file_content = """
+        # TODO(mattmoor): Remove all of this (copied from google/containerregistry)
+        # once transitive workspace instantiation lands.
+
+    if "httplib2" not in excludes:
+        # TODO(mattmoor): Is there a clean way to override?
+        native.new_http_archive(
+            name = "httplib2",
+            url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.10.3",
+            sha256 = "d1bee28a68cc665c451c83d315e3afdbeb5391f08971dcc91e060d5ba16986f1",
+            strip_prefix = "httplib2-0.10.3/python2/httplib2/",
+            type = "tar.gz",
+            build_file_content = """
 py_library(
    name = "httplib2",
    srcs = glob(["**/*.py"]),
    data = ["cacerts.txt"],
    visibility = ["//visibility:public"]
 )""",
-    )
+        )
 
-  # Used by oauth2client
-  if "six" not in excludes:
-    # TODO(mattmoor): Is there a clean way to override?
-    native.new_http_archive(
-      name = "six",
-      url = "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz",
-      sha256 = "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5",
-      strip_prefix = "six-1.9.0/",
-      type = "tar.gz",
-      build_file_content = """
+        # Used by oauth2client
+    if "six" not in excludes:
+        # TODO(mattmoor): Is there a clean way to override?
+        native.new_http_archive(
+            name = "six",
+            url = "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz",
+            sha256 = "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5",
+            strip_prefix = "six-1.9.0/",
+            type = "tar.gz",
+            build_file_content = """
 # Rename six.py to __init__.py
 genrule(
     name = "rename",
@@ -102,19 +103,19 @@ py_library(
    name = "six",
    srcs = [":__init__.py"],
    visibility = ["//visibility:public"],
-)"""
-    )
+)""",
+        )
 
-  # Used for authentication in containerregistry
-  if "oauth2client" not in excludes:
-    # TODO(mattmoor): Is there a clean way to override?
-    native.new_http_archive(
-      name = "oauth2client",
-      url = "https://codeload.github.com/google/oauth2client/tar.gz/v4.0.0",
-      sha256 = "7230f52f7f1d4566a3f9c3aeb5ffe2ed80302843ce5605853bee1f08098ede46",
-      strip_prefix = "oauth2client-4.0.0/oauth2client/",
-      type = "tar.gz",
-      build_file_content = """
+        # Used for authentication in containerregistry
+    if "oauth2client" not in excludes:
+        # TODO(mattmoor): Is there a clean way to override?
+        native.new_http_archive(
+            name = "oauth2client",
+            url = "https://codeload.github.com/google/oauth2client/tar.gz/v4.0.0",
+            sha256 = "7230f52f7f1d4566a3f9c3aeb5ffe2ed80302843ce5605853bee1f08098ede46",
+            strip_prefix = "oauth2client-4.0.0/oauth2client/",
+            type = "tar.gz",
+            build_file_content = """
 py_library(
    name = "oauth2client",
    srcs = glob(["**/*.py"]),
@@ -123,45 +124,45 @@ py_library(
      "@httplib2//:httplib2",
      "@six//:six",
    ]
-)"""
-    )
+)""",
+        )
 
-  # Used for parallel execution in containerregistry
-  if "concurrent" not in excludes:
-    # TODO(mattmoor): Is there a clean way to override?
-    native.new_http_archive(
-      name = "concurrent",
-      url = "https://codeload.github.com/agronholm/pythonfutures/tar.gz/3.0.5",
-      sha256 = "a7086ddf3c36203da7816f7e903ce43d042831f41a9705bc6b4206c574fcb765",
-      strip_prefix = "pythonfutures-3.0.5/concurrent/",
-      type = "tar.gz",
-      build_file_content = """
+        # Used for parallel execution in containerregistry
+    if "concurrent" not in excludes:
+        # TODO(mattmoor): Is there a clean way to override?
+        native.new_http_archive(
+            name = "concurrent",
+            url = "https://codeload.github.com/agronholm/pythonfutures/tar.gz/3.0.5",
+            sha256 = "a7086ddf3c36203da7816f7e903ce43d042831f41a9705bc6b4206c574fcb765",
+            strip_prefix = "pythonfutures-3.0.5/concurrent/",
+            type = "tar.gz",
+            build_file_content = """
 py_library(
    name = "concurrent",
    srcs = glob(["**/*.py"]),
    visibility = ["//visibility:public"]
-)"""
-    )
+)""",
+        )
 
-  # For packaging python tools.
-  if "subpar" not in excludes:
-    native.git_repository(
-      name = "subpar",
-      remote = "https://github.com/google/subpar",
-      commit = "7e12cc130eb8f09c8cb02c3585a91a4043753c56",
-    )
+        # For packaging python tools.
+    if "subpar" not in excludes:
+        native.git_repository(
+            name = "subpar",
+            remote = "https://github.com/google/subpar",
+            commit = "7e12cc130eb8f09c8cb02c3585a91a4043753c56",
+        )
 
-  if "structure_test" not in excludes:
-    native.git_repository(
-      name = "structure_test",
-      remote = "https://github.com/GoogleCloudPlatform/container-structure-test.git",
-      commit = STRUCTURE_TEST_COMMIT,
-  )
+    if "structure_test" not in excludes:
+        native.git_repository(
+            name = "structure_test",
+            remote = "https://github.com/GoogleCloudPlatform/container-structure-test.git",
+            commit = STRUCTURE_TEST_COMMIT,
+        )
 
-  # For skylark_library.
-  if "bazel_skylib" not in excludes:
-    native.git_repository(
-        name = "bazel_skylib",
-        remote = "https://github.com/bazelbuild/bazel-skylib.git",
-        tag = "0.2.0",
-    )
+        # For skylark_library.
+    if "bazel_skylib" not in excludes:
+        native.git_repository(
+            name = "bazel_skylib",
+            remote = "https://github.com/bazelbuild/bazel-skylib.git",
+            tag = "0.2.0",
+        )

--- a/container/flatten.bzl
+++ b/container/flatten.bzl
@@ -20,42 +20,42 @@ load(
 )
 
 def _impl(ctx):
-  """Core implementation of container_flatten."""
+    """Core implementation of container_flatten."""
 
-  image = _get_layers(ctx, ctx.attr.image)
+    image = _get_layers(ctx, ctx.attr.image)
 
-  # Leverage our efficient intermediate representation to push.
-  legacy_base_arg = []
-  legacy_files = []
-  if image.get("legacy"):
-    legacy_files += [image["legacy"]]
-    legacy_base_arg = ["--tarball=%s" % image["legacy"].path]
+    # Leverage our efficient intermediate representation to push.
+    legacy_base_arg = []
+    legacy_files = []
+    if image.get("legacy"):
+        legacy_files += [image["legacy"]]
+        legacy_base_arg = ["--tarball=%s" % image["legacy"].path]
 
-  blobsums = image.get("blobsum", [])
-  digest_args = ["--digest=" + f.path for f in blobsums]
-  blobs = image.get("zipped_layer", [])
-  layer_args = ["--layer=" + f.path for f in blobs]
-  uncompressed_blobs = image.get("unzipped_layer", [])
-  uncompressed_layer_args = ["--uncompressed_layer=" + f.path for f in uncompressed_blobs]
-  diff_ids = image.get("diff_id", [])
-  diff_id_args = ["--diff_id=%s" % f.path for f in diff_ids]
-  config_arg = "--config=%s" % image["config"].path
+    blobsums = image.get("blobsum", [])
+    digest_args = ["--digest=" + f.path for f in blobsums]
+    blobs = image.get("zipped_layer", [])
+    layer_args = ["--layer=" + f.path for f in blobs]
+    uncompressed_blobs = image.get("unzipped_layer", [])
+    uncompressed_layer_args = ["--uncompressed_layer=" + f.path for f in uncompressed_blobs]
+    diff_ids = image.get("diff_id", [])
+    diff_id_args = ["--diff_id=%s" % f.path for f in diff_ids]
+    config_arg = "--config=%s" % image["config"].path
 
-  ctx.action(
-      executable = ctx.executable._flattener,
-      arguments = legacy_base_arg + digest_args + layer_args + diff_id_args +
-                  uncompressed_layer_args + [
-          config_arg,
-          "--filesystem=" + ctx.outputs.filesystem.path,
-          "--metadata=" + ctx.outputs.metadata.path,
-      ],
-      inputs = blobsums + blobs + uncompressed_blobs + [image["config"]] +
-               legacy_files + diff_ids,
-      outputs = [ctx.outputs.filesystem, ctx.outputs.metadata],
-      use_default_shell_env=True,
-      mnemonic="Flatten"
-  )
-  return struct()
+    ctx.action(
+        executable = ctx.executable._flattener,
+        arguments = legacy_base_arg + digest_args + layer_args + diff_id_args +
+                    uncompressed_layer_args + [
+            config_arg,
+            "--filesystem=" + ctx.outputs.filesystem.path,
+            "--metadata=" + ctx.outputs.metadata.path,
+        ],
+        inputs = blobsums + blobs + uncompressed_blobs + [image["config"]] +
+                 legacy_files + diff_ids,
+        outputs = [ctx.outputs.filesystem, ctx.outputs.metadata],
+        use_default_shell_env = True,
+        mnemonic = "Flatten",
+    )
+    return struct()
 
 container_flatten = rule(
     attrs = dict({

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -83,98 +83,126 @@ load(
 )
 
 def _get_base_config(ctx, base):
-  if ctx.files.base:
-    # The base is the first layer in container_parts if provided.
-    l = _get_layers(ctx, ctx.attr.base, base)
-    return l.get("config")
+    if ctx.files.base:
+        # The base is the first layer in container_parts if provided.
+        l = _get_layers(ctx, ctx.attr.base, base)
+        return l.get("config")
 
-def _image_config(ctx, layer_names, entrypoint=None, cmd=None,
-                  creation_time=None, env=None, base_config=None,
-                  layer_name=None):
-  """Create the configuration for a new container image."""
-  config = ctx.new_file(ctx.label.name + "." + layer_name + ".config")
+def _image_config(
+        ctx,
+        layer_names,
+        entrypoint = None,
+        cmd = None,
+        creation_time = None,
+        env = None,
+        base_config = None,
+        layer_name = None):
+    """Create the configuration for a new container image."""
+    config = ctx.new_file(ctx.label.name + "." + layer_name + ".config")
 
-  label_file_dict = _string_to_label(
-      ctx.files.label_files, ctx.attr.label_file_strings)
+    label_file_dict = _string_to_label(
+        ctx.files.label_files,
+        ctx.attr.label_file_strings,
+    )
 
-  labels = dict()
-  for l in ctx.attr.labels:
-    fname = ctx.attr.labels[l]
-    if fname[0] == "@":
-      labels[l] = "@" + label_file_dict[fname[1:]].path
-    else:
-      labels[l] = fname
+    labels = dict()
+    for l in ctx.attr.labels:
+        fname = ctx.attr.labels[l]
+        if fname[0] == "@":
+            labels[l] = "@" + label_file_dict[fname[1:]].path
+        else:
+            labels[l] = fname
 
-  args = [
-      "--output=%s" % config.path,
-  ] + [
-      "--entrypoint=%s" % x for x in entrypoint
-  ] + [
-      "--command=%s" % x for x in cmd
-  ] + [
-      "--ports=%s" % x for x in ctx.attr.ports
-  ] + [
-      "--volumes=%s" % x for x in ctx.attr.volumes
-  ]
-  if creation_time:
-    args += ["--creation_time=%s" % creation_time]
-  elif ctx.attr.stamp:
-    # If stamping is enabled, and the creation_time is not manually defined,
-    # default to '{BUILD_TIMESTAMP}'.
-    args += ["--creation_time={BUILD_TIMESTAMP}"]
+    args = [
+        "--output=%s" % config.path,
+    ] + [
+        "--entrypoint=%s" % x
+        for x in entrypoint
+    ] + [
+        "--command=%s" % x
+        for x in cmd
+    ] + [
+        "--ports=%s" % x
+        for x in ctx.attr.ports
+    ] + [
+        "--volumes=%s" % x
+        for x in ctx.attr.volumes
+    ]
+    if creation_time:
+        args += ["--creation_time=%s" % creation_time]
+    elif ctx.attr.stamp:
+        # If stamping is enabled, and the creation_time is not manually defined,
+        # default to '{BUILD_TIMESTAMP}'.
+        args += ["--creation_time={BUILD_TIMESTAMP}"]
 
-  _labels = _serialize_dict(labels)
-  if _labels:
-    args += ["--labels=%s" % x for x in _labels.split(',')]
-  _env = _serialize_dict(env)
-  if _env:
-    args += ["--env=%s" % x for x in _env.split(',')]
+    _labels = _serialize_dict(labels)
+    if _labels:
+        args += ["--labels=%s" % x for x in _labels.split(",")]
+    _env = _serialize_dict(env)
+    if _env:
+        args += ["--env=%s" % x for x in _env.split(",")]
 
-  if ctx.attr.user:
-    args += ["--user=" + ctx.attr.user]
-  if ctx.attr.workdir:
-    args += ["--workdir=" + ctx.attr.workdir]
+    if ctx.attr.user:
+        args += ["--user=" + ctx.attr.user]
+    if ctx.attr.workdir:
+        args += ["--workdir=" + ctx.attr.workdir]
 
-  inputs = layer_names
-  for layer_name in layer_names:
-    args += ["--layer=@" + layer_name.path]
+    inputs = layer_names
+    for layer_name in layer_names:
+        args += ["--layer=@" + layer_name.path]
 
-  if ctx.attr.label_files:
-    inputs += ctx.files.label_files
+    if ctx.attr.label_files:
+        inputs += ctx.files.label_files
 
-  if base_config:
-    args += ["--base=%s" % base_config.path]
-    inputs += [base_config]
+    if base_config:
+        args += ["--base=%s" % base_config.path]
+        inputs += [base_config]
 
-  if ctx.attr.stamp:
-    stamp_inputs = [ctx.info_file, ctx.version_file]
-    args += ["--stamp-info-file=%s" % f.path for f in stamp_inputs]
-    inputs += stamp_inputs
+    if ctx.attr.stamp:
+        stamp_inputs = [ctx.info_file, ctx.version_file]
+        args += ["--stamp-info-file=%s" % f.path for f in stamp_inputs]
+        inputs += stamp_inputs
 
-  ctx.action(
-      executable = ctx.executable.create_image_config,
-      arguments = args,
-      inputs = inputs,
-      outputs = [config],
-      use_default_shell_env=True,
-      mnemonic = "ImageConfig")
-  return config, _sha256(ctx, config)
+    ctx.action(
+        executable = ctx.executable.create_image_config,
+        arguments = args,
+        inputs = inputs,
+        outputs = [config],
+        use_default_shell_env = True,
+        mnemonic = "ImageConfig",
+    )
+    return config, _sha256(ctx, config)
 
 def _repository_name(ctx):
-  """Compute the repository name for the current rule."""
-  if ctx.attr.legacy_repository_naming:
-    # Legacy behavior, off by default.
-    return _join_path(ctx.attr.repository, ctx.label.package.replace("/", "_"))
-  # Newer Docker clients support multi-level names, which are a part of
-  # the v2 registry specification.
-  return _join_path(ctx.attr.repository, ctx.label.package)
+    """Compute the repository name for the current rule."""
+    if ctx.attr.legacy_repository_naming:
+        # Legacy behavior, off by default.
+        return _join_path(ctx.attr.repository, ctx.label.package.replace("/", "_"))
+        # Newer Docker clients support multi-level names, which are a part of
+        # the v2 registry specification.
 
-def _impl(ctx, base=None, files=None, file_map=None, empty_files=None,
-          empty_dirs=None, directory=None, entrypoint=None, cmd=None,
-          creation_time=None, symlinks=None, env=None, layers=None, debs=None,
-          tars=None, output_executable=None, output_tarball=None,
-          output_layer=None):
-  """Implementation for the container_image rule.
+    return _join_path(ctx.attr.repository, ctx.label.package)
+
+def _impl(
+        ctx,
+        base = None,
+        files = None,
+        file_map = None,
+        empty_files = None,
+        empty_dirs = None,
+        directory = None,
+        entrypoint = None,
+        cmd = None,
+        creation_time = None,
+        symlinks = None,
+        env = None,
+        layers = None,
+        debs = None,
+        tars = None,
+        output_executable = None,
+        output_tarball = None,
+        output_layer = None):
+    """Implementation for the container_image rule.
 
   Args:
     ctx: The bazel rule context
@@ -196,87 +224,105 @@ def _impl(ctx, base=None, files=None, file_map=None, empty_files=None,
     output_tarball: File, overrides ctx.outputs.out
     output_layer: File, overrides ctx.outputs.layer
   """
-  entrypoint=entrypoint or ctx.attr.entrypoint
-  cmd=cmd or ctx.attr.cmd
-  creation_time=creation_time or ctx.attr.creation_time
-  output_executable = output_executable or ctx.outputs.executable
-  output_tarball = output_tarball or ctx.outputs.out
-  output_layer = output_layer or ctx.outputs.layer
+    entrypoint = entrypoint or ctx.attr.entrypoint
+    cmd = cmd or ctx.attr.cmd
+    creation_time = creation_time or ctx.attr.creation_time
+    output_executable = output_executable or ctx.outputs.executable
+    output_tarball = output_tarball or ctx.outputs.out
+    output_layer = output_layer or ctx.outputs.layer
 
-  # composite a layer from the container_image rule attrs,
-  image_layer = _layer.implementation(ctx=ctx, files=files,
-                                      file_map=file_map,
-                                      empty_files=empty_files,
-                                      empty_dirs=empty_dirs,
-                                      directory=directory,
-                                      symlinks=symlinks,
-                                      debs=debs, tars=tars,
-                                      env=env)
+    # composite a layer from the container_image rule attrs,
+    image_layer = _layer.implementation(
+        ctx = ctx,
+        files = files,
+        file_map = file_map,
+        empty_files = empty_files,
+        empty_dirs = empty_dirs,
+        directory = directory,
+        symlinks = symlinks,
+        debs = debs,
+        tars = tars,
+        env = env,
+    )
 
-  layer_providers= layers or ctx.attr.layers
-  layers = [provider[LayerInfo] for provider in layer_providers] + image_layer
+    layer_providers = layers or ctx.attr.layers
+    layers = [provider[LayerInfo] for provider in layer_providers] + image_layer
 
-  # Get the layers and shas from our base.
-  # These are ordered as they'd appear in the v2.2 config,
-  # so they grow at the end.
-  parent_parts = _get_layers(ctx, ctx.attr.base, base)
-  zipped_layers = parent_parts.get("zipped_layer", []) + [layer.zipped_layer for layer in layers]
-  shas = parent_parts.get("blobsum", [])  + [layer.blob_sum for layer in layers]
-  unzipped_layers = parent_parts.get("unzipped_layer", []) + [layer.unzipped_layer for layer in layers]
-  layer_diff_ids = [layer.diff_id for layer in layers]
-  diff_ids = parent_parts.get("diff_id", []) + layer_diff_ids
+    # Get the layers and shas from our base.
+    # These are ordered as they'd appear in the v2.2 config,
+    # so they grow at the end.
+    parent_parts = _get_layers(ctx, ctx.attr.base, base)
+    zipped_layers = parent_parts.get("zipped_layer", []) + [layer.zipped_layer for layer in layers]
+    shas = parent_parts.get("blobsum", []) + [layer.blob_sum for layer in layers]
+    unzipped_layers = parent_parts.get("unzipped_layer", []) + [layer.unzipped_layer for layer in layers]
+    layer_diff_ids = [layer.diff_id for layer in layers]
+    diff_ids = parent_parts.get("diff_id", []) + layer_diff_ids
 
-  # Get the config for the base layer
-  config_file = _get_base_config(ctx, base)
-  # Generate the new config layer by layer, using the attributes specified and the diff_id
-  for i, layer in enumerate(layers):
-    config_file, config_digest = _image_config(
-        ctx, [layer_diff_ids[i]],
-        entrypoint=entrypoint, cmd=cmd, creation_time=creation_time,
-        env=layer.env, base_config=config_file, layer_name=str(i), )
+    # Get the config for the base layer
+    config_file = _get_base_config(ctx, base)
 
-  # Construct a temporary name based on the build target.
-  tag_name = _repository_name(ctx) + ":" + ctx.label.name
+    # Generate the new config layer by layer, using the attributes specified and the diff_id
+    for i, layer in enumerate(layers):
+        config_file, config_digest = _image_config(
+            ctx,
+            [layer_diff_ids[i]],
+            entrypoint = entrypoint,
+            cmd = cmd,
+            creation_time = creation_time,
+            env = layer.env,
+            base_config = config_file,
+            layer_name = str(i),
+        )
 
-  # These are the constituent parts of the Container image, which each
-  # rule in the chain must preserve.
-  container_parts = {
-      # The path to the v2.2 configuration file.
-      "config": config_file,
-      "config_digest": config_digest,
+        # Construct a temporary name based on the build target.
+    tag_name = _repository_name(ctx) + ":" + ctx.label.name
 
-      # A list of paths to the layer .tar.gz files
-      "zipped_layer": zipped_layers,
-      # A list of paths to the layer digests.
-      "blobsum": shas,
+    # These are the constituent parts of the Container image, which each
+    # rule in the chain must preserve.
+    container_parts = {
+        # The path to the v2.2 configuration file.
+        "config": config_file,
+        "config_digest": config_digest,
 
-      # A list of paths to the layer .tar files
-      "unzipped_layer": unzipped_layers,
-      # A list of paths to the layer diff_ids.
-      "diff_id": diff_ids,
+        # A list of paths to the layer .tar.gz files
+        "zipped_layer": zipped_layers,
+        # A list of paths to the layer digests.
+        "blobsum": shas,
 
-      # At the root of the chain, we support deriving from a tarball
-      # base image.
-      "legacy": parent_parts.get("legacy"),
-  }
+        # A list of paths to the layer .tar files
+        "unzipped_layer": unzipped_layers,
+        # A list of paths to the layer diff_ids.
+        "diff_id": diff_ids,
 
-  # We support incrementally loading or assembling this single image
-  # with a temporary name given by its build rule.
-  images = {
-      tag_name: container_parts
-  }
+        # At the root of the chain, we support deriving from a tarball
+        # base image.
+        "legacy": parent_parts.get("legacy"),
+    }
 
-  _incr_load(ctx, images, output_executable,
-             run=not ctx.attr.legacy_run_behavior,
-             run_flags=ctx.attr.docker_run_flags)
-  _assemble_image(ctx, images, output_tarball)
+    # We support incrementally loading or assembling this single image
+    # with a temporary name given by its build rule.
+    images = {
+        tag_name: container_parts,
+    }
 
-  runfiles = ctx.runfiles(
-      files = unzipped_layers + diff_ids + [config_file, config_digest] +
-      ([container_parts["legacy"]] if container_parts["legacy"] else []))
-  return struct(runfiles = runfiles,
-                files = depset([output_layer]),
-                container_parts = container_parts)
+    _incr_load(
+        ctx,
+        images,
+        output_executable,
+        run = not ctx.attr.legacy_run_behavior,
+        run_flags = ctx.attr.docker_run_flags,
+    )
+    _assemble_image(ctx, images, output_tarball)
+
+    runfiles = ctx.runfiles(
+        files = unzipped_layers + diff_ids + [config_file, config_digest] +
+                ([container_parts["legacy"]] if container_parts["legacy"] else []),
+    )
+    return struct(
+        runfiles = runfiles,
+        files = depset([output_layer]),
+        container_parts = container_parts,
+    )
 
 _attrs = dict(_layer.attrs.items() + {
     "base": attr.label(allow_files = container_filetype),
@@ -352,94 +398,95 @@ container_image_ = rule(
 #   ],
 # NOTE: prefacing a command with 'exec' just ends up with the former
 def _validate_command(name, argument):
-  if type(argument) == type(""):
-    return ["/bin/sh", "-c", argument]
-  elif type(argument) == type([]):
-    return argument
-  elif argument:
-    fail("The %s attribute must be a string or list, if specified." % name)
-  else:
-    return None
+    if type(argument) == type(""):
+        return ["/bin/sh", "-c", argument]
+    elif type(argument) == type([]):
+        return argument
+    elif argument:
+        fail("The %s attribute must be a string or list, if specified." % name)
+    else:
+        return None
 
-# Produces a new container image tarball compatible with 'docker load', which
-# is a single additional layer atop 'base'.  The goal is to have relatively
-# complete support for building container image, from the Dockerfile spec.
-#
-# For more information see the 'Config' section of the image specification:
-# https://github.com/opencontainers/image-spec/blob/v0.2.0/serialization.md
-#
-# Only 'name' is required. All other fields have sane defaults.
-#
-#   container_image(
-#      name="...",
-#      visibility="...",
-#
-#      # The base layers on top of which to overlay this layer,
-#      # equivalent to FROM.
-#      base="//another/build:rule",
-#
-#      # The base directory of the files, defaulted to
-#      # the package of the input.
-#      # All files structure relatively to that path will be preserved.
-#      # A leading '/' mean the workspace root and this path is relative
-#      # to the current package by default.
-#      data_path="...",
-#
-#      # The directory in which to expand the specified files,
-#      # defaulting to '/'.
-#      # Only makes sense accompanying one of files/tars/debs.
-#      directory="...",
-#
-#      # The set of archives to expand, or packages to install
-#      # within the chroot of this layer
-#      files=[...],
-#      tars=[...],
-#      debs=[...],
-#
-#      # The set of symlinks to create within a given layer.
-#      symlinks = {
-#          "/path/to/link": "/path/to/target",
-#          ...
-#      },
-#
-#      # Other layers built from container_layer rule
-#      layers = [":c-lang-layer", ":java-lang-layer", ...]
-#
-#      # https://docs.docker.com/engine/reference/builder/#entrypoint
-#      entrypoint="...", or
-#      entrypoint=[...],            -- exec form
-#
-#      # https://docs.docker.com/engine/reference/builder/#cmd
-#      cmd="...", or
-#      cmd=[...],                   -- exec form
-#
-#      # https://docs.docker.com/engine/reference/builder/#expose
-#      ports=[...],
-#
-#      # https://docs.docker.com/engine/reference/builder/#user
-#      # NOTE: the normal directive affects subsequent RUN, CMD,
-#      # and ENTRYPOINT
-#      user="...",
-#
-#      # https://docs.docker.com/engine/reference/builder/#volume
-#      volumes=[...],
-#
-#      # https://docs.docker.com/engine/reference/builder/#workdir
-#      # NOTE: the normal directive affects subsequent RUN, CMD,
-#      # ENTRYPOINT, ADD, and COPY, but this attribute only affects
-#      # the entry point.
-#      workdir="...",
-#
-#      # https://docs.docker.com/engine/reference/builder/#env
-#      env = {
-#         "var1": "val1",
-#         "var2": "val2",
-#         ...
-#         "varN": "valN",
-#      },
-#   )
+        # Produces a new container image tarball compatible with 'docker load', which
+        # is a single additional layer atop 'base'.  The goal is to have relatively
+        # complete support for building container image, from the Dockerfile spec.
+        #
+        # For more information see the 'Config' section of the image specification:
+        # https://github.com/opencontainers/image-spec/blob/v0.2.0/serialization.md
+        #
+        # Only 'name' is required. All other fields have sane defaults.
+        #
+        #   container_image(
+        #      name="...",
+        #      visibility="...",
+        #
+        #      # The base layers on top of which to overlay this layer,
+        #      # equivalent to FROM.
+        #      base="//another/build:rule",
+        #
+        #      # The base directory of the files, defaulted to
+        #      # the package of the input.
+        #      # All files structure relatively to that path will be preserved.
+        #      # A leading '/' mean the workspace root and this path is relative
+        #      # to the current package by default.
+        #      data_path="...",
+        #
+        #      # The directory in which to expand the specified files,
+        #      # defaulting to '/'.
+        #      # Only makes sense accompanying one of files/tars/debs.
+        #      directory="...",
+        #
+        #      # The set of archives to expand, or packages to install
+        #      # within the chroot of this layer
+        #      files=[...],
+        #      tars=[...],
+        #      debs=[...],
+        #
+        #      # The set of symlinks to create within a given layer.
+        #      symlinks = {
+        #          "/path/to/link": "/path/to/target",
+        #          ...
+        #      },
+        #
+        #      # Other layers built from container_layer rule
+        #      layers = [":c-lang-layer", ":java-lang-layer", ...]
+        #
+        #      # https://docs.docker.com/engine/reference/builder/#entrypoint
+        #      entrypoint="...", or
+        #      entrypoint=[...],            -- exec form
+        #
+        #      # https://docs.docker.com/engine/reference/builder/#cmd
+        #      cmd="...", or
+        #      cmd=[...],                   -- exec form
+        #
+        #      # https://docs.docker.com/engine/reference/builder/#expose
+        #      ports=[...],
+        #
+        #      # https://docs.docker.com/engine/reference/builder/#user
+        #      # NOTE: the normal directive affects subsequent RUN, CMD,
+        #      # and ENTRYPOINT
+        #      user="...",
+        #
+        #      # https://docs.docker.com/engine/reference/builder/#volume
+        #      volumes=[...],
+        #
+        #      # https://docs.docker.com/engine/reference/builder/#workdir
+        #      # NOTE: the normal directive affects subsequent RUN, CMD,
+        #      # ENTRYPOINT, ADD, and COPY, but this attribute only affects
+        #      # the entry point.
+        #      workdir="...",
+        #
+        #      # https://docs.docker.com/engine/reference/builder/#env
+        #      env = {
+        #         "var1": "val1",
+        #         "var2": "val2",
+        #         ...
+        #         "varN": "valN",
+        #      },
+        #   )
+
 def container_image(**kwargs):
-  """Package a docker image.
+    """Package a docker image.
 
   This rule generates a sequence of genrules the last of which is named 'name',
   so the dependency graph works out properly.  The output of this rule is a
@@ -463,15 +510,15 @@ def container_image(**kwargs):
   Args:
     **kwargs: See above.
   """
-  if "cmd" in kwargs:
-    kwargs["cmd"] = _validate_command("cmd", kwargs["cmd"])
-  for reserved in ["label_files", "label_file_strings"]:
-    if reserved in kwargs:
-      fail("reserved for internal use by container_image macro", attr=reserved)
-  if "labels" in kwargs:
-    files = sorted({v[1:]: None for v in kwargs["labels"].values() if v[0] == "@"}.keys())
-    kwargs["label_files"] = files
-    kwargs["label_file_strings"] = files
-  if "entrypoint" in kwargs:
-    kwargs["entrypoint"] = _validate_command("entrypoint", kwargs["entrypoint"])
-  container_image_(**kwargs)
+    if "cmd" in kwargs:
+        kwargs["cmd"] = _validate_command("cmd", kwargs["cmd"])
+    for reserved in ["label_files", "label_file_strings"]:
+        if reserved in kwargs:
+            fail("reserved for internal use by container_image macro", attr = reserved)
+    if "labels" in kwargs:
+        files = sorted({v[1:]: None for v in kwargs["labels"].values() if v[0] == "@"}.keys())
+        kwargs["label_files"] = files
+        kwargs["label_file_strings"] = files
+    if "entrypoint" in kwargs:
+        kwargs["entrypoint"] = _validate_command("entrypoint", kwargs["entrypoint"])
+    container_image_(**kwargs)

--- a/container/import.bzl
+++ b/container/import.bzl
@@ -43,82 +43,88 @@ load(
 )
 
 def _is_filetype(filename, extensions):
-  for filetype in extensions:
-    if filename.endswith(filetype):
-      return True
+    for filetype in extensions:
+        if filename.endswith(filetype):
+            return True
 
 def _is_tgz(layer):
-  return _is_filetype(layer.basename, tgz_filetype)
+    return _is_filetype(layer.basename, tgz_filetype)
 
 def _is_tar(layer):
-  return _is_filetype(layer.basename, tar_filetype)
+    return _is_filetype(layer.basename, tar_filetype)
 
 def _layer_pair(ctx, layer):
-  zipped = _is_tgz(layer)
-  unzipped = not zipped and _is_tar(layer)
-  if not (zipped or unzipped):
-    fail("Unknown filetype provided (need .tar or .tar.gz): %s" % layer)
+    zipped = _is_tgz(layer)
+    unzipped = not zipped and _is_tar(layer)
+    if not (zipped or unzipped):
+        fail("Unknown filetype provided (need .tar or .tar.gz): %s" % layer)
 
-  zipped_layer = layer if zipped else _gzip(ctx, layer)
-  unzipped_layer = layer if unzipped else _gunzip(ctx, layer)
-  return zipped_layer, unzipped_layer, _sha256(ctx, unzipped_layer)
+    zipped_layer = layer if zipped else _gzip(ctx, layer)
+    unzipped_layer = layer if unzipped else _gunzip(ctx, layer)
+    return zipped_layer, unzipped_layer, _sha256(ctx, unzipped_layer)
 
 def _repository_name(ctx):
-  """Compute the repository name for the current rule."""
-  return _join_path(ctx.attr.repository, ctx.label.package)
+    """Compute the repository name for the current rule."""
+    return _join_path(ctx.attr.repository, ctx.label.package)
 
 def _container_import_impl(ctx):
-  """Implementation for the container_import rule."""
+    """Implementation for the container_import rule."""
 
-  blobsums = []
-  zipped_layers = []
-  unzipped_layers = []
-  diff_ids = []
-  for layer in ctx.files.layers:
-    blobsums += [_sha256(ctx, layer)]
-    zipped, unzipped, diff_id = _layer_pair(ctx, layer)
-    zipped_layers += [zipped]
-    unzipped_layers += [unzipped]
-    diff_ids += [diff_id]
+    blobsums = []
+    zipped_layers = []
+    unzipped_layers = []
+    diff_ids = []
+    for layer in ctx.files.layers:
+        blobsums += [_sha256(ctx, layer)]
+        zipped, unzipped, diff_id = _layer_pair(ctx, layer)
+        zipped_layers += [zipped]
+        unzipped_layers += [unzipped]
+        diff_ids += [diff_id]
 
-  # These are the constituent parts of the Container image, which each
-  # rule in the chain must preserve.
-  container_parts = {
-      # The path to the v2.2 configuration file.
-      "config": ctx.files.config[0],
-      "config_digest": _sha256(ctx, ctx.files.config[0]),
+        # These are the constituent parts of the Container image, which each
+        # rule in the chain must preserve.
 
-      # A list of paths to the layer .tar.gz files
-      "zipped_layer": zipped_layers,
-      # A list of paths to the layer digests.
-      "blobsum": blobsums,
+    container_parts = {
+        # The path to the v2.2 configuration file.
+        "config": ctx.files.config[0],
+        "config_digest": _sha256(ctx, ctx.files.config[0]),
 
-      # A list of paths to the layer .tar files
-      "unzipped_layer": unzipped_layers,
-      # A list of paths to the layer diff_ids.
-      "diff_id": diff_ids,
+        # A list of paths to the layer .tar.gz files
+        "zipped_layer": zipped_layers,
+        # A list of paths to the layer digests.
+        "blobsum": blobsums,
 
-      # We do not have a "legacy" field, because we are importing a
-      # more efficient form.
-  }
+        # A list of paths to the layer .tar files
+        "unzipped_layer": unzipped_layers,
+        # A list of paths to the layer diff_ids.
+        "diff_id": diff_ids,
 
-  # We support incrementally loading or assembling this single image
-  # with a temporary name given by its build rule.
-  images = {
-      _repository_name(ctx) + ":" + ctx.label.name: container_parts
-  }
+        # We do not have a "legacy" field, because we are importing a
+        # more efficient form.
+    }
 
-  _incr_load(ctx, images, ctx.outputs.executable)
-  _assemble_image(ctx, images, ctx.outputs.out)
+    # We support incrementally loading or assembling this single image
+    # with a temporary name given by its build rule.
+    images = {
+        _repository_name(ctx) + ":" + ctx.label.name: container_parts,
+    }
 
-  runfiles = ctx.runfiles(
-      files = (container_parts["unzipped_layer"] +
-               container_parts["diff_id"] +
-               [container_parts["config"],
-                container_parts["config_digest"]]))
-  return struct(runfiles = runfiles,
-                files = depset([ctx.outputs.out]),
-                container_parts = container_parts)
+    _incr_load(ctx, images, ctx.outputs.executable)
+    _assemble_image(ctx, images, ctx.outputs.out)
+
+    runfiles = ctx.runfiles(
+        files = (container_parts["unzipped_layer"] +
+                 container_parts["diff_id"] +
+                 [
+                     container_parts["config"],
+                     container_parts["config_digest"],
+                 ]),
+    )
+    return struct(
+        runfiles = runfiles,
+        files = depset([ctx.outputs.out]),
+        container_parts = container_parts,
+    )
 
 container_import = rule(
     attrs = dict({

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -41,60 +41,69 @@ load(
 )
 
 def _magic_path(ctx, f):
-  # Right now the logic this uses is a bit crazy/buggy, so to support
-  # bug-for-bug compatibility in the foo_image rules, expose the logic.
-  # See also: https://github.com/bazelbuild/rules_docker/issues/106
-  # See also: https://groups.google.com/forum/#!topic/bazel-discuss/1lX3aiTZX3Y
+    # Right now the logic this uses is a bit crazy/buggy, so to support
+    # bug-for-bug compatibility in the foo_image rules, expose the logic.
+    # See also: https://github.com/bazelbuild/rules_docker/issues/106
+    # See also: https://groups.google.com/forum/#!topic/bazel-discuss/1lX3aiTZX3Y
 
-  if ctx.attr.data_path:
-    # If data_prefix is specified, then add files relative to that.
-    data_path = _join_path(
-        dirname(ctx.outputs.layer.short_path),
-        _canonicalize_path(ctx.attr.data_path))
-    return strip_prefix(f.short_path, data_path)
-  else:
-    # Otherwise, files are added without a directory prefix at all.
-    return f.basename
+    if ctx.attr.data_path:
+        # If data_prefix is specified, then add files relative to that.
+        data_path = _join_path(
+            dirname(ctx.outputs.layer.short_path),
+            _canonicalize_path(ctx.attr.data_path),
+        )
+        return strip_prefix(f.short_path, data_path)
+    else:
+        # Otherwise, files are added without a directory prefix at all.
+        return f.basename
 
-def build_layer(ctx, files=None, file_map=None, empty_files=None,
-                empty_dirs=None, directory=None, symlinks=None, debs=None,
-                tars=None):
-  """Build the current layer for appending it to the base layer"""
-  layer = ctx.outputs.layer
-  build_layer_exec = ctx.executable.build_layer
-  args = [
-      "--output=" + layer.path,
-      "--directory=" + directory,
-      "--mode=" + ctx.attr.mode,
-  ]
+def build_layer(
+        ctx,
+        files = None,
+        file_map = None,
+        empty_files = None,
+        empty_dirs = None,
+        directory = None,
+        symlinks = None,
+        debs = None,
+        tars = None):
+    """Build the current layer for appending it to the base layer"""
+    layer = ctx.outputs.layer
+    build_layer_exec = ctx.executable.build_layer
+    args = [
+        "--output=" + layer.path,
+        "--directory=" + directory,
+        "--mode=" + ctx.attr.mode,
+    ]
 
-  args += ["--file=%s=%s" % (f.path, _magic_path(ctx, f)) for f in files]
-  args += ["--file=%s=%s" % (f.path, path) for (path, f) in file_map.items()]
-  args += ["--empty_file=%s" % f for f in empty_files or []]
-  args += ["--empty_dir=%s" % f for f in empty_dirs or []]
-  args += ["--tar=" + f.path for f in tars]
-  args += ["--deb=" + f.path for f in debs]
-  for k in symlinks:
-    if ":" in k:
-      fail("The source of a symlink cannot container ':', got: %s" % k)
-  args += ["--link=%s:%s" % (k, symlinks[k]) for k in symlinks]
-  arg_file = ctx.new_file(ctx.label.name + "-layer.args")
-  ctx.file_action(arg_file, "\n".join(args))
-  ctx.action(
-      executable = build_layer_exec,
-      arguments = ["--flagfile=" + arg_file.path],
-      inputs = files + file_map.values() + tars + debs + [arg_file],
-      outputs = [layer],
-      use_default_shell_env = True,
-      mnemonic="ImageLayer",
-  )
-  return layer, _sha256(ctx, layer)
+    args += ["--file=%s=%s" % (f.path, _magic_path(ctx, f)) for f in files]
+    args += ["--file=%s=%s" % (f.path, path) for (path, f) in file_map.items()]
+    args += ["--empty_file=%s" % f for f in empty_files or []]
+    args += ["--empty_dir=%s" % f for f in empty_dirs or []]
+    args += ["--tar=" + f.path for f in tars]
+    args += ["--deb=" + f.path for f in debs]
+    for k in symlinks:
+        if ":" in k:
+            fail("The source of a symlink cannot container ':', got: %s" % k)
+    args += ["--link=%s:%s" % (k, symlinks[k]) for k in symlinks]
+    arg_file = ctx.new_file(ctx.label.name + "-layer.args")
+    ctx.file_action(arg_file, "\n".join(args))
+    ctx.action(
+        executable = build_layer_exec,
+        arguments = ["--flagfile=" + arg_file.path],
+        inputs = files + file_map.values() + tars + debs + [arg_file],
+        outputs = [layer],
+        use_default_shell_env = True,
+        mnemonic = "ImageLayer",
+    )
+    return layer, _sha256(ctx, layer)
 
 def zip_layer(ctx, layer):
-  zipped_layer = _gzip(ctx, layer)
-  return zipped_layer, _sha256(ctx, zipped_layer)
+    zipped_layer = _gzip(ctx, layer)
+    return zipped_layer, _sha256(ctx, zipped_layer)
 
-# A provider containing information needed in container_image and other rules.
+    # A provider containing information needed in container_image and other rules.
+
 LayerInfo = provider(fields = [
     "zipped_layer",
     "blob_sum",
@@ -103,9 +112,18 @@ LayerInfo = provider(fields = [
     "env",
 ])
 
-def _impl(ctx, files=None, file_map=None, empty_files=None, empty_dirs=None,
-          directory=None, symlinks=None, debs=None, tars=None, env=None):
-  """Implementation for the container_layer rule.
+def _impl(
+        ctx,
+        files = None,
+        file_map = None,
+        empty_files = None,
+        empty_dirs = None,
+        directory = None,
+        symlinks = None,
+        debs = None,
+        tars = None,
+        env = None):
+    """Implementation for the container_layer rule.
 
   Args:
     ctx: The bazel rule context
@@ -119,35 +137,44 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, empty_dirs=None,
     debs: File list, overrides ctx.files.debs
     tars: File list, overrides ctx.files.tars
   """
-  file_map = file_map or {}
-  files = files or ctx.files.files
-  empty_files = empty_files or ctx.attr.empty_files
-  empty_dirs = empty_dirs or ctx.attr.empty_dirs
-  directory = directory or ctx.attr.directory
-  symlinks = symlinks or ctx.attr.symlinks
-  debs = debs or ctx.files.debs
-  tars = tars or ctx.files.tars
+    file_map = file_map or {}
+    files = files or ctx.files.files
+    empty_files = empty_files or ctx.attr.empty_files
+    empty_dirs = empty_dirs or ctx.attr.empty_dirs
+    directory = directory or ctx.attr.directory
+    symlinks = symlinks or ctx.attr.symlinks
+    debs = debs or ctx.files.debs
+    tars = tars or ctx.files.tars
 
-  # Generate the unzipped filesystem layer, and its sha256 (aka diff_id)
-  unzipped_layer, diff_id = build_layer(ctx, files=files, file_map=file_map,
-                                        empty_files=empty_files,
-                                        empty_dirs=empty_dirs,
-                                        directory=directory, symlinks=symlinks,
-                                        debs=debs, tars=tars)
-  # Generate the zipped filesystem layer, and its sha256 (aka blob sum)
-  zipped_layer, blob_sum = zip_layer(ctx, unzipped_layer)
+    # Generate the unzipped filesystem layer, and its sha256 (aka diff_id)
+    unzipped_layer, diff_id = build_layer(
+        ctx,
+        files = files,
+        file_map = file_map,
+        empty_files = empty_files,
+        empty_dirs = empty_dirs,
+        directory = directory,
+        symlinks = symlinks,
+        debs = debs,
+        tars = tars,
+    )
 
-  # Returns constituent parts of the Container layer as provider:
-  # - in container_image rule, we need to use all the following information,
-  #   e.g. zipped_layer etc., to assemble the complete container image.
-  # - in order to expose information from container_layer rule to container_image
-  #   rule, they need to be packaged into a provider, see:
-  #   https://docs.bazel.build/versions/master/skylark/rules.html#providers
-  return [LayerInfo(zipped_layer=zipped_layer,
-                    blob_sum=blob_sum,
-                    unzipped_layer=unzipped_layer,
-                    diff_id=diff_id,
-                    env=env or ctx.attr.env)]
+    # Generate the zipped filesystem layer, and its sha256 (aka blob sum)
+    zipped_layer, blob_sum = zip_layer(ctx, unzipped_layer)
+
+    # Returns constituent parts of the Container layer as provider:
+    # - in container_image rule, we need to use all the following information,
+    #   e.g. zipped_layer etc., to assemble the complete container image.
+    # - in order to expose information from container_layer rule to container_image
+    #   rule, they need to be packaged into a provider, see:
+    #   https://docs.bazel.build/versions/master/skylark/rules.html#providers
+    return [LayerInfo(
+        zipped_layer = zipped_layer,
+        blob_sum = blob_sum,
+        unzipped_layer = unzipped_layer,
+        diff_id = diff_id,
+        env = env or ctx.attr.env,
+    )]
 
 _layer_attrs = dict({
     "data_path": attr.string(),
@@ -187,4 +214,4 @@ container_layer_ = rule(
 )
 
 def container_layer(**kwargs):
-  container_layer_(**kwargs)
+    container_layer_(**kwargs)

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -19,149 +19,166 @@ load(
 )
 
 def _extract_layers(ctx, artifact):
-  config_file = ctx.new_file(ctx.label.name + "." + artifact.basename + ".config")
-  ctx.action(
-      executable = ctx.executable.extract_config,
-      arguments = [
-          "--tarball", artifact.path,
-          "--output", config_file.path],
-      inputs = [artifact],
-      outputs = [config_file],
-      mnemonic = "ExtractConfig")
-  return {
-      "config": config_file,
-      # TODO(mattmoor): Do we need to compute config_digest here?
-      # I believe we would for a checked in tarball to be usable
-      # with docker_bundle + bazel run.
-      "legacy": artifact,
-  }
+    config_file = ctx.new_file(ctx.label.name + "." + artifact.basename + ".config")
+    ctx.action(
+        executable = ctx.executable.extract_config,
+        arguments = [
+            "--tarball",
+            artifact.path,
+            "--output",
+            config_file.path,
+        ],
+        inputs = [artifact],
+        outputs = [config_file],
+        mnemonic = "ExtractConfig",
+    )
+    return {
+        "config": config_file,
+        # TODO(mattmoor): Do we need to compute config_digest here?
+        # I believe we would for a checked in tarball to be usable
+        # with docker_bundle + bazel run.
+        "legacy": artifact,
+    }
 
-def get_from_target(ctx, attr_target, file_target=None):
-  if file_target:
-    return _extract_layers(ctx, file_target)
-  elif hasattr(attr_target, "container_parts"):
-    return attr_target.container_parts
-  else:
-    if not hasattr(attr_target, "files"):
-      return {}
-    target = attr_target.files.to_list()[0]
-    return _extract_layers(ctx, target)
+def get_from_target(ctx, attr_target, file_target = None):
+    if file_target:
+        return _extract_layers(ctx, file_target)
+    elif hasattr(attr_target, "container_parts"):
+        return attr_target.container_parts
+    else:
+        if not hasattr(attr_target, "files"):
+            return {}
+        target = attr_target.files.to_list()[0]
+        return _extract_layers(ctx, target)
 
-def assemble(ctx, images, output, stamp=False):
-  """Create the full image from the list of layers."""
-  args = [
-      "--output=" + output.path,
-  ]
-
-  inputs = []
-  for tag in images:
-    image = images[tag]
-    args += [
-        "--tags=" + tag + "=@" + image["config"].path
-    ]
-    inputs += [image["config"]]
-
-    for i in range(0, len(image["diff_id"])):
-      args += [
-          "--layer=" +
-          "@" + image["diff_id"][i].path +
-          "=@" + image["blobsum"][i].path +
-          # No @, not resolved through utils, always filename.
-          "=" + image["unzipped_layer"][i].path +
-          "=" + image["zipped_layer"][i].path
-      ]
-    inputs += image["unzipped_layer"]
-    inputs += image["diff_id"]
-    inputs += image["zipped_layer"]
-    inputs += image["blobsum"]
-
-    if image.get("legacy"):
-      args += ["--legacy=" + image["legacy"].path]
-      inputs += [image["legacy"]]
-
-  if stamp:
-    args += ["--stamp-info-file=%s" % f.path for f in (ctx.info_file, ctx.version_file)]
-    inputs += [ctx.info_file, ctx.version_file]
-  ctx.action(
-      executable = ctx.executable.join_layers,
-      arguments = args,
-      inputs = inputs,
-      outputs = [output],
-      mnemonic = "JoinLayers"
-  )
-
-def incremental_load(ctx, images, output,
-                     stamp=False, run=False, run_flags=None):
-  """Generate the incremental load statement."""
-  stamp_files = []
-  if stamp:
-    stamp_files = [ctx.info_file, ctx.version_file]
-
-  # Default to interactively launching the container,
-  # and cleaning up when it exits.
-  run_flags = run_flags or "-i --rm"
-
-  if len(images) > 1 and run:
-    fail("Bazel run does not currently support execution of " +
-         "multiple containers (only loading).")
-
-  load_statements = []
-  tag_statements = []
-  run_statements = []
-  # TODO(mattmoor): Consider adding cleanup_statements.
-  for tag in images:
-    image = images[tag]
-
-    # First load the legacy base image, if it exists.
-    if image.get("legacy"):
-      load_statements += [
-          "load_legacy '%s'" % _get_runfile_path(ctx, image["legacy"])
-      ]
-
-    pairs = zip(image["diff_id"], image["unzipped_layer"])
-
-    # Import the config and the subset of layers not present
-    # in the daemon.
-    load_statements += [
-        "import_config '%s' %s" % (
-            _get_runfile_path(ctx, image["config"]),
-            " ".join([
-              "'%s' '%s'" % (
-                _get_runfile_path(ctx, diff_id),
-                _get_runfile_path(ctx, unzipped_layer))
-              for (diff_id, unzipped_layer) in pairs]))
+def assemble(ctx, images, output, stamp = False):
+    """Create the full image from the list of layers."""
+    args = [
+        "--output=" + output.path,
     ]
 
-    # Now tag the imported config with the specified tag.
-    tag_reference = tag if not stamp else tag.replace("{", "${")
-    tag_statements += [
-        "tag_layer \"%s\" '%s'" % (
-            # Turn stamp variable references into bash variables.
-            # It is notable that the only legal use of '{' in a
-            # tag would be for stamp variables, '$' is not allowed.
-            tag_reference,
-            _get_runfile_path(ctx, image["config_digest"]))
-    ]
-    if run:
-      run_statements += [
-          "docker run %s %s \"$@\"" % (run_flags, tag_reference)
-      ]
+    inputs = []
+    for tag in images:
+        image = images[tag]
+        args += [
+            "--tags=" + tag + "=@" + image["config"].path,
+        ]
+        inputs += [image["config"]]
 
-  ctx.template_action(
-      template = ctx.file.incremental_load_template,
-      substitutions = {
-          # If this rule involves stamp variables than load them as bash
-          # variables, and turn references to them into bash variable
-          # references.
-          "%{stamp_statements}": "\n".join([
-              "read_variables %s" % _get_runfile_path(ctx, f)
-              for f in stamp_files]),
-          "%{load_statements}": "\n".join(load_statements),
-          "%{tag_statements}": "\n".join(tag_statements),
-          "%{run_statements}": "\n".join(run_statements),
-      },
-      output = output,
-      executable = True)
+        for i in range(0, len(image["diff_id"])):
+            args += [
+                "--layer=" +
+                "@" + image["diff_id"][i].path +
+                "=@" + image["blobsum"][i].path +
+                # No @, not resolved through utils, always filename.
+                "=" + image["unzipped_layer"][i].path +
+                "=" + image["zipped_layer"][i].path,
+            ]
+        inputs += image["unzipped_layer"]
+        inputs += image["diff_id"]
+        inputs += image["zipped_layer"]
+        inputs += image["blobsum"]
+
+        if image.get("legacy"):
+            args += ["--legacy=" + image["legacy"].path]
+            inputs += [image["legacy"]]
+
+    if stamp:
+        args += ["--stamp-info-file=%s" % f.path for f in (ctx.info_file, ctx.version_file)]
+        inputs += [ctx.info_file, ctx.version_file]
+    ctx.action(
+        executable = ctx.executable.join_layers,
+        arguments = args,
+        inputs = inputs,
+        outputs = [output],
+        mnemonic = "JoinLayers",
+    )
+
+def incremental_load(
+        ctx,
+        images,
+        output,
+        stamp = False,
+        run = False,
+        run_flags = None):
+    """Generate the incremental load statement."""
+    stamp_files = []
+    if stamp:
+        stamp_files = [ctx.info_file, ctx.version_file]
+
+        # Default to interactively launching the container,
+        # and cleaning up when it exits.
+
+    run_flags = run_flags or "-i --rm"
+
+    if len(images) > 1 and run:
+        fail("Bazel run does not currently support execution of " +
+             "multiple containers (only loading).")
+
+    load_statements = []
+    tag_statements = []
+    run_statements = []
+
+    # TODO(mattmoor): Consider adding cleanup_statements.
+    for tag in images:
+        image = images[tag]
+
+        # First load the legacy base image, if it exists.
+        if image.get("legacy"):
+            load_statements += [
+                "load_legacy '%s'" % _get_runfile_path(ctx, image["legacy"]),
+            ]
+
+        pairs = zip(image["diff_id"], image["unzipped_layer"])
+
+        # Import the config and the subset of layers not present
+        # in the daemon.
+        load_statements += [
+            "import_config '%s' %s" % (
+                _get_runfile_path(ctx, image["config"]),
+                " ".join([
+                    "'%s' '%s'" % (
+                        _get_runfile_path(ctx, diff_id),
+                        _get_runfile_path(ctx, unzipped_layer),
+                    )
+                    for (diff_id, unzipped_layer) in pairs
+                ]),
+            ),
+        ]
+
+        # Now tag the imported config with the specified tag.
+        tag_reference = tag if not stamp else tag.replace("{", "${")
+        tag_statements += [
+            "tag_layer \"%s\" '%s'" % (
+                # Turn stamp variable references into bash variables.
+                # It is notable that the only legal use of '{' in a
+                # tag would be for stamp variables, '$' is not allowed.
+                tag_reference,
+                _get_runfile_path(ctx, image["config_digest"]),
+            ),
+        ]
+        if run:
+            run_statements += [
+                "docker run %s %s \"$@\"" % (run_flags, tag_reference),
+            ]
+
+    ctx.template_action(
+        template = ctx.file.incremental_load_template,
+        substitutions = {
+            # If this rule involves stamp variables than load them as bash
+            # variables, and turn references to them into bash variable
+            # references.
+            "%{stamp_statements}": "\n".join([
+                "read_variables %s" % _get_runfile_path(ctx, f)
+                for f in stamp_files
+            ]),
+            "%{load_statements}": "\n".join(load_statements),
+            "%{tag_statements}": "\n".join(tag_statements),
+            "%{run_statements}": "\n".join(run_statements),
+        },
+        output = output,
+        executable = True,
+    )
 
 tools = {
     "incremental_load_template": attr.label(

--- a/container/load.bzl
+++ b/container/load.bzl
@@ -23,12 +23,12 @@ load(
 )
 
 def _impl(repository_ctx):
-  """Core implementation of container_load."""
+    """Core implementation of container_load."""
 
-  # Add an empty top-level BUILD file.
-  repository_ctx.file("BUILD", "")
+    # Add an empty top-level BUILD file.
+    repository_ctx.file("BUILD", "")
 
-  repository_ctx.file("image/BUILD", """
+    repository_ctx.file("image/BUILD", """
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//container:import.bzl", "container_import")
@@ -38,16 +38,19 @@ container_import(
   config = "config.json",
   layers = glob(["*.tar"]),
 )
-""", executable=False)
+""", executable = False)
 
-  result = repository_ctx.execute([
-      _python(repository_ctx),
-      repository_ctx.path(repository_ctx.attr._importer),
-      "--directory", repository_ctx.path("image"),
-      "--tarball", repository_ctx.path(repository_ctx.attr.file)])
+    result = repository_ctx.execute([
+        _python(repository_ctx),
+        repository_ctx.path(repository_ctx.attr._importer),
+        "--directory",
+        repository_ctx.path("image"),
+        "--tarball",
+        repository_ctx.path(repository_ctx.attr.file),
+    ])
 
-  if result.return_code:
-    fail("Importing from tarball failed (status %s): %s" % (result.return_code, result.stderr))
+    if result.return_code:
+        fail("Importing from tarball failed (status %s): %s" % (result.return_code, result.stderr))
 
 container_load = repository_rule(
     attrs = {

--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -19,25 +19,25 @@ construct new images.
 """
 
 def python(repository_ctx):
-  if "BAZEL_PYTHON" in repository_ctx.os.environ:
-    return repository_ctx.os.environ.get("BAZEL_PYTHON")
+    if "BAZEL_PYTHON" in repository_ctx.os.environ:
+        return repository_ctx.os.environ.get("BAZEL_PYTHON")
 
-  python_path = repository_ctx.which("python")
-  if not python_path:
-    python_path = repository_ctx.which("python.exe")
-  if python_path:
-    return python_path
+    python_path = repository_ctx.which("python")
+    if not python_path:
+        python_path = repository_ctx.which("python.exe")
+    if python_path:
+        return python_path
 
-  fail("rules_docker requires a python interpreter installed. " +
-       "Please set BAZEL_PYTHON, or put it on your path.")
+    fail("rules_docker requires a python interpreter installed. " +
+         "Please set BAZEL_PYTHON, or put it on your path.")
 
 def _impl(repository_ctx):
-  """Core implementation of container_pull."""
+    """Core implementation of container_pull."""
 
-  # Add an empty top-level BUILD file.
-  repository_ctx.file("BUILD", "")
+    # Add an empty top-level BUILD file.
+    repository_ctx.file("BUILD", "")
 
-  repository_ctx.file("image/BUILD", """
+    repository_ctx.file("image/BUILD", """
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//container:import.bzl", "container_import")
@@ -49,35 +49,40 @@ container_import(
 )
 """)
 
-  args = [
-      python(repository_ctx),
-      repository_ctx.path(repository_ctx.attr._puller),
-      "--directory", repository_ctx.path("image")
-  ]
-
-  # If a digest is specified, then pull by digest.  Otherwise, pull by tag.
-  if repository_ctx.attr.digest:
-    args += [
-        "--name", "{registry}/{repository}@{digest}".format(
-            registry=repository_ctx.attr.registry,
-            repository=repository_ctx.attr.repository,
-            digest=repository_ctx.attr.digest)
-    ]
-  else:
-    args += [
-        "--name", "{registry}/{repository}:{tag}".format(
-            registry=repository_ctx.attr.registry,
-            repository=repository_ctx.attr.repository,
-            tag=repository_ctx.attr.tag)
+    args = [
+        python(repository_ctx),
+        repository_ctx.path(repository_ctx.attr._puller),
+        "--directory",
+        repository_ctx.path("image"),
     ]
 
-  kwargs = {}
-  if "PULLER_TIMEOUT" in repository_ctx.os.environ:
-      kwargs["timeout"] = int(repository_ctx.os.environ.get("PULLER_TIMEOUT"))
+    # If a digest is specified, then pull by digest.  Otherwise, pull by tag.
+    if repository_ctx.attr.digest:
+        args += [
+            "--name",
+            "{registry}/{repository}@{digest}".format(
+                registry = repository_ctx.attr.registry,
+                repository = repository_ctx.attr.repository,
+                digest = repository_ctx.attr.digest,
+            ),
+        ]
+    else:
+        args += [
+            "--name",
+            "{registry}/{repository}:{tag}".format(
+                registry = repository_ctx.attr.registry,
+                repository = repository_ctx.attr.repository,
+                tag = repository_ctx.attr.tag,
+            ),
+        ]
 
-  result = repository_ctx.execute(args, **kwargs)
-  if result.return_code:
-    fail("Pull command failed: %s (%s)" % (result.stderr, " ".join(args)))
+    kwargs = {}
+    if "PULLER_TIMEOUT" in repository_ctx.os.environ:
+        kwargs["timeout"] = int(repository_ctx.os.environ.get("PULLER_TIMEOUT"))
+
+    result = repository_ctx.execute(args, **kwargs)
+    if result.return_code:
+        fail("Pull command failed: %s (%s)" % (result.stderr, " ".join(args)))
 
 container_pull = repository_rule(
     attrs = {

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -28,60 +28,74 @@ load(
 )
 
 def _get_runfile_path(ctx, f):
-  return "${RUNFILES}/%s" % runfile(ctx, f)
+    return "${RUNFILES}/%s" % runfile(ctx, f)
 
 def _impl(ctx):
-  """Core implementation of container_push."""
-  stamp_inputs = []
-  if ctx.attr.stamp:
-    stamp_inputs = [ctx.info_file, ctx.version_file]
+    """Core implementation of container_push."""
+    stamp_inputs = []
+    if ctx.attr.stamp:
+        stamp_inputs = [ctx.info_file, ctx.version_file]
 
-  image = _get_layers(ctx, ctx.attr.image)
+    image = _get_layers(ctx, ctx.attr.image)
 
-  stamp_arg = " ".join(["--stamp-info-file=%s" % _get_runfile_path(ctx, f) for f in stamp_inputs])
+    stamp_arg = " ".join(["--stamp-info-file=%s" % _get_runfile_path(ctx, f) for f in stamp_inputs])
 
-  # Leverage our efficient intermediate representation to push.
-  legacy_base_arg = ""
-  if image.get("legacy"):
-    print("Pushing an image based on a tarball can be very " +
-          "expensive.  If the image is the output of a " +
-          "docker_build, consider dropping the '.tar' extension. " +
-          "If the image is checked in, consider using " +
-          "docker_import instead.")
-    legacy_base_arg = "--tarball=%s" % _get_runfile_path(ctx, image["legacy"])
+    # Leverage our efficient intermediate representation to push.
+    legacy_base_arg = ""
+    if image.get("legacy"):
+        print("Pushing an image based on a tarball can be very " +
+              "expensive.  If the image is the output of a " +
+              "docker_build, consider dropping the '.tar' extension. " +
+              "If the image is checked in, consider using " +
+              "docker_import instead.")
+        legacy_base_arg = "--tarball=%s" % _get_runfile_path(ctx, image["legacy"])
 
-  blobsums = image.get("blobsum", [])
-  digest_arg = " ".join(["--digest=%s" % _get_runfile_path(ctx, f) for f in blobsums])
-  blobs = image.get("zipped_layer", [])
-  layer_arg = " ".join(["--layer=%s" % _get_runfile_path(ctx, f) for f in blobs])
-  config_arg = "--config=%s" % _get_runfile_path(ctx, image["config"])
+    blobsums = image.get("blobsum", [])
+    digest_arg = " ".join(["--digest=%s" % _get_runfile_path(ctx, f) for f in blobsums])
+    blobs = image.get("zipped_layer", [])
+    layer_arg = " ".join(["--layer=%s" % _get_runfile_path(ctx, f) for f in blobs])
+    config_arg = "--config=%s" % _get_runfile_path(ctx, image["config"])
 
-  ctx.template_action(
-      template = ctx.file._tag_tpl,
-      substitutions = {
-          "%{tag}": "{registry}/{repository}:{tag}".format(
-            registry=ctx.expand_make_variables(
-              "registry", ctx.attr.registry, {}),
-            repository=ctx.expand_make_variables(
-              "repository", ctx.attr.repository, {}),
-            tag=ctx.expand_make_variables(
-              "tag", ctx.attr.tag, {})),
-          "%{stamp}": stamp_arg,
-          "%{image}": "%s %s %s %s" % (
-              legacy_base_arg, config_arg, digest_arg, layer_arg),
-          "%{format}": "--oci" if ctx.attr.format == "OCI" else "",
-          "%{container_pusher}": _get_runfile_path(ctx, ctx.executable._pusher),
-      },
-      output = ctx.outputs.executable,
-      executable=True,
-  )
+    ctx.template_action(
+        template = ctx.file._tag_tpl,
+        substitutions = {
+            "%{tag}": "{registry}/{repository}:{tag}".format(
+                registry = ctx.expand_make_variables(
+                    "registry",
+                    ctx.attr.registry,
+                    {},
+                ),
+                repository = ctx.expand_make_variables(
+                    "repository",
+                    ctx.attr.repository,
+                    {},
+                ),
+                tag = ctx.expand_make_variables(
+                    "tag",
+                    ctx.attr.tag,
+                    {},
+                ),
+            ),
+            "%{stamp}": stamp_arg,
+            "%{image}": "%s %s %s %s" % (
+                legacy_base_arg,
+                config_arg,
+                digest_arg,
+                layer_arg,
+            ),
+            "%{format}": "--oci" if ctx.attr.format == "OCI" else "",
+            "%{container_pusher}": _get_runfile_path(ctx, ctx.executable._pusher),
+        },
+        output = ctx.outputs.executable,
+        executable = True,
+    )
 
-  return struct(runfiles = ctx.runfiles(files = [
-      ctx.executable._pusher,
-      image["config"]
-  ] + image.get("blobsum", []) + image.get("zipped_layer", []) +
-  stamp_inputs + ([image["legacy"]] if image.get("legacy") else []) +
-  list(ctx.attr._pusher.default_runfiles.files)))
+    return struct(runfiles = ctx.runfiles(files = [
+                                                      ctx.executable._pusher,
+                                                      image["config"],
+                                                  ] + image.get("blobsum", []) + image.get("zipped_layer", []) +
+                                                  stamp_inputs + ([image["legacy"]] if image.get("legacy") else []) +
+                                                  list(ctx.attr._pusher.default_runfiles.files)))
 
 container_push = rule(
     attrs = dict({

--- a/contrib/group.bzl
+++ b/contrib/group.bzl
@@ -19,23 +19,24 @@ GroupFileContentProvider = provider(fields = [
 ])
 
 def _group_entry_impl(ctx):
-  """Creates a passwd_file_content_provider containing a single entry."""
-  return [GroupFileContentProvider(
-      groupname = ctx.attr.groupname,
-      gid = ctx.attr.gid,
-      users = ctx.attr.users,
-  )]
+    """Creates a passwd_file_content_provider containing a single entry."""
+    return [GroupFileContentProvider(
+        groupname = ctx.attr.groupname,
+        gid = ctx.attr.gid,
+        users = ctx.attr.users,
+    )]
 
 def _group_file_impl(ctx):
-  f = "".join(
-      ["%s:x:%s:%s\n" % (
-          entry[GroupFileContentProvider].groupname,
-          entry[GroupFileContentProvider].gid,
-          ",".join(entry[GroupFileContentProvider].users))
-       for entry in ctx.attr.entries])
-  group_file = ctx.actions.declare_file(ctx.label.name)
-  ctx.actions.write(output=group_file, content=f)
-  return DefaultInfo(files=depset([group_file]))
+    f = "".join(
+        ["%s:x:%s:%s\n" % (
+            entry[GroupFileContentProvider].groupname,
+            entry[GroupFileContentProvider].gid,
+            ",".join(entry[GroupFileContentProvider].users),
+        ) for entry in ctx.attr.entries],
+    )
+    group_file = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(output = group_file, content = f)
+    return DefaultInfo(files = depset([group_file]))
 
 group_entry = rule(
     attrs = {

--- a/contrib/passwd.bzl
+++ b/contrib/passwd.bzl
@@ -25,29 +25,30 @@ PasswdFileContentProvider = provider(
 )
 
 def _passwd_entry_impl(ctx):
-  """Creates a passwd_file_content_provider containing a single entry."""
-  return [PasswdFileContentProvider(
-      username = ctx.attr.username,
-      uid = ctx.attr.uid,
-      gid = ctx.attr.gid,
-      info = ctx.attr.info,
-      home = ctx.attr.home,
-      shell = ctx.attr.shell,
-      name = ctx.attr.name,
-  )]
+    """Creates a passwd_file_content_provider containing a single entry."""
+    return [PasswdFileContentProvider(
+        username = ctx.attr.username,
+        uid = ctx.attr.uid,
+        gid = ctx.attr.gid,
+        info = ctx.attr.info,
+        home = ctx.attr.home,
+        shell = ctx.attr.shell,
+        name = ctx.attr.name,
+    )]
 
 def _passwd_file_impl(ctx):
-  """Core implementation of passwd_file."""
-  f = "".join(["%s:x:%s:%s:%s:%s:%s\n" % (
-      entry[PasswdFileContentProvider].username,
-      entry[PasswdFileContentProvider].uid,
-      entry[PasswdFileContentProvider].gid,
-      entry[PasswdFileContentProvider].info,
-      entry[PasswdFileContentProvider].home,
-      entry[PasswdFileContentProvider].shell) for entry in ctx.attr.entries])
-  passwd_file  = ctx.actions.declare_file(ctx.label.name)
-  ctx.actions.write(output=passwd_file, content=f)
-  return DefaultInfo(files=depset([passwd_file]))
+    """Core implementation of passwd_file."""
+    f = "".join(["%s:x:%s:%s:%s:%s:%s\n" % (
+        entry[PasswdFileContentProvider].username,
+        entry[PasswdFileContentProvider].uid,
+        entry[PasswdFileContentProvider].gid,
+        entry[PasswdFileContentProvider].info,
+        entry[PasswdFileContentProvider].home,
+        entry[PasswdFileContentProvider].shell,
+    ) for entry in ctx.attr.entries])
+    passwd_file = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(output = passwd_file, content = f)
+    return DefaultInfo(files = depset([passwd_file]))
 
 passwd_entry = rule(
     attrs = {

--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -23,75 +23,80 @@ load(
 )
 
 def _get_runfile_path(ctx, f):
-  return "${RUNFILES}/%s" % runfile(ctx, f)
+    return "${RUNFILES}/%s" % runfile(ctx, f)
 
 def _impl(ctx):
-  """Core implementation of container_push."""
-  stamp = ctx.attr.bundle.stamp
-  images = ctx.attr.bundle.container_images
+    """Core implementation of container_push."""
+    stamp = ctx.attr.bundle.stamp
+    images = ctx.attr.bundle.container_images
 
-  stamp_inputs = []
-  if stamp:
-    stamp_inputs = [ctx.info_file, ctx.version_file]
+    stamp_inputs = []
+    if stamp:
+        stamp_inputs = [ctx.info_file, ctx.version_file]
 
-  stamp_arg = " ".join(["--stamp-info-file=%s" % _get_runfile_path(ctx, f) for f in stamp_inputs])
+    stamp_arg = " ".join(["--stamp-info-file=%s" % _get_runfile_path(ctx, f) for f in stamp_inputs])
 
-  scripts = []
-  runfiles = []
-  for index, tag in enumerate(images.keys()):
-    image = images[tag]
-    # Leverage our efficient intermediate representation to push.
-    legacy_base_arg = ""
-    if image.get("legacy"):
-      print("Pushing an image based on a tarball can be very " +
-            "expensive.  If the image is the output of a " +
-            "docker_build, consider dropping the '.tar' extension. " +
-            "If the image is checked in, consider using " +
-            "docker_import instead.")
-      legacy_base_arg = "--tarball=%s" % _get_runfile_path(ctx, image["legacy"])
-      runfiles += [image["legacy"]]
+    scripts = []
+    runfiles = []
+    for index, tag in enumerate(images.keys()):
+        image = images[tag]
 
-    blobsums = image.get("blobsum", [])
-    digest_arg = " ".join(["--digest=%s" % _get_runfile_path(ctx, f) for f in blobsums])
-    blobs = image.get("zipped_layer", [])
-    layer_arg = " ".join(["--layer=%s" % _get_runfile_path(ctx, f) for f in blobs])
-    config_arg = "--config=%s" % _get_runfile_path(ctx, image["config"])
+        # Leverage our efficient intermediate representation to push.
+        legacy_base_arg = ""
+        if image.get("legacy"):
+            print("Pushing an image based on a tarball can be very " +
+                  "expensive.  If the image is the output of a " +
+                  "docker_build, consider dropping the '.tar' extension. " +
+                  "If the image is checked in, consider using " +
+                  "docker_import instead.")
+            legacy_base_arg = "--tarball=%s" % _get_runfile_path(ctx, image["legacy"])
+            runfiles += [image["legacy"]]
 
-    runfiles += [image["config"]] + blobsums + blobs
+        blobsums = image.get("blobsum", [])
+        digest_arg = " ".join(["--digest=%s" % _get_runfile_path(ctx, f) for f in blobsums])
+        blobs = image.get("zipped_layer", [])
+        layer_arg = " ".join(["--layer=%s" % _get_runfile_path(ctx, f) for f in blobs])
+        config_arg = "--config=%s" % _get_runfile_path(ctx, image["config"])
 
-    out = ctx.new_file("%s.%d.push" % (ctx.label.name, index))
+        runfiles += [image["config"]] + blobsums + blobs
+
+        out = ctx.new_file("%s.%d.push" % (ctx.label.name, index))
+        ctx.template_action(
+            template = ctx.file._tag_tpl,
+            substitutions = {
+                "%{stamp}": stamp_arg,
+                "%{tag}": ctx.expand_make_variables("tag", tag, {}),
+                "%{image}": "%s %s %s %s" % (
+                    legacy_base_arg,
+                    config_arg,
+                    digest_arg,
+                    layer_arg,
+                ),
+                "%{format}": "--oci" if ctx.attr.format == "OCI" else "",
+                "%{container_pusher}": _get_runfile_path(ctx, ctx.executable._pusher),
+            },
+            output = out,
+            executable = True,
+        )
+
+        scripts += [out]
+        runfiles += [out]
+
     ctx.template_action(
-        template = ctx.file._tag_tpl,
+        template = ctx.file._all_tpl,
         substitutions = {
-            "%{stamp}": stamp_arg,
-            "%{tag}": ctx.expand_make_variables("tag", tag, {}),
-            "%{image}": "%s %s %s %s" % (
-                legacy_base_arg, config_arg, digest_arg, layer_arg),
-            "%{format}": "--oci" if ctx.attr.format == "OCI" else "",
-            "%{container_pusher}": _get_runfile_path(ctx, ctx.executable._pusher),
+            "%{push_statements}": "\n".join([
+                "async \"%s\"" % _get_runfile_path(ctx, command)
+                for command in scripts
+            ]),
         },
-        output = out,
-        executable=True,
+        output = ctx.outputs.executable,
+        executable = True,
     )
 
-    scripts += [out]
-    runfiles += [out]
-
-  ctx.template_action(
-    template = ctx.file._all_tpl,
-    substitutions = {
-      "%{push_statements}": "\n".join([
-        'async "%s"' % _get_runfile_path(ctx, command)
-        for command in scripts
-      ]),
-    },
-    output = ctx.outputs.executable,
-    executable=True,
-  )
-
-  return struct(runfiles = ctx.runfiles(files = [
-    ctx.executable._pusher
-  ] + stamp_inputs + runfiles + list(ctx.attr._pusher.default_runfiles.files)))
+    return struct(runfiles = ctx.runfiles(files = [
+        ctx.executable._pusher,
+    ] + stamp_inputs + runfiles + list(ctx.attr._pusher.default_runfiles.files)))
 
 container_push = rule(
     attrs = {
@@ -133,15 +138,19 @@ Args:
 """
 
 def docker_push(*args, **kwargs):
-  if "format" in kwargs:
-    fail("Cannot override 'format' attribute on docker_push",
-         attr="format")
-  kwargs["format"] = "Docker"
-  container_push(*args, **kwargs)
+    if "format" in kwargs:
+        fail(
+            "Cannot override 'format' attribute on docker_push",
+            attr = "format",
+        )
+    kwargs["format"] = "Docker"
+    container_push(*args, **kwargs)
 
 def oci_push(*args, **kwargs):
-  if "format" in kwargs:
-    fail("Cannot override 'format' attribute on oci_push",
-         attr="format")
-  kwargs["format"] = "OCI"
-  container_push(*args, **kwargs)
+    if "format" in kwargs:
+        fail(
+            "Cannot override 'format' attribute on oci_push",
+            attr = "format",
+        )
+    kwargs["format"] = "OCI"
+    container_push(*args, **kwargs)

--- a/contrib/test.bzl
+++ b/contrib/test.bzl
@@ -23,40 +23,43 @@ load(
 )
 
 def _impl(ctx):
-    config_str = ' '.join(['$(pwd)/' + c.short_path for c in ctx.files.configs])
+    config_str = " ".join(["$(pwd)/" + c.short_path for c in ctx.files.configs])
 
-    if ctx.attr.driver == 'tar':
+    if ctx.attr.driver == "tar":
         # no need to load if we're using raw tar
-        load_statement = ''
-        image_name = '$(pwd)/' + ctx.file.image_tar.short_path
+        load_statement = ""
+        image_name = "$(pwd)/" + ctx.file.image_tar.short_path
 
     else:
         # Since we're always bundling/renaming the image in the macro, this is valid.
-        load_statement = 'docker load -i %s' % ctx.file.image_tar.short_path
+        load_statement = "docker load -i %s" % ctx.file.image_tar.short_path
         image_name = ctx.attr.image_name
 
-    # Generate a shell script to execute structure_tests with the correct flags.
+        # Generate a shell script to execute structure_tests with the correct flags.
     ctx.actions.expand_template(
-        template=ctx.file._structure_test_tpl,
-        output=ctx.outputs.executable,
-        substitutions={
-          "%{load_statement}": load_statement,
-          "%{configs}": config_str,
-          "%{workspace_name}": ctx.workspace_name,
-          "%{test_executable}": ctx.executable._structure_test.short_path,
-          "%{image}": image_name,
-          "%{driver}": ctx.attr.driver,
+        template = ctx.file._structure_test_tpl,
+        output = ctx.outputs.executable,
+        substitutions = {
+            "%{load_statement}": load_statement,
+            "%{configs}": config_str,
+            "%{workspace_name}": ctx.workspace_name,
+            "%{test_executable}": ctx.executable._structure_test.short_path,
+            "%{image}": image_name,
+            "%{driver}": ctx.attr.driver,
         },
-        is_executable=True
+        is_executable = True,
     )
 
-    return struct(runfiles=ctx.runfiles(files = [
-            ctx.executable._structure_test,
-            ctx.executable.image_tar,
-            ctx.file.image_tar] +
-            ctx.attr.image_tar.files.to_list() +
-            ctx.attr.image_tar.data_runfiles.files.to_list() +
-            ctx.files.configs,
+    return struct(
+        runfiles = ctx.runfiles(
+            files = [
+                        ctx.executable._structure_test,
+                        ctx.executable.image_tar,
+                        ctx.file.image_tar,
+                    ] +
+                    ctx.attr.image_tar.files.to_list() +
+                    ctx.attr.image_tar.data_runfiles.files.to_list() +
+                    ctx.files.configs,
         ),
     )
 
@@ -106,12 +109,12 @@ _container_test = rule(
     implementation = _impl,
 )
 
-def container_test(name, image, configs, driver=None, verbose=None, **kwargs):
+def container_test(name, image, configs, driver = None, verbose = None, **kwargs):
     """A macro to predictably rename the image under test before threading
     it to the container test rule."""
 
-    # Remove commonly encountered characters that Docker will choke on 
-    sanitized_name = image.replace(':', '').replace('@', '').replace('/', '')
+    # Remove commonly encountered characters that Docker will choke on
+    sanitized_name = image.replace(":", "").replace("@", "").replace("/", "")
     intermediate_image_name = "%s:intermediate" % sanitized_name
     image_tar_name = "intermediate_bundle_%s" % name
 
@@ -120,7 +123,7 @@ def container_test(name, image, configs, driver=None, verbose=None, **kwargs):
         name = image_tar_name,
         images = {
             intermediate_image_name: image,
-        }
+        },
     )
     _container_test(
         name = name,

--- a/contrib/with-defaults.bzl
+++ b/contrib/with-defaults.bzl
@@ -36,11 +36,11 @@ Any of "registry", "repository" or "tag" may be given a new default.
 """
 
 def _impl(repository_ctx):
-  """Core implementation of docker_default."""
+    """Core implementation of docker_default."""
 
-  repository_ctx.file("BUILD", "")
+    repository_ctx.file("BUILD", "")
 
-  repository_ctx.file("defaults.bzl", """
+    repository_ctx.file("defaults.bzl", """
 load(
   "@io_bazel_rules_docker//container:push.bzl",
   _container_push="container_push"
@@ -70,10 +70,10 @@ def oci_push(*args, **kwargs):
   kwargs["format"] = "OCI"
   container_push(*args, **kwargs)
 """.format(
-  registry=repository_ctx.attr.registry or "",
-  repository=repository_ctx.attr.repository or "",
-  tag=repository_ctx.attr.tag or "",
-))
+        registry = repository_ctx.attr.registry or "",
+        repository = repository_ctx.attr.repository or "",
+        tag = repository_ctx.attr.tag or "",
+    ))
 
 defaults = repository_rule(
     attrs = {

--- a/contrib/with-tag.bzl
+++ b/contrib/with-tag.bzl
@@ -18,10 +18,10 @@ load(
     _container_image = "container_image",
 )
 
-def container_image(name=None, tag=None, **kwargs):
-    _container_image(name=name + '-internal', **kwargs)
-    container_bundle(name=name, images={
-      tag: ':' + name + '-internal'
+def container_image(name = None, tag = None, **kwargs):
+    _container_image(name = name + "-internal", **kwargs)
+    container_bundle(name = name, images = {
+        tag: ":" + name + "-internal",
     })
 
 docker_build = container_image

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -29,10 +29,10 @@ load(
 load("@io_bazel_rules_d//d:d.bzl", "d_binary")
 
 def repositories():
-  _repositories()
+    _repositories()
 
-def d_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
-  """Constructs a container image wrapping a d_binary target.
+def d_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+    """Constructs a container image wrapping a d_binary target.
 
   Args:
     binary: An alternative binary target to use instead of generating one.
@@ -40,22 +40,29 @@ def d_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
            their own layers.
     **kwargs: See d_binary.
   """
-  if layers:
-    print("d_image does not benefit from layers=[], got: %s" % layers)
+    if layers:
+        print("d_image does not benefit from layers=[], got: %s" % layers)
 
-  if not binary:
-    binary = name + "_binary"
-    d_binary(name=binary, deps=deps + layers, **kwargs)
-  elif deps:
-    fail("kwarg does nothing when binary is specified", "deps")
+    if not binary:
+        binary = name + "_binary"
+        d_binary(name = binary, deps = deps + layers, **kwargs)
+    elif deps:
+        fail("kwarg does nothing when binary is specified", "deps")
 
-  base = base or DEFAULT_BASE
-  for index, dep in enumerate(layers):
-    this_name = "%s_%d" % (name, index)
-    dep_layer(name=this_name, base=base, dep=dep)
-    base = this_name
+    base = base or DEFAULT_BASE
+    for index, dep in enumerate(layers):
+        this_name = "%s_%d" % (name, index)
+        dep_layer(name = this_name, base = base, dep = dep)
+        base = this_name
 
-  visibility = kwargs.get('visibility', None)
-  tags = kwargs.get('tags', None)
-  app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility, tags=tags, args=kwargs.get("args"))
+    visibility = kwargs.get("visibility", None)
+    tags = kwargs.get("tags", None)
+    app_layer(
+        name = name,
+        base = base,
+        binary = binary,
+        lang_layers = layers,
+        visibility = visibility,
+        tags = tags,
+        args = kwargs.get("args"),
+    )

--- a/docker/docker.bzl
+++ b/docker/docker.bzl
@@ -28,8 +28,10 @@ load(
 )
 
 def docker_push(*args, **kwargs):
-  if "format" in kwargs:
-    fail("Cannot override 'format' attribute on docker_push",
-         attr="format")
-  kwargs["format"] = "Docker"
-  container_push(*args, **kwargs)
+    if "format" in kwargs:
+        fail(
+            "Cannot override 'format' attribute on docker_push",
+            attr = "format",
+        )
+    kwargs["format"] = "Docker"
+    container_push(*args, **kwargs)

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -36,25 +36,25 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load(":go.bzl", "DIGESTS")
 
 def repositories():
-  # Call the core "repositories" function to reduce boilerplate.
-  # This is idempotent if folks call it themselves.
-  _repositories()
+    # Call the core "repositories" function to reduce boilerplate.
+    # This is idempotent if folks call it themselves.
+    _repositories()
 
-  excludes = native.existing_rules().keys()
-  if "go_image_base" not in excludes:
-    container_pull(
-      name = "go_image_base",
-      registry = "gcr.io",
-      repository = "distroless/base",
-      digest = DIGESTS["latest"],
-    )
-  if "go_debug_image_base" not in excludes:
-    container_pull(
-      name = "go_debug_image_base",
-      registry = "gcr.io",
-      repository = "distroless/base",
-      digest = DIGESTS["debug"],
-    )
+    excludes = native.existing_rules().keys()
+    if "go_image_base" not in excludes:
+        container_pull(
+            name = "go_image_base",
+            registry = "gcr.io",
+            repository = "distroless/base",
+            digest = DIGESTS["latest"],
+        )
+    if "go_debug_image_base" not in excludes:
+        container_pull(
+            name = "go_debug_image_base",
+            registry = "gcr.io",
+            repository = "distroless/base",
+            digest = DIGESTS["debug"],
+        )
 
 DEFAULT_BASE = select({
     "@io_bazel_rules_docker//:fastbuild": "@go_image_base//image",
@@ -63,30 +63,37 @@ DEFAULT_BASE = select({
     "//conditions:default": "@go_image_base//image",
 })
 
-def go_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
-  """Constructs a container image wrapping a go_binary target.
+def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+    """Constructs a container image wrapping a go_binary target.
 
   Args:
     binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into their own layers.
     **kwargs: See go_binary.
   """
-  if layers:
-    print("go_image does not benefit from layers=[], got: %s" % layers)
+    if layers:
+        print("go_image does not benefit from layers=[], got: %s" % layers)
 
-  if not binary:
-    binary = name + ".binary"
-    go_binary(name=binary, deps=deps + layers, **kwargs)
-  elif deps:
-    fail("kwarg does nothing when binary is specified", "deps")
+    if not binary:
+        binary = name + ".binary"
+        go_binary(name = binary, deps = deps + layers, **kwargs)
+    elif deps:
+        fail("kwarg does nothing when binary is specified", "deps")
 
-  base = base or DEFAULT_BASE
-  for index, dep in enumerate(layers):
-    this_name = "%s.%d" % (name, index)
-    dep_layer(name=this_name, base=base, dep=dep)
-    base = this_name
+    base = base or DEFAULT_BASE
+    for index, dep in enumerate(layers):
+        this_name = "%s.%d" % (name, index)
+        dep_layer(name = this_name, base = base, dep = dep)
+        base = this_name
 
-  visibility = kwargs.get('visibility', None)
-  tags = kwargs.get('tags', None)
-  app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility, tags=tags, args=kwargs.get("args"))
+    visibility = kwargs.get("visibility", None)
+    tags = kwargs.get("tags", None)
+    app_layer(
+        name = name,
+        base = base,
+        binary = binary,
+        lang_layers = layers,
+        visibility = visibility,
+        tags = tags,
+        args = kwargs.get("args"),
+    )

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -35,44 +35,44 @@ load(
 )
 
 def repositories():
-  # Call the core "repositories" function to reduce boilerplate.
-  # This is idempotent if folks call it themselves.
-  _repositories()
+    # Call the core "repositories" function to reduce boilerplate.
+    # This is idempotent if folks call it themselves.
+    _repositories()
 
-  excludes = native.existing_rules().keys()
-  if "java_image_base" not in excludes:
-    container_pull(
-      name = "java_image_base",
-      registry = "gcr.io",
-      repository = "distroless/java",
-      digest = _JAVA_DIGESTS["latest"],
-    )
-  if "java_debug_image_base" not in excludes:
-    container_pull(
-      name = "java_debug_image_base",
-      registry = "gcr.io",
-      repository = "distroless/java",
-      digest = _JAVA_DIGESTS["debug"],
-    )
-  if "jetty_image_base" not in excludes:
-    container_pull(
-      name = "jetty_image_base",
-      registry = "gcr.io",
-      repository = "distroless/java/jetty",
-      digest = _JETTY_DIGESTS["latest"],
-    )
-  if "jetty_debug_image_base" not in excludes:
-    container_pull(
-      name = "jetty_debug_image_base",
-      registry = "gcr.io",
-      repository = "distroless/java/jetty",
-      digest = _JETTY_DIGESTS["debug"],
-    )
-  if "servlet_api" not in excludes:
-    native.maven_jar(
-        name = "javax_servlet_api",
-        artifact = "javax.servlet:javax.servlet-api:3.0.1",
-    )
+    excludes = native.existing_rules().keys()
+    if "java_image_base" not in excludes:
+        container_pull(
+            name = "java_image_base",
+            registry = "gcr.io",
+            repository = "distroless/java",
+            digest = _JAVA_DIGESTS["latest"],
+        )
+    if "java_debug_image_base" not in excludes:
+        container_pull(
+            name = "java_debug_image_base",
+            registry = "gcr.io",
+            repository = "distroless/java",
+            digest = _JAVA_DIGESTS["debug"],
+        )
+    if "jetty_image_base" not in excludes:
+        container_pull(
+            name = "jetty_image_base",
+            registry = "gcr.io",
+            repository = "distroless/java/jetty",
+            digest = _JETTY_DIGESTS["latest"],
+        )
+    if "jetty_debug_image_base" not in excludes:
+        container_pull(
+            name = "jetty_debug_image_base",
+            registry = "gcr.io",
+            repository = "distroless/java/jetty",
+            digest = _JETTY_DIGESTS["debug"],
+        )
+    if "servlet_api" not in excludes:
+        native.maven_jar(
+            name = "javax_servlet_api",
+            artifact = "javax.servlet:javax.servlet-api:3.0.1",
+        )
 
 DEFAULT_JAVA_BASE = select({
     "@io_bazel_rules_docker//:fastbuild": "@java_image_base//image",
@@ -94,13 +94,13 @@ load(
 )
 
 def java_files(f):
-  files = []
-  if java_common.provider in f:
-    java_provider = f[java_common.provider]
-    files += list(java_provider.transitive_runtime_jars)
-  if hasattr(f, "files"):  # a jar file
-    files += list(f.files)
-  return files
+    files = []
+    if java_common.provider in f:
+        java_provider = f[java_common.provider]
+        files += list(java_provider.transitive_runtime_jars)
+    if hasattr(f, "files"):  # a jar file
+        files += list(f.files)
+    return files
 
 load(
     "//lang:image.bzl",
@@ -109,8 +109,8 @@ load(
 )
 
 def _jar_dep_layer_impl(ctx):
-  """Appends a layer for a single dependency's runfiles."""
-  return dep_layer_impl(ctx, runfiles=java_files)
+    """Appends a layer for a single dependency's runfiles."""
+    return dep_layer_impl(ctx, runfiles = java_files)
 
 jar_dep_layer = rule(
     attrs = dict(_container.image.attrs.items() + {
@@ -136,51 +136,55 @@ jar_dep_layer = rule(
 )
 
 def _jar_app_layer_impl(ctx):
-  """Appends the app layer with all remaining runfiles."""
+    """Appends the app layer with all remaining runfiles."""
 
-  available = depset()
-  for jar in ctx.attr.jar_layers:
-    available += java_files(jar)
+    available = depset()
+    for jar in ctx.attr.jar_layers:
+        available += java_files(jar)
 
-  # We compute the set of unavailable stuff by walking deps
-  # in the same way, adding in our binary and then subtracting
-  # out what it available.
-  unavailable = depset()
-  for jar in ctx.attr.deps + ctx.attr.runtime_deps:
-    unavailable += java_files(jar)
+        # We compute the set of unavailable stuff by walking deps
+        # in the same way, adding in our binary and then subtracting
+        # out what it available.
 
-  unavailable += java_files(ctx.attr.binary)
-  unavailable = [x for x in unavailable if x not in available]
+    unavailable = depset()
+    for jar in ctx.attr.deps + ctx.attr.runtime_deps:
+        unavailable += java_files(jar)
 
-  classpath = ":".join([
-    layer_file_path(ctx, x) for x in available + unavailable
-  ])
+    unavailable += java_files(ctx.attr.binary)
+    unavailable = [x for x in unavailable if x not in available]
 
-  # Classpaths can grow long and there is a limit on the length of a
-  # command line, so mitigate this by always writing the classpath out
-  # to a file instead.
-  classpath_file = ctx.new_file(ctx.attr.name + ".classpath")
-  ctx.actions.write(classpath_file, classpath)
+    classpath = ":".join([
+        layer_file_path(ctx, x)
+        for x in available + unavailable
+    ])
 
-  binary_path = layer_file_path(ctx, ctx.files.binary[0])
-  classpath_path = layer_file_path(ctx, classpath_file)
-  entrypoint = [
-      '/usr/bin/java',
-      '-cp',
-      # Support optionally passing the classpath as a file.
-      '@' + classpath_path if ctx.attr._classpath_as_file else classpath,
-   ] + ctx.attr.jvm_flags + [ctx.attr.main_class] + ctx.attr.args
+    # Classpaths can grow long and there is a limit on the length of a
+    # command line, so mitigate this by always writing the classpath out
+    # to a file instead.
+    classpath_file = ctx.new_file(ctx.attr.name + ".classpath")
+    ctx.actions.write(classpath_file, classpath)
 
-  file_map = {
-    layer_file_path(ctx, f): f
-    for f in unavailable + [classpath_file]
-  }
+    binary_path = layer_file_path(ctx, ctx.files.binary[0])
+    classpath_path = layer_file_path(ctx, classpath_file)
+    entrypoint = [
+        "/usr/bin/java",
+        "-cp",
+        # Support optionally passing the classpath as a file.
+        "@" + classpath_path if ctx.attr._classpath_as_file else classpath,
+    ] + ctx.attr.jvm_flags + [ctx.attr.main_class] + ctx.attr.args
 
-  return _container.image.implementation(
-    ctx,
-    # We use all absolute paths.
-    directory="/", file_map=file_map,
-    entrypoint=entrypoint)
+    file_map = {
+        layer_file_path(ctx, f): f
+        for f in unavailable + [classpath_file]
+    }
+
+    return _container.image.implementation(
+        ctx,
+        # We use all absolute paths.
+        directory = "/",
+        file_map = file_map,
+        entrypoint = entrypoint,
+    )
 
 jar_app_layer = rule(
     attrs = dict(_container.image.attrs.items() + {
@@ -218,46 +222,67 @@ jar_app_layer = rule(
     implementation = _jar_app_layer_impl,
 )
 
-def java_image(name, base=None, main_class=None,
-               deps=[], runtime_deps=[], layers=[], jvm_flags=[],
-               **kwargs):
-  """Builds a container image overlaying the java_binary.
+def java_image(
+        name,
+        base = None,
+        main_class = None,
+        deps = [],
+        runtime_deps = [],
+        layers = [],
+        jvm_flags = [],
+        **kwargs):
+    """Builds a container image overlaying the java_binary.
 
   Args:
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     **kwargs: See java_binary.
   """
-  binary_name = name + ".binary"
+    binary_name = name + ".binary"
 
-  native.java_binary(name=binary_name, main_class=main_class,
-                     # If the rule is turning a JAR built with java_library into
-                     # a binary, then it will appear in runtime_deps.  We are
-                     # not allowed to pass deps (even []) if there is no srcs
-                     # kwarg.
-                     deps=(deps + layers) or None, runtime_deps=runtime_deps,
-                     jvm_flags=jvm_flags, **kwargs)
+    native.java_binary(
+        name = binary_name,
+        main_class = main_class,
+        # If the rule is turning a JAR built with java_library into
+        # a binary, then it will appear in runtime_deps.  We are
+        # not allowed to pass deps (even []) if there is no srcs
+        # kwarg.
+        deps = (deps + layers) or None,
+        runtime_deps = runtime_deps,
+        jvm_flags = jvm_flags,
+        **kwargs
+    )
 
-  base = base or DEFAULT_JAVA_BASE
-  for index, dep in enumerate(layers):
-    this_name = "%s.%d" % (name, index)
-    jar_dep_layer(name=this_name, base=base, dep=dep)
-    base = this_name
+    base = base or DEFAULT_JAVA_BASE
+    for index, dep in enumerate(layers):
+        this_name = "%s.%d" % (name, index)
+        jar_dep_layer(name = this_name, base = base, dep = dep)
+        base = this_name
 
-  visibility = kwargs.get('visibility', None)
-  jar_app_layer(name=name, base=base, binary=binary_name,
-                 main_class=main_class, jvm_flags=jvm_flags,
-                 deps=deps, runtime_deps=runtime_deps, jar_layers=layers,
-                 visibility=visibility, args=kwargs.get("args"))
+    visibility = kwargs.get("visibility", None)
+    jar_app_layer(
+        name = name,
+        base = base,
+        binary = binary_name,
+        main_class = main_class,
+        jvm_flags = jvm_flags,
+        deps = deps,
+        runtime_deps = runtime_deps,
+        jar_layers = layers,
+        visibility = visibility,
+        args = kwargs.get("args"),
+    )
 
 def _war_dep_layer_impl(ctx):
-  """Appends a layer for a single dependency's runfiles."""
-  # TODO(mattmoor): Today we run the risk of filenames colliding when
-  # they get flattened.  Instead of just flattening and using basename
-  # we should use a file_map based scheme.
-  return _container.image.implementation(
-    ctx, files=java_files(ctx.attr.dep),
-  )
+    """Appends a layer for a single dependency's runfiles."""
+
+    # TODO(mattmoor): Today we run the risk of filenames colliding when
+    # they get flattened.  Instead of just flattening and using basename
+    # we should use a file_map based scheme.
+    return _container.image.implementation(
+        ctx,
+        files = java_files(ctx.attr.dep),
+    )
 
 _war_dep_layer = rule(
     attrs = dict(_container.image.attrs.items() + {
@@ -283,23 +308,23 @@ _war_dep_layer = rule(
 )
 
 def _war_app_layer_impl(ctx):
-  """Appends the app layer with all remaining runfiles."""
+    """Appends the app layer with all remaining runfiles."""
 
-  available = depset()
-  for jar in ctx.attr.jar_layers:
-    available += java_files(jar)
+    available = depset()
+    for jar in ctx.attr.jar_layers:
+        available += java_files(jar)
 
-  # This is based on rules_appengine's WAR rules.
-  transitive_deps = depset()
-  transitive_deps += java_files(ctx.attr.library)
+        # This is based on rules_appengine's WAR rules.
+    transitive_deps = depset()
+    transitive_deps += java_files(ctx.attr.library)
 
-  # TODO(mattmoor): Handle data files.
+    # TODO(mattmoor): Handle data files.
 
-  # If we start putting libs in servlet-agnostic paths,
-  # then consider adding symlinks here.
-  files = [d for d in transitive_deps if d not in available]
+    # If we start putting libs in servlet-agnostic paths,
+    # then consider adding symlinks here.
+    files = [d for d in transitive_deps if d not in available]
 
-  return _container.image.implementation(ctx, files=files)
+    return _container.image.implementation(ctx, files = files)
 
 _war_app_layer = rule(
     attrs = dict(_container.image.attrs.items() + {
@@ -329,8 +354,8 @@ _war_app_layer = rule(
     implementation = _war_app_layer_impl,
 )
 
-def war_image(name, base=None, deps=[], layers=[], **kwargs):
-  """Builds a container image overlaying the java_library as an exploded WAR.
+def war_image(name, base = None, deps = [], layers = [], **kwargs):
+    """Builds a container image overlaying the java_library as an exploded WAR.
 
   TODO(mattmoor): For `bazel run` of this to be useful, we need to be able
   to ctrl-C it and have the container actually terminate.  More information:
@@ -341,17 +366,23 @@ def war_image(name, base=None, deps=[], layers=[], **kwargs):
            their own layers.
     **kwargs: See java_library.
   """
-  library_name = name + ".library"
+    library_name = name + ".library"
 
-  native.java_library(name=library_name, deps=deps + layers, **kwargs)
+    native.java_library(name = library_name, deps = deps + layers, **kwargs)
 
-  base = base or DEFAULT_JETTY_BASE
-  for index, dep in enumerate(layers):
-    this_name = "%s.%d" % (name, index)
-    _war_dep_layer(name=this_name, base=base, dep=dep)
-    base = this_name
+    base = base or DEFAULT_JETTY_BASE
+    for index, dep in enumerate(layers):
+        this_name = "%s.%d" % (name, index)
+        _war_dep_layer(name = this_name, base = base, dep = dep)
+        base = this_name
 
-  visibility = kwargs.get('visibility', None)
-  tags = kwargs.get('tags', None)
-  _war_app_layer(name=name, base=base, library=library_name, jar_layers=layers,
-                 visibility=visibility, tags=tags)
+    visibility = kwargs.get("visibility", None)
+    tags = kwargs.get("tags", None)
+    _war_app_layer(
+        name = name,
+        base = base,
+        library = library_name,
+        jar_layers = layers,
+        visibility = visibility,
+        tags = tags,
+    )

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -20,109 +20,117 @@ load(
 )
 
 def _binary_name(ctx):
-  # For //foo/bar/baz:blah this would translate to
-  # /app/foo/bar/baz/blah
-  return "/".join([
-      ctx.attr.directory,
-      ctx.label.package,
-      ctx.attr.binary.label.name,
-  ])
+    # For //foo/bar/baz:blah this would translate to
+    # /app/foo/bar/baz/blah
+    return "/".join([
+        ctx.attr.directory,
+        ctx.label.package,
+        ctx.attr.binary.label.name,
+    ])
 
 def _runfiles_dir(ctx):
-  # For @foo//bar/baz:blah this would translate to
-  # /app/bar/baz/blah.runfiles
-  return _binary_name(ctx) + ".runfiles"
+    # For @foo//bar/baz:blah this would translate to
+    # /app/bar/baz/blah.runfiles
+    return _binary_name(ctx) + ".runfiles"
 
-# The directory relative to which all ".short_path" paths are relative.
+    # The directory relative to which all ".short_path" paths are relative.
+
 def _reference_dir(ctx):
-  # For @foo//bar/baz:blah this would translate to
-  # /app/bar/baz/blah.runfiles/foo
-  return "/".join([_runfiles_dir(ctx), ctx.workspace_name])
+    # For @foo//bar/baz:blah this would translate to
+    # /app/bar/baz/blah.runfiles/foo
+    return "/".join([_runfiles_dir(ctx), ctx.workspace_name])
 
-# The special "external" directory which is an alternate way of accessing
-# other repositories.
+    # The special "external" directory which is an alternate way of accessing
+    # other repositories.
+
 def _external_dir(ctx):
-  # For @foo//bar/baz:blah this would translate to
-  # /app/bar/baz/blah.runfiles/foo/external
-  return "/".join([_reference_dir(ctx), "external"])
+    # For @foo//bar/baz:blah this would translate to
+    # /app/bar/baz/blah.runfiles/foo/external
+    return "/".join([_reference_dir(ctx), "external"])
 
-# The final location that this file needs to exist for the foo_binary target to
-# properly execute.
+    # The final location that this file needs to exist for the foo_binary target to
+    # properly execute.
+
 def _final_emptyfile_path(ctx, name):
-  if not name.startswith('external/'):
-    # Names that don't start with external are relative to our own workspace.
-    return _reference_dir(ctx) + "/" + name
+    if not name.startswith("external/"):
+        # Names that don't start with external are relative to our own workspace.
+        return _reference_dir(ctx) + "/" + name
 
-  # References to workspace-external dependencies, which are identifiable
-  # because their path begins with external/, are inconsistent with the
-  # form of their File counterparts, whose ".short_form" is relative to
-  #    .../foo.runfiles/workspace-name/  (aka _reference_dir(ctx))
-  # whereas we see:
-  #    external/foreign-workspace/...
-  # so we "fix" the empty files' paths by removing "external/" and basing them
-  # directly on the runfiles path.
-  return "/".join([_runfiles_dir(ctx), name[len("external/"):]])
+        # References to workspace-external dependencies, which are identifiable
+        # because their path begins with external/, are inconsistent with the
+        # form of their File counterparts, whose ".short_form" is relative to
+        #    .../foo.runfiles/workspace-name/  (aka _reference_dir(ctx))
+        # whereas we see:
+        #    external/foreign-workspace/...
+        # so we "fix" the empty files' paths by removing "external/" and basing them
+        # directly on the runfiles path.
 
-# The final location that this file needs to exist for the foo_binary target to
-# properly execute.
+    return "/".join([_runfiles_dir(ctx), name[len("external/"):]])
+
+    # The final location that this file needs to exist for the foo_binary target to
+    # properly execute.
+
 def _final_file_path(ctx, f):
-  return "/".join([_reference_dir(ctx), f.short_path])
+    return "/".join([_reference_dir(ctx), f.short_path])
 
-# The foo_binary independent location in which we store a particular dependency's
-# file such that it can be shared.
+    # The foo_binary independent location in which we store a particular dependency's
+    # file such that it can be shared.
+
 def _layer_emptyfile_path(ctx, name):
-  if not name.startswith('external/'):
-    # Names that don't start with external are relative to our own workspace.
-    return "/".join([ctx.attr.directory, ctx.workspace_name, name])
+    if not name.startswith("external/"):
+        # Names that don't start with external are relative to our own workspace.
+        return "/".join([ctx.attr.directory, ctx.workspace_name, name])
 
-  # References to workspace-external dependencies, which are identifiable
-  # because their path begins with external/, are inconsistent with the
-  # form of their File counterparts, whose ".short_form" is relative to
-  #    .../foo.runfiles/workspace-name/  (aka _reference_dir(ctx))
-  # whereas we see:
-  #    external/foreign-workspace/...
-  # so we "fix" the empty files' paths by removing "external/" and basing them
-  # directly on the runfiles path.
-  return "/".join([ctx.attr.directory, name[len("external/"):]])
+        # References to workspace-external dependencies, which are identifiable
+        # because their path begins with external/, are inconsistent with the
+        # form of their File counterparts, whose ".short_form" is relative to
+        #    .../foo.runfiles/workspace-name/  (aka _reference_dir(ctx))
+        # whereas we see:
+        #    external/foreign-workspace/...
+        # so we "fix" the empty files' paths by removing "external/" and basing them
+        # directly on the runfiles path.
 
-# The foo_binary independent location in which we store a particular dependency's
-# file such that it can be shared.
+    return "/".join([ctx.attr.directory, name[len("external/"):]])
+
+    # The foo_binary independent location in which we store a particular dependency's
+    # file such that it can be shared.
+
 def layer_file_path(ctx, f):
-  return "/".join([ctx.attr.directory, ctx.workspace_name, f.short_path])
+    return "/".join([ctx.attr.directory, ctx.workspace_name, f.short_path])
 
 def _default_runfiles(dep):
-  return dep.default_runfiles.files
+    return dep.default_runfiles.files
 
 def _default_emptyfiles(dep):
-  return dep.default_runfiles.empty_filenames
+    return dep.default_runfiles.empty_filenames
 
-def dep_layer_impl(ctx, runfiles=None, emptyfiles=None):
-  """Appends a layer for a single dependency's runfiles."""
+def dep_layer_impl(ctx, runfiles = None, emptyfiles = None):
+    """Appends a layer for a single dependency's runfiles."""
 
-  runfiles = runfiles or _default_runfiles
-  emptyfiles = emptyfiles or _default_emptyfiles
+    runfiles = runfiles or _default_runfiles
+    emptyfiles = emptyfiles or _default_emptyfiles
 
-  filepath = layer_file_path if ctx.attr.agnostic_dep_layout else _final_file_path
-  emptyfilepath = _layer_emptyfile_path if ctx.attr.agnostic_dep_layout else _final_emptyfile_path
+    filepath = layer_file_path if ctx.attr.agnostic_dep_layout else _final_file_path
+    emptyfilepath = _layer_emptyfile_path if ctx.attr.agnostic_dep_layout else _final_emptyfile_path
 
-  return _container.image.implementation(
-    ctx,
-    # We use all absolute paths.
-    directory="/",
-    # We put the files from dependency layers into a binary-agnostic
-    # path to increase the likelihood of layer sharing across images,
-    # then we symlink them into the appropriate place in the app layer.
-    # This references the binary package because the file paths are
-    # relative to it, and normalized by the tarball package.
-    file_map={
-        filepath(ctx, f): f
-        for f in runfiles(ctx.attr.dep)
-    },
-    empty_files=[
-        emptyfilepath(ctx, empty)
-        for empty in emptyfiles(ctx.attr.dep)
-    ]
-  )
+    return _container.image.implementation(
+        ctx,
+        # We use all absolute paths.
+        directory = "/",
+        # We put the files from dependency layers into a binary-agnostic
+        # path to increase the likelihood of layer sharing across images,
+        # then we symlink them into the appropriate place in the app layer.
+        # This references the binary package because the file paths are
+        # relative to it, and normalized by the tarball package.
+        file_map = {
+            filepath(ctx, f): f
+            for f in runfiles(ctx.attr.dep)
+        },
+        empty_files = [
+            emptyfilepath(ctx, empty)
+            for empty in emptyfiles(ctx.attr.dep)
+        ],
+    )
 
 dep_layer = rule(
     attrs = dict(_container.image.attrs.items() + {
@@ -153,71 +161,72 @@ dep_layer = rule(
     implementation = dep_layer_impl,
 )
 
-def _app_layer_impl(ctx, runfiles=None, emptyfiles=None):
-  """Appends the app layer with all remaining runfiles."""
+def _app_layer_impl(ctx, runfiles = None, emptyfiles = None):
+    """Appends the app layer with all remaining runfiles."""
 
-  runfiles = runfiles or _default_runfiles
-  emptyfiles = emptyfiles or _default_emptyfiles
+    runfiles = runfiles or _default_runfiles
+    emptyfiles = emptyfiles or _default_emptyfiles
 
-  # Compute the set of runfiles that have been made available
-  # in our base image, tracking absolute paths.
-  available = {}
-  for dep in ctx.attr.lang_layers:
-    available.update({
-        _final_file_path(ctx, f): layer_file_path(ctx, f)
-        for f in runfiles(dep)
+    # Compute the set of runfiles that have been made available
+    # in our base image, tracking absolute paths.
+    available = {}
+    for dep in ctx.attr.lang_layers:
+        available.update({
+            _final_file_path(ctx, f): layer_file_path(ctx, f)
+            for f in runfiles(dep)
+        })
+        available.update({
+            _final_emptyfile_path(ctx, f): _layer_emptyfile_path(ctx, f)
+            for f in emptyfiles(dep)
+        })
+
+        # Compute the set of remaining runfiles to include into the
+        # application layer.
+
+    file_map = {
+        _final_file_path(ctx, f): f
+        for f in runfiles(ctx.attr.binary)
+        if _final_file_path(ctx, f) not in available
+    }
+
+    empty_files = [
+        _final_emptyfile_path(ctx, f)
+        for f in emptyfiles(ctx.attr.binary)
+        if _final_emptyfile_path(ctx, f) not in available
+    ]
+
+    # For each of the runfiles we aren't including directly into
+    # the application layer, link to their binary-agnostic
+    # location from the runfiles path.
+    symlinks = {}
+
+    # Include symlinks to available files if they were laid out in a
+    # binary-agnostic fashion.
+    if ctx.attr.agnostic_dep_layout:
+        symlinks.update(available)
+
+    symlinks.update({
+        # Create a symlink from our entrypoint to where it will actually be put
+        # under runfiles.
+        _binary_name(ctx): _final_file_path(ctx, ctx.executable.binary),
+        # Create a directory symlink from <workspace>/external to the runfiles
+        # root, since they may be accessed via either path.
+        _external_dir(ctx): _runfiles_dir(ctx),
     })
-    available.update({
-        _final_emptyfile_path(ctx, f): _layer_emptyfile_path(ctx, f)
-        for f in emptyfiles(dep)
-    })
 
-  # Compute the set of remaining runfiles to include into the
-  # application layer.
-  file_map = {
-    _final_file_path(ctx, f): f
-    for f in runfiles(ctx.attr.binary)
-    # It is notable that this assumes that our version of
-    # this runfile matches that of the dependency.  It is
-    # not clear at this time whether that is an invariant
-    # broadly in Bazel.
-    if _final_file_path(ctx, f) not in available
-  }
-
-  empty_files = [
-    _final_emptyfile_path(ctx, f)
-    for f in emptyfiles(ctx.attr.binary)
-    if _final_emptyfile_path(ctx, f) not in available
-  ]
-
-  # For each of the runfiles we aren't including directly into
-  # the application layer, link to their binary-agnostic
-  # location from the runfiles path.
-  symlinks = {}
-  # Include symlinks to available files if they were laid out in a
-  # binary-agnostic fashion.
-  if ctx.attr.agnostic_dep_layout:
-    symlinks.update(available)
-
-  symlinks.update({
-    # Create a symlink from our entrypoint to where it will actually be put
-    # under runfiles.
-    _binary_name(ctx): _final_file_path(ctx, ctx.executable.binary),
-    # Create a directory symlink from <workspace>/external to the runfiles
-    # root, since they may be accessed via either path.
-    _external_dir(ctx): _runfiles_dir(ctx),
-  })
-
-  return _container.image.implementation(
-    ctx,
-    # We use all absolute paths.
-    directory="/", file_map=file_map,
-    empty_files=empty_files, symlinks=symlinks,
-    # Use entrypoint so we can easily add arguments when the resulting
-    # image is `docker run ...`.
-    # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
-    # we should use the "exec" (list) form of entrypoint.
-    entrypoint=ctx.attr.entrypoint + [_binary_name(ctx)] + ctx.attr.args)
+    return _container.image.implementation(
+        ctx,
+        # We use all absolute paths.
+        directory = "/",
+        file_map = file_map,
+        empty_files = empty_files,
+        symlinks = symlinks,
+        # Use entrypoint so we can easily add arguments when the resulting
+        # image is `docker run ...`.
+        # Per: https://docs.docker.com/engine/reference/builder/#entrypoint
+        # we should use the "exec" (list) form of entrypoint.
+        entrypoint = ctx.attr.entrypoint + [_binary_name(ctx)] + ctx.attr.args,
+    )
 
 app_layer = rule(
     attrs = dict(_container.image.attrs.items() + {

--- a/oci/oci.bzl
+++ b/oci/oci.bzl
@@ -26,8 +26,10 @@ load(
 )
 
 def oci_push(*args, **kwargs):
-  if "format" in kwargs:
-    fail("Cannot override 'format' attribute on oci_push",
-         attr="format")
-  kwargs["format"] = "OCI"
-  container_push(*args, **kwargs)
+    if "format" in kwargs:
+        fail(
+            "Cannot override 'format' attribute on oci_push",
+            attr = "format",
+        )
+    kwargs["format"] = "OCI"
+    container_push(*args, **kwargs)

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -31,25 +31,25 @@ load(
 load(":python.bzl", "DIGESTS")
 
 def repositories():
-  # Call the core "repositories" function to reduce boilerplate.
-  # This is idempotent if folks call it themselves.
-  _repositories()
+    # Call the core "repositories" function to reduce boilerplate.
+    # This is idempotent if folks call it themselves.
+    _repositories()
 
-  excludes = native.existing_rules().keys()
-  if "py_image_base" not in excludes:
-    container_pull(
-      name = "py_image_base",
-      registry = "gcr.io",
-      repository = "distroless/python2.7",
-      digest = DIGESTS["latest"],
-    )
-  if "py_debug_image_base" not in excludes:
-    container_pull(
-      name = "py_debug_image_base",
-      registry = "gcr.io",
-      repository = "distroless/python2.7",
-      digest = DIGESTS["debug"],
-    )
+    excludes = native.existing_rules().keys()
+    if "py_image_base" not in excludes:
+        container_pull(
+            name = "py_image_base",
+            registry = "gcr.io",
+            repository = "distroless/python2.7",
+            digest = DIGESTS["latest"],
+        )
+    if "py_debug_image_base" not in excludes:
+        container_pull(
+            name = "py_debug_image_base",
+            registry = "gcr.io",
+            repository = "distroless/python2.7",
+            digest = DIGESTS["debug"],
+        )
 
 DEFAULT_BASE = select({
     "@io_bazel_rules_docker//:fastbuild": "@py_image_base//image",
@@ -58,33 +58,41 @@ DEFAULT_BASE = select({
     "//conditions:default": "@py_image_base//image",
 })
 
-def py_image(name, base=None, deps=[], layers=[], **kwargs):
-  """Constructs a container image wrapping a py_binary target.
+def py_image(name, base = None, deps = [], layers = [], **kwargs):
+    """Constructs a container image wrapping a py_binary target.
 
   Args:
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     **kwargs: See py_binary.
   """
-  binary_name = name + ".binary"
+    binary_name = name + ".binary"
 
-  if "main" not in kwargs:
-    kwargs["main"] = name + ".py"
+    if "main" not in kwargs:
+        kwargs["main"] = name + ".py"
 
-  # TODO(mattmoor): Consider using par_binary instead, so that
-  # a single target can be used for all three.
-  native.py_binary(name=binary_name, deps=deps + layers, **kwargs)
+        # TODO(mattmoor): Consider using par_binary instead, so that
+        # a single target can be used for all three.
 
-  # TODO(mattmoor): Consider making the directory into which the app
-  # is placed configurable.
-  base = base or DEFAULT_BASE
-  for index, dep in enumerate(layers):
-    this_name = "%s.%d" % (name, index)
-    dep_layer(name=this_name, base=base, dep=dep)
-    base = this_name
+    native.py_binary(name = binary_name, deps = deps + layers, **kwargs)
 
-  visibility = kwargs.get('visibility', None)
-  tags = kwargs.get('tags', None)
-  app_layer(name=name, base=base, entrypoint=['/usr/bin/python'],
-            binary=binary_name, lang_layers=layers, visibility=visibility,
-            tags=tags, args=kwargs.get("args"))
+    # TODO(mattmoor): Consider making the directory into which the app
+    # is placed configurable.
+    base = base or DEFAULT_BASE
+    for index, dep in enumerate(layers):
+        this_name = "%s.%d" % (name, index)
+        dep_layer(name = this_name, base = base, dep = dep)
+        base = this_name
+
+    visibility = kwargs.get("visibility", None)
+    tags = kwargs.get("tags", None)
+    app_layer(
+        name = name,
+        base = base,
+        entrypoint = ["/usr/bin/python"],
+        binary = binary_name,
+        lang_layers = layers,
+        visibility = visibility,
+        tags = tags,
+        args = kwargs.get("args"),
+    )

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -31,25 +31,25 @@ load(
 load(":python3.bzl", "DIGESTS")
 
 def repositories():
-  # Call the core "repositories" function to reduce boilerplate.
-  # This is idempotent if folks call it themselves.
-  _repositories()
+    # Call the core "repositories" function to reduce boilerplate.
+    # This is idempotent if folks call it themselves.
+    _repositories()
 
-  excludes = native.existing_rules().keys()
-  if "py3_image_base" not in excludes:
-    container_pull(
-      name = "py3_image_base",
-      registry = "gcr.io",
-      repository = "distroless/python3",
-      digest = DIGESTS["latest"],
-    )
-  if "py3_debug_image_base" not in excludes:
-    container_pull(
-      name = "py3_debug_image_base",
-      registry = "gcr.io",
-      repository = "distroless/python3",
-      digest = DIGESTS["debug"],
-    )
+    excludes = native.existing_rules().keys()
+    if "py3_image_base" not in excludes:
+        container_pull(
+            name = "py3_image_base",
+            registry = "gcr.io",
+            repository = "distroless/python3",
+            digest = DIGESTS["latest"],
+        )
+    if "py3_debug_image_base" not in excludes:
+        container_pull(
+            name = "py3_debug_image_base",
+            registry = "gcr.io",
+            repository = "distroless/python3",
+            digest = DIGESTS["debug"],
+        )
 
 DEFAULT_BASE = select({
     "@io_bazel_rules_docker//:fastbuild": "@py3_image_base//image",
@@ -58,33 +58,41 @@ DEFAULT_BASE = select({
     "//conditions:default": "@py3_image_base//image",
 })
 
-def py3_image(name, base=None, deps=[], layers=[], **kwargs):
-  """Constructs a container image wrapping a py_binary target.
+def py3_image(name, base = None, deps = [], layers = [], **kwargs):
+    """Constructs a container image wrapping a py_binary target.
 
   Args:
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     **kwargs: See py_binary.
   """
-  binary_name = name + ".binary"
+    binary_name = name + ".binary"
 
-  if "main" not in kwargs:
-    kwargs["main"] = name + ".py"
+    if "main" not in kwargs:
+        kwargs["main"] = name + ".py"
 
-  # TODO(mattmoor): Consider using par_binary instead, so that
-  # a single target can be used for all three.
-  native.py_binary(name=binary_name, deps=deps + layers, **kwargs)
+        # TODO(mattmoor): Consider using par_binary instead, so that
+        # a single target can be used for all three.
 
-  # TODO(mattmoor): Consider making the directory into which the app
-  # is placed configurable.
-  base = base or DEFAULT_BASE
-  for index, dep in enumerate(layers):
-    this_name = "%s.%d" % (name, index)
-    dep_layer(name=this_name, base=base, dep=dep)
-    base = this_name
+    native.py_binary(name = binary_name, deps = deps + layers, **kwargs)
 
-  visibility = kwargs.get('visibility', None)
-  tags = kwargs.get('tags', None)
-  app_layer(name=name, base=base, entrypoint=['/usr/bin/python'],
-            binary=binary_name, lang_layers=layers, visibility=visibility,
-            tags=tags, args=kwargs.get("args"))
+    # TODO(mattmoor): Consider making the directory into which the app
+    # is placed configurable.
+    base = base or DEFAULT_BASE
+    for index, dep in enumerate(layers):
+        this_name = "%s.%d" % (name, index)
+        dep_layer(name = this_name, base = base, dep = dep)
+        base = this_name
+
+    visibility = kwargs.get("visibility", None)
+    tags = kwargs.get("tags", None)
+    app_layer(
+        name = name,
+        base = base,
+        entrypoint = ["/usr/bin/python"],
+        binary = binary_name,
+        lang_layers = layers,
+        visibility = visibility,
+        tags = tags,
+        args = kwargs.get("args"),
+    )

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -29,10 +29,10 @@ load(
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
 
 def repositories():
-  _repositories()
+    _repositories()
 
-def rust_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
-  """Constructs a container image wrapping a rust_binary target.
+def rust_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+    """Constructs a container image wrapping a rust_binary target.
 
   Args:
     binary: An alternative binary target to use instead of generating one.
@@ -40,22 +40,29 @@ def rust_image(name, base=None, deps=[], layers=[], binary=None, **kwargs):
            their own layers.
     **kwargs: See rust_binary.
   """
-  if layers:
-    print("rust_image does not benefit from layers=[], got: %s" % layers)
+    if layers:
+        print("rust_image does not benefit from layers=[], got: %s" % layers)
 
-  if not binary:
-    binary = name + "_binary"
-    rust_binary(name=binary, deps=deps + layers, **kwargs)
-  elif deps:
-    fail("kwarg does nothing when binary is specified", "deps")
+    if not binary:
+        binary = name + "_binary"
+        rust_binary(name = binary, deps = deps + layers, **kwargs)
+    elif deps:
+        fail("kwarg does nothing when binary is specified", "deps")
 
-  base = base or DEFAULT_BASE
-  for index, dep in enumerate(layers):
-    this_name = "%s_%d" % (name, index)
-    dep_layer(name=this_name, base=base, dep=dep)
-    base = this_name
+    base = base or DEFAULT_BASE
+    for index, dep in enumerate(layers):
+        this_name = "%s_%d" % (name, index)
+        dep_layer(name = this_name, base = base, dep = dep)
+        base = this_name
 
-  visibility = kwargs.get('visibility', None)
-  tags = kwargs.get('tags', None)
-  app_layer(name=name, base=base, binary=binary, lang_layers=layers,
-            visibility=visibility, tags=tags, args=kwargs.get("args"))
+    visibility = kwargs.get("visibility", None)
+    tags = kwargs.get("tags", None)
+    app_layer(
+        name = name,
+        base = base,
+        binary = binary,
+        lang_layers = layers,
+        visibility = visibility,
+        tags = tags,
+        args = kwargs.get("args"),
+    )

--- a/scala/image.bzl
+++ b/scala/image.bzl
@@ -26,38 +26,58 @@ load(
     _repositories = "repositories",
 )
 
-def scala_image(name, base=None, main_class=None,
-                deps=[], runtime_deps=[], layers=[], jvm_flags=[],
-                **kwargs):
-  """Builds a container image overlaying the scala_binary.
+def scala_image(
+        name,
+        base = None,
+        main_class = None,
+        deps = [],
+        runtime_deps = [],
+        layers = [],
+        jvm_flags = [],
+        **kwargs):
+    """Builds a container image overlaying the scala_binary.
 
   Args:
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     **kwargs: See scala_binary.
   """
-  binary_name = name + ".binary"
+    binary_name = name + ".binary"
 
-  scala_binary(name=binary_name, main_class=main_class,
-                      # If the rule is turning a JAR built with java_library into
-                      # a binary, then it will appear in runtime_deps.  We are
-                      # not allowed to pass deps (even []) if there is no srcs
-                      # kwarg.
-                      deps=(deps + layers) or None, runtime_deps=runtime_deps,
-                      jvm_flags=jvm_flags, **kwargs)
+    scala_binary(
+        name = binary_name,
+        main_class = main_class,
+        # If the rule is turning a JAR built with java_library into
+        # a binary, then it will appear in runtime_deps.  We are
+        # not allowed to pass deps (even []) if there is no srcs
+        # kwarg.
+        deps = (deps + layers) or None,
+        runtime_deps = runtime_deps,
+        jvm_flags = jvm_flags,
+        **kwargs
+    )
 
-  base = base or DEFAULT_JAVA_BASE
-  for index, dep in enumerate(layers):
-    this_name = "%s.%d" % (name, index)
-    jar_dep_layer(name=this_name, base=base, dep=dep)
-    base = this_name
+    base = base or DEFAULT_JAVA_BASE
+    for index, dep in enumerate(layers):
+        this_name = "%s.%d" % (name, index)
+        jar_dep_layer(name = this_name, base = base, dep = dep)
+        base = this_name
 
-  visibility = kwargs.get('visibility', None)
-  tags = kwargs.get('tags', None)
-  jar_app_layer(name=name, base=base, binary=binary_name,
-                 main_class=main_class, jvm_flags=jvm_flags,
-                 deps=deps, runtime_deps=runtime_deps, jar_layers=layers,
-                 visibility=visibility, tags=tags, args=kwargs.get("args"))
+    visibility = kwargs.get("visibility", None)
+    tags = kwargs.get("tags", None)
+    jar_app_layer(
+        name = name,
+        base = base,
+        binary = binary_name,
+        main_class = main_class,
+        jvm_flags = jvm_flags,
+        deps = deps,
+        runtime_deps = runtime_deps,
+        jar_layers = layers,
+        visibility = visibility,
+        tags = tags,
+        args = kwargs.get("args"),
+    )
 
 def repositories():
-  _repositories()
+    _repositories()

--- a/skylib/label.bzl
+++ b/skylib/label.bzl
@@ -14,10 +14,10 @@
 """Rules for dealing with labels and their string form."""
 
 def string_to_label(label_list, string_list):
-  """Form a mapping from label strings to the resolved label."""
-  label_string_dict = dict()
-  for i in range(len(label_list)):
-    string = string_list[i]
-    label = label_list[i]
-    label_string_dict[string] = label
-  return label_string_dict
+    """Form a mapping from label strings to the resolved label."""
+    label_string_dict = dict()
+    for i in range(len(label_list)):
+        string = string_list[i]
+        label = label_list[i]
+        label_string_dict[string] = label
+    return label_string_dict

--- a/skylib/path.bzl
+++ b/skylib/path.bzl
@@ -14,51 +14,52 @@
 """Rules for manipulating paths."""
 
 def dirname(path):
-  """Returns the directory's name."""
-  last_sep = path.rfind("/")
-  if last_sep == -1:
-    return ""  # The artifact is at the top level.
-  return path[:last_sep]
+    """Returns the directory's name."""
+    last_sep = path.rfind("/")
+    if last_sep == -1:
+        return ""  # The artifact is at the top level.
+    return path[:last_sep]
 
 def join(directory, path):
-  """Compute the relative data path prefix from the data_path attribute."""
-  if not path:
-    return directory
-  if path[0] == "/":
-    return path[1:]
-  if directory == "/":
-    return path
-  return directory + "/" + path
+    """Compute the relative data path prefix from the data_path attribute."""
+    if not path:
+        return directory
+    if path[0] == "/":
+        return path[1:]
+    if directory == "/":
+        return path
+    return directory + "/" + path
 
 def canonicalize(path):
-  """Canonicalize the input path."""
-  if not path:
-    return path
-  # Strip ./ from the beginning if specified.
-  # There is no way to handle .// correctly (no function that would make
-  # that possible and Skylark is not turing complete) so just consider it
-  # as an absolute path. A path of / should preserve the entire
-  # path up to the repository root.
-  if path == "/":
-    return path
-  if len(path) >= 2 and path[0:2] == "./":
-    path = path[2:]
-  if not path or path == ".":  # Relative to current package
-    return ""
-  elif path[0] == "/":  # Absolute path
-    return path
-  else:  # Relative to a sub-directory
-    return path
+    """Canonicalize the input path."""
+    if not path:
+        return path
+        # Strip ./ from the beginning if specified.
+        # There is no way to handle .// correctly (no function that would make
+        # that possible and Skylark is not turing complete) so just consider it
+        # as an absolute path. A path of / should preserve the entire
+        # path up to the repository root.
+
+    if path == "/":
+        return path
+    if len(path) >= 2 and path[0:2] == "./":
+        path = path[2:]
+    if not path or path == ".":  # Relative to current package
+        return ""
+    elif path[0] == "/":  # Absolute path
+        return path
+    else:  # Relative to a sub-directory
+        return path
 
 def strip_prefix(path, prefix):
-  """Returns the path with the specified prefix removed."""
-  if path.startswith(prefix):
-    return path[len(prefix):]
-  return path
+    """Returns the path with the specified prefix removed."""
+    if path.startswith(prefix):
+        return path[len(prefix):]
+    return path
 
 def runfile(ctx, f):
-  """Return the runfiles relative path of f."""
-  if ctx.workspace_name:
-    return ctx.workspace_name + "/" + f.short_path
-  else:
-    return f.short_path
+    """Return the runfiles relative path of f."""
+    if ctx.workspace_name:
+        return ctx.workspace_name + "/" + f.short_path
+    else:
+        return f.short_path

--- a/skylib/serialize.bzl
+++ b/skylib/serialize.bzl
@@ -14,5 +14,5 @@
 """Methods for serializing objects."""
 
 def dict_to_associative_list(dict_value):
-  """Serializes a dict to an associative list."""
-  return ",".join(["%s=%s" % (k, dict_value[k]) for k in dict_value])
+    """Serializes a dict to an associative list."""
+    return ",".join(["%s=%s" % (k, dict_value[k]) for k in dict_value])

--- a/skylib/zip.bzl
+++ b/skylib/zip.bzl
@@ -14,23 +14,25 @@
 """Functions for producing the gzip of an artifact."""
 
 def gzip(ctx, artifact):
-  """Create an action to compute the gzipped artifact."""
-  out = ctx.new_file(artifact.basename + ".gz")
-  ctx.action(
-      command = 'gzip -n < %s > %s' % (artifact.path, out.path),
-      inputs = [artifact],
-      outputs = [out],
-      mnemonic = "GZIP")
-  return out
+    """Create an action to compute the gzipped artifact."""
+    out = ctx.new_file(artifact.basename + ".gz")
+    ctx.action(
+        command = "gzip -n < %s > %s" % (artifact.path, out.path),
+        inputs = [artifact],
+        outputs = [out],
+        mnemonic = "GZIP",
+    )
+    return out
 
 def gunzip(ctx, artifact):
-  """Create an action to compute the gunzipped artifact."""
-  out = ctx.new_file(artifact.basename + ".nogz")
-  ctx.action(
-      command = 'gunzip < %s > %s' % (artifact.path, out.path),
-      inputs = [artifact],
-      outputs = [out],
-      mnemonic = "GUNZIP")
-  return out
+    """Create an action to compute the gunzipped artifact."""
+    out = ctx.new_file(artifact.basename + ".nogz")
+    ctx.action(
+        command = "gunzip < %s > %s" % (artifact.path, out.path),
+        inputs = [artifact],
+        outputs = [out],
+        mnemonic = "GUNZIP",
+    )
+    return out
 
 tools = {}

--- a/testdata/utils.bzl
+++ b/testdata/utils.bzl
@@ -13,15 +13,16 @@
 # limitations under the License.
 """Utility Rules for testing"""
 
-def generate_deb(name, args=[]):
-  args_str = ""
-  if args:
-      args_str = '-a' + ' -a '.join(args)
-  native.genrule(
-    name = name,
-    outs = [name + ".deb"],
-    cmd = "$(location :gen_deb) -p {name} {args_str} -o $@".format(
-        name=name,
-        args_str=args_str),
-    tools = [":gen_deb"],
-  )
+def generate_deb(name, args = []):
+    args_str = ""
+    if args:
+        args_str = "-a" + " -a ".join(args)
+    native.genrule(
+        name = name,
+        outs = [name + ".deb"],
+        cmd = "$(location :gen_deb) -p {name} {args_str} -o $@".format(
+            name = name,
+            args_str = args_str,
+        ),
+        tools = [":gen_deb"],
+    )


### PR DESCRIPTION
Fix #397 

- The current error message, `Undefined Sort.SliceStable`, was
  introduced in Go version 1.8
  https://beta.golang.org/doc/go1.8#sort_slice

- It looks like the tusty images doesn't have go in common
  environment:
  https://docs.travis-ci.com/user/reference/trusty/#Environment-common-to-all-Trusty-images

- On the other hand, precise has go in common environment, and with
  default to 1.8.1:
  https://docs.travis-ci.com/user/reference/precise/#Environment-common-to-all-Precise-images