### PR TITLE
Update rules_nodejs to 0.9.1 and fix node target

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -153,9 +153,9 @@ d_repositories()
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "a672bbb4eb8c49363942fe9a491f35214b5d7a0000c86e0152ea8cd3261b1c12",
-    strip_prefix = "rules_nodejs-0.8.0",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.8.0.tar.gz"],
+    sha256 = "6139762b62b37c1fd171d7f22aa39566cb7dc2916f0f801d505a9aaf118c117f",
+    strip_prefix = "rules_nodejs-0.9.1",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.9.1.zip"],
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "npm_install")

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -117,13 +117,14 @@ def nodejs_image(
 
     layers = [
         # Put the Node binary into its own layer.
-        "@nodejs//:bin/node",
+        "@nodejs//:node/bin/node",
         # node_modules can get large, it should be in its own layer.
         node_modules,
     ] + layers
 
     nodejs_binary(
         name = binary_name,
+        node = "@nodejs//:node/bin/node",
         node_modules = node_modules,
         data = data + layers,
         **kwargs


### PR DESCRIPTION
This https://github.com/bazelbuild/rules_nodejs/pull/193/files#diff-09498dbadf45966909850dc8a47ebb13R30 will break this rule when it is released.

This isn't yet released with `rules_nodejs` but will be in the next release.
@gregmagolan just aheads up.