### PR TITLE
Made function extract_image_id into its own script

### DIFF
--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -20,3 +20,5 @@ exports_files(["push-all.sh.tpl"])
 exports_files(["structure-test.sh.tpl"])
 
 exports_files(["compare_ids_test.sh.tpl"])
+
+exports_files(["extract_image_id.sh"])

--- a/contrib/compare_ids_test.bzl
+++ b/contrib/compare_ids_test.bzl
@@ -28,12 +28,16 @@ def _compare_ids_test_impl(ctx):
     for tar in tar_files:
         tars_string += tar.short_path + " "
 
-    runfiles = ctx.runfiles(files = tar_files)
+    runfiles = ctx.runfiles(files = tar_files + [ctx.file._id_extract_script])
 
     ctx.actions.expand_template(
         template = ctx.file._executable_template,
         output = ctx.outputs.executable,
-        substitutions = {"{id}": ctx.attr.id, "{tars}": tars_string},
+        substitutions = {
+            "{id}": ctx.attr.id,
+            "{tars}": tars_string,
+            "{id_script_path}": ctx.file._id_extract_script.short_path,
+        },
         is_executable = True,
     )
 
@@ -75,6 +79,11 @@ compare_ids_test = rule(
             allow_files = True,
             single_file = True,
             default = "compare_ids_test.sh.tpl",
+        ),
+        "_id_extract_script": attr.label(
+            allow_files = True,
+            single_file = True,
+            default = "extract_image_id.sh",
         ),
     },
 )

--- a/contrib/extract_image_id.sh
+++ b/contrib/extract_image_id.sh
@@ -12,19 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -exu
+set -eux
 
-ID={id}
+tar_path=$1
 
-for image in {tars}
+test -e $tar_path
+
+# Extracts the manifest.json file from the image's tarball
+# and finds the image id in it
+tar -xf $tar_path "manifest.json"
+i=1
+while [ true ]
 do
-  if [ ${#ID} = 0 ] # Checks if ID has been assigned yet
+  if [ $(cut -d '"' -f$i manifest.json) = "Config" ]
   then
-    ID=$({id_script_path} $image)
-  elif [ $({id_script_path} $image) != $ID ]
-  then
-    exit 1
+    image_id=$(cut -d '"' -f$(expr $i + 2) manifest.json | cut -d "." -f1)
+    break
   fi
+  i=$(expr $i + 1)
 done
-
-exit 0
+echo $image_id


### PR DESCRIPTION
Also changed the script that had that function to now use the new script instead

(This was done so that the script can be used to replace the more flaky one used in the base-image-docker repo)