### PR TITLE
 Fixed bug involving passing in invalid image tarball 

### DIFF
--- a/contrib/compare_ids_test.bzl
+++ b/contrib/compare_ids_test.bzl
@@ -15,8 +15,8 @@
 # Implementation of compare_ids_test
 def _compare_ids_test_impl(ctx):
     tar_files = []
-    for tar in ctx.attr.tars:
-        tar_files += list(tar.files)
+    for image in ctx.attr.images:
+        tar_files += list(image.files)
 
     if (len(tar_files) == 0):
         fail("No tar files provided for test.")
@@ -48,7 +48,7 @@ Test to compare ids of images in tarballs.
 Useful for testing reproducibility.
 
 Args:
-    tars: List of Labels which refer to the docker image tarballs (from docker save)
+    images: List of Labels which refer to the docker image tarballs (from docker save)
     id: (optional) the id we want the images in the tarballs to have
 
 The test passes if all images in the tarballs have the given id.
@@ -60,12 +60,12 @@ Examples of use:
 
 compare_ids_test(
     name = "test1",
-    tars = ["image1.tar", "image2.tar", "image3.tar"],
+    images = ["image1.tar", "image2.tar", "image3.tar"],
 )
 
 compare_ids_test(
     name = "test2",
-    tars = ["image.tar"],
+    images = ["image.tar"],
     id = "<my_image_sha256>",
 )
 """
@@ -73,7 +73,7 @@ compare_ids_test = rule(
     implementation = _compare_ids_test_impl,
     test = True,
     attrs = {
-        "tars": attr.label_list(mandatory = True, allow_files = True),
+        "images": attr.label_list(mandatory = True, allow_files = True),
         "id": attr.string(mandatory = False, default = ""),
         "_executable_template": attr.label(
             allow_files = True,

--- a/contrib/compare_ids_test.sh.tpl
+++ b/contrib/compare_ids_test.sh.tpl
@@ -18,10 +18,11 @@ ID={id}
 
 for image in {tars}
 do
+  current_id=$({id_script_path} $image)
   if [ ${#ID} = 0 ] # Checks if ID has been assigned yet
   then
-    ID=$({id_script_path} $image)
-  elif [ $({id_script_path} $image) != $ID ]
+    ID=$current_id
+  elif [ $current_id != $ID ]
   then
     exit 1
   fi

--- a/contrib/extract_image_id.sh
+++ b/contrib/extract_image_id.sh
@@ -20,7 +20,11 @@ test -e $tar_path
 
 # Extracts the manifest.json file from the image's tarball
 # and finds the image id in it
-tar -xf $tar_path "manifest.json"
+if tar -xf $tar_path "manifest.json"; then :
+else
+  echo Unable to extract manifest.json, make sure $tar_path is a valid docker image. >&2
+  exit 1
+fi
 i=1
 while [ true ]
 do

--- a/tests/contrib/BUILD
+++ b/tests/contrib/BUILD
@@ -46,7 +46,7 @@ alias(
 
 compare_ids_test(
     name = "test_compare_ids_test",
-    tars = [
+    images = [
         ":duplicate1",
         ":duplicate2",
     ],
@@ -55,5 +55,5 @@ compare_ids_test(
 compare_ids_test(
     name = "test_id_compare_ids_test",
     id = "d86477c0011ee23ba00c9d2ffce09d15a0a9282e9af1f54309ecbb7b2c6736cc",
-    tars = ["@distroless_fixed_id//image"],
+    images = ["@distroless_fixed_id//image"],
 )


### PR DESCRIPTION
Passing an invalid tarball into compare_ids_test would give a false
passing test. Added fix for this as well as a message to stderr which clearly
states that there was an issue extracting a manifest.json, and to make
sure the tarball is a valid image tarball.

Also changed compare_ids_test attr 'tars' to 'images' for clarity
(This will break the usage of the rule in our private repo and base-images-docker. I will fix this.)