### PR TITLE
Add missing .git in subpar remote url

### DIFF
--- a/container/container.bzl
+++ b/container/container.bzl
@@ -148,7 +148,7 @@ py_library(
     if "subpar" not in excludes:
         native.git_repository(
             name = "subpar",
-            remote = "https://github.com/google/subpar",
+            remote = "https://github.com/google/subpar.git",
             commit = "7e12cc130eb8f09c8cb02c3585a91a4043753c56",
         )
 


### PR DESCRIPTION
I found an url that gives you trouble at least if you use SSH keys to clone the repositories