### PR TITLE
Add a SHA256 for containerregistry.tar.gz

### DIFF
--- a/container/container.bzl
+++ b/container/container.bzl
@@ -86,6 +86,7 @@ def repositories():
             name = "containerregistry",
             url = ("https://github.com/google/containerregistry/archive/" +
                    CONTAINERREGISTRY_RELEASE + ".tar.gz"),
+            sha256 = "21bdca48f39e5c73b83a1b3b9ea8888d20fa4c352e8cd879b00f1d0166972928",
             strip_prefix = "containerregistry-" + CONTAINERREGISTRY_RELEASE[1:],
         )
 


### PR DESCRIPTION
This avoids the INFO: SHA256... build spam with bazel 0.14.0.

Two SHAs already have to be updated when changing
CONTAINERREGISTRY_RELEASE, so adding a third shouldn't be a problem.