### PR TITLE
Remove usages of + on dicts from .bzl files

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -369,7 +369,7 @@ _attrs = dict(_layer.attrs.items() + {
 }.items() + _hash_tools.items() + _layer_tools.items() + _zip_tools.items())
 
 _outputs = dict(_layer.outputs)
-_outputs["out"] =  "%{name}.tar"
+_outputs["out"] = "%{name}.tar"
 
 image = struct(
     attrs = _attrs,

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -368,9 +368,8 @@ _attrs = dict(_layer.attrs.items() + {
     ),
 }.items() + _hash_tools.items() + _layer_tools.items() + _zip_tools.items())
 
-_outputs = _layer.outputs + {
-    "out": "%{name}.tar",
-}
+_outputs = dict(_layer.outputs)
+_outputs["out"] =  "%{name}.tar"
 
 image = struct(
     attrs = _attrs,

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -69,7 +69,7 @@ def _dep_layer_impl(ctx):
     return dep_layer_impl(ctx, runfiles = _runfiles, emptyfiles = _emptyfiles)
 
 _dep_layer = rule(
-    attrs = _container.image.attrs + {
+    attrs = dict(_container.image.attrs.items() + {
         # The base image on which to overlay the dependency layers.
         "base": attr.label(mandatory = True),
         # The dependency whose runfiles we're appending.
@@ -91,7 +91,7 @@ _dep_layer = rule(
         # https://github.com/bazelbuild/bazel/issues/2176
         "data_path": attr.string(default = "."),
         "directory": attr.string(default = "/app"),
-    },
+    }.items()),
     executable = True,
     outputs = _container.image.outputs,
     implementation = _dep_layer_impl,


### PR DESCRIPTION
The `+` operator on dicts is deprecated and will be removed from Bazel.