### PR TITLE
Fix javax_servlet_api exclusion

### DIFF
--- a/java/image.bzl
+++ b/java/image.bzl
@@ -68,7 +68,7 @@ def repositories():
             repository = "distroless/java/jetty",
             digest = _JETTY_DIGESTS["debug"],
         )
-    if "servlet_api" not in excludes:
+    if "javax_servlet_api" not in excludes:
         native.maven_jar(
             name = "javax_servlet_api",
             artifact = "javax.servlet:javax.servlet-api:3.0.1",


### PR DESCRIPTION
The guard against re-importing `javax_servlet_api` must check the actual name
it is guarding against.