### PR TITLE
Support control.tar with xz or gzip compression

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -369,6 +369,7 @@ _attrs = dict(_layer.attrs.items() + {
 }.items() + _hash_tools.items() + _layer_tools.items() + _zip_tools.items())
 
 _outputs = dict(_layer.outputs)
+
 _outputs["out"] = "%{name}.tar"
 
 image = struct(

--- a/contrib/compare_ids_test.bzl
+++ b/contrib/compare_ids_test.bzl
@@ -69,12 +69,17 @@ compare_ids_test(
     id = "<my_image_sha256>",
 )
 """
+
 compare_ids_test = rule(
-    implementation = _compare_ids_test_impl,
-    test = True,
     attrs = {
-        "images": attr.label_list(mandatory = True, allow_files = True),
-        "id": attr.string(mandatory = False, default = ""),
+        "images": attr.label_list(
+            mandatory = True,
+            allow_files = True,
+        ),
+        "id": attr.string(
+            mandatory = False,
+            default = "",
+        ),
         "_executable_template": attr.label(
             allow_files = True,
             single_file = True,
@@ -86,4 +91,6 @@ compare_ids_test = rule(
             default = "extract_image_id.sh",
         ),
     },
+    test = True,
+    implementation = _compare_ids_test_impl,
 )

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -916,10 +916,10 @@ generate_deb(
 
 generate_deb(
     name = "pkg_control_gz",
-    metadata_compression_type = "gzip"
+    metadata_compression_type = "gzip",
 )
 
 generate_deb(
     name = "pkg_control_xz",
-    metadata_compression_type = "xz"
+    metadata_compression_type = "xz",
 )

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -913,3 +913,13 @@ generate_deb(
 generate_deb(
     name = "pkg2",
 )
+
+generate_deb(
+    name = "pkg_control_gz",
+    metadata_compression_type = "gzip"
+)
+
+generate_deb(
+    name = "pkg_control_xz",
+    metadata_compression_type = "xz"
+)

--- a/testdata/gen_deb.py
+++ b/testdata/gen_deb.py
@@ -12,41 +12,90 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """A simple cross-platform helper to create a dummy debian package."""
+from __future__ import print_function, unicode_literals
 import argparse
-from StringIO import StringIO
-import sys
+import gzip
+from io import BytesIO
 import tarfile
 
 
-def AddArFileEntry(fileobj, filename, content=''):
+def AddArFileEntry(fileobj, filename, content=b''):
   """Add a AR file entry to fileobj."""
-  fileobj.write((filename + '/').ljust(16))    # filename (SysV)
-  fileobj.write('0'.ljust(12))                 # timestamp
-  fileobj.write('0'.ljust(6))                  # owner id
-  fileobj.write('0'.ljust(6))                  # group id
-  fileobj.write('0644'.ljust(8))               # mode
-  fileobj.write(str(len(content)).ljust(10))   # size
-  fileobj.write('\x60\x0a')                    # end of file entry
+  def write_utf8(f, t):
+      f.write(t.encode('utf-8'))
+
+  write_utf8(fileobj, (filename + '/').ljust(16))    # filename (SysV)
+  write_utf8(fileobj, '0'.ljust(12))                 # timestamp
+  write_utf8(fileobj, '0'.ljust(6))                  # owner id
+  write_utf8(fileobj, '0'.ljust(6))                  # group id
+  write_utf8(fileobj, '0644'.ljust(8))               # mode
+  write_utf8(fileobj, str(len(content)).ljust(10))   # size
+  fileobj.write(b'\x60\x0a')                    # end of file entry
   fileobj.write(content)
   if len(content) % 2 != 0:
-    fileobj.write('\n')  # 2-byte alignment padding
+    write_utf8(fileobj, '\n')  # 2-byte alignment padding
 
 
-def add_file_to_tar(tar, filename, content):
+def add_file_to_tar(tar, filename, content, compression='none'):
    tarinfo = tarfile.TarInfo(filename)
    tarinfo.size = len(content)
-   tar.addfile(tarinfo, fileobj=StringIO(content))
+   tar.addfile(tarinfo, fileobj=BytesIO(content))
 
 
-def get_metadata(pkg_name, content=[]):
+def get_metadata(pkg_name, content=None):
   if content:
-     return '\n'.join(content)
+     return '\n'.join(content).encode()
   else:
      return '\n'.join([
          'Package: {0}'.format(pkg_name),
          'Description: Just a dummy description for dummy package {0}'.format(
              pkg_name),
-     ])
+     ]).encode()
+
+
+def extension_for_compression(compression_type):
+    if compression_type == 'gzip':
+        return '.gz'
+    elif compression_type == 'xz':
+        return '.xz'
+    elif compression_type == 'none':
+        return ''
+    else:
+        return ValueError('Invalid value {0} for compression type'.format(compression_type))
+
+
+def _compress_gzip(data):
+    compressed_data = BytesIO()
+    with gzip.GzipFile(fileobj=compressed_data, mode='wb', mtime=0) as f:
+        f.write(data)
+    return compressed_data.getvalue()
+
+
+def _compress_xz(data):
+    try:
+        import lzma
+        return lzma.compress(data)
+    except ImportError:
+        import subprocess
+        if subprocess.call('which xz', shell=True, stdout=subprocess.PIPE):
+            raise RuntimeError('Cannot handle .xz compression: xz not found.')
+        xz_proc = subprocess.Popen(
+            ['xz', '--compress', '--stdout'],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE)
+        return xz_proc.communicate(data)[0]
+
+
+def compress_data(data, compression_type):
+    if compression_type == 'none':
+      return data
+    if compression_type == 'gzip':
+        return _compress_gzip(data)
+    elif compression_type == 'xz':
+        return _compress_xz(data)
+    else:
+        return ValueError('Invalid value {0} for compression type'.format(compression_type))
+
 
 parser = argparse.ArgumentParser()
 
@@ -59,30 +108,37 @@ parser.add_argument('-a', action='append', dest='metadata',
 parser.add_argument('-o', action='store', dest='outdir',
                     help='Destination dir')
 
+parser.add_argument('--metadata_compression', action='store',
+                    choices=['none', 'gzip', 'xz'], default='none',
+                    help='Compression for control.tar')
+
 if __name__ == '__main__':
   args = parser.parse_args()
 
   # Create data.tar
-  tar = StringIO()
+  tar = BytesIO()
   with tarfile.open('data.tar', mode='w', fileobj=tar) as f:
     tarinfo = tarfile.TarInfo('usr/')
     tarinfo.type = tarfile.DIRTYPE
     f.addfile(tarinfo)
-    add_file_to_tar(f, 'usr/{0}'.format(args.pkg_name), 'toto\n')
+    add_file_to_tar(f, 'usr/{0}'.format(args.pkg_name), 'toto\n'.encode())
   data = tar.getvalue()
   tar.close()
+
   # Create control.tar
-  tar = StringIO()
-  with tarfile.open('control.tar', mode='w', fileobj=tar) as f:
+  tar = BytesIO()
+  metadata_filename = 'control.tar' + extension_for_compression(args.metadata_compression)
+  with tarfile.open(metadata_filename, mode='w', fileobj=tar) as f:
     metadata_content = get_metadata(pkg_name=args.pkg_name,
                                     content=args.metadata)
-    add_file_to_tar(f, 'control', metadata_content)
-  control = tar.getvalue()
+    add_file_to_tar(f, 'control', metadata_content,
+                    compression=args.metadata_compression)
+  control = compress_data(tar.getvalue(), args.metadata_compression)
   tar.close()
 
   # Write the final AR archive (the deb package)
-  with open(args.outdir, 'w') as f:
-    f.write('!<arch>\n')  # Magic AR header
-    AddArFileEntry(f, 'debian-binary', '2.0')
-    AddArFileEntry(f, 'control.tar', control)
+  with open(args.outdir, 'wb') as f:
+    f.write('!<arch>\n'.encode())  # Magic AR header
+    AddArFileEntry(f, 'debian-binary', '2.0'.encode())
+    AddArFileEntry(f, metadata_filename, control)
     AddArFileEntry(f, 'data.tar', data)

--- a/testdata/utils.bzl
+++ b/testdata/utils.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Utility Rules for testing"""
 
-def generate_deb(name, args = [], metadata_compression_type='none'):
+def generate_deb(name, args = [], metadata_compression_type = "none"):
     args_str = "--metadata_compression " + metadata_compression_type
     if args:
         args_str = " -a" + " -a ".join(args)

--- a/testdata/utils.bzl
+++ b/testdata/utils.bzl
@@ -13,10 +13,10 @@
 # limitations under the License.
 """Utility Rules for testing"""
 
-def generate_deb(name, args = []):
-    args_str = ""
+def generate_deb(name, args = [], metadata_compression_type='none'):
+    args_str = "--metadata_compression " + metadata_compression_type
     if args:
-        args_str = "-a" + " -a ".join(args)
+        args_str = " -a" + " -a ".join(args)
     native.genrule(
         name = name,
         outs = [name + ".deb"],

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -27,6 +27,8 @@ container_image(
     debs = [
         "//testdata:pkg1.deb",
         "//testdata:pkg2.deb",
+        "//testdata:pkg_control_gz.deb",
+        "//testdata:pkg_control_xz.deb",
         # TODO: (tejaldesai) Once we figure out how to selectively disable tests using build_tag_filters
         # ":busybox-static_ubuntu1_amd64.deb",
     ],

--- a/tests/docker/configs/deb_image_with_dpkgs.yaml
+++ b/tests/docker/configs/deb_image_with_dpkgs.yaml
@@ -4,42 +4,72 @@ fileExistenceTests:
   path: '/var/lib/dpkg/status.d/pkg1'
   shouldExist: true
   permissions: '-rw-r--r--'
+
+- name: 'pkg1 package files'
+  path: '/usr/pkg1'
+  shouldExist: true
+  permissions: '-rw-r--r--'
+
+- name: 'Dpkg status file for Pkg2'
+  path: '/var/lib/dpkg/status.d/pkg2'
+  shouldExist: true
+  permissions: '-rw-r--r--'
+
+- name: 'pkg2 package files'
+  path: '/usr/pkg2'
+  shouldExist: true
+  permissions: '-rw-r--r--'
+
+- name: 'dpkg status file for pkg_control_gz'
+  path: '/var/lib/dpkg/status.d/pkg_control_gz'
+  shouldExist: true
+  permissions: '-rw-r--r--'
+
+- name: 'pkg_control_gz package files'
+  path: '/usr/pkg_control_gz'
+  shouldExist: true
+  permissions: '-rw-r--r--'
+
+- name: 'dpkg status file for pkg_control_xz'
+  path: '/var/lib/dpkg/status.d/pkg_control_xz'
+  shouldExist: true
+  permissions: '-rw-r--r--'
+
+- name: 'pkg_control_xz package files'
+  path: '/usr/pkg_control_xz'
+  shouldExist: true
+  permissions: '-rw-r--r--'
+
 fileContentTests:
 - name: 'Dpkg status file for Pkg1 contents'
   expectedContents: ['Package: pkg1',
                      'Description:.*pkg1.*']
   path: '/var/lib/dpkg/status.d/pkg1'
-fileExistenceTests:
-- name: 'pkg1 package files'
-  path: '/usr/pkg1'
-  shouldExist: true
-  permissions: '-rw-r--r--'
-fileContentTests:
+
 - name: 'pkg1 package files contents'
   expectedContents: ['toto.*']
-  path: '/usr'
-fileExistenceTests:
-- name: 'Dpkg status file for Pkg2'
-  path: '/var/lib/dpkg/status.d/pkg2'
-  shouldExist: true
-  permissions: '-rw-r--r--'
-fileContentTests:
+  path: '/usr/pkg1'
+
 - name: 'Dpkg status file for Pkg2 contents'
   expectedContents: ['Package: pkg2',
                      'Description:.*pkg2.*']
   path: '/var/lib/dpkg/status.d/pkg2'
-fileExistenceTests:
-- name: 'pkg2 package files'
-  path: '/usr/pkg2'
-  shouldExist: true
-  permissions: '-rw-r--r--'
-fileContentTests:
+
 - name: 'pkg2 package files contents'
   expectedContents: ['toto.*']
   path: '/usr/pkg2'
 
+- name: 'Dpkg status file for pkg_control_gz contents'
+  expectedContents: ['Package: pkg_control_gz',
+                     'Description:.*pkg_control_gz.*']
+  path: '/var/lib/dpkg/status.d/pkg_control_gz'
+
+- name: 'Dpkg status file for pkg_control_xz contents'
+  expectedContents: ['Package: pkg_control_xz',
+                     'Description:.*pkg_control_xz.*']
+  path: '/var/lib/dpkg/status.d/pkg_control_xz'
+
 # TODO: (tejaldesai) Bring this test back in when we can figure out disabling tests
-#fileContentTests:
 #- name: 'Dpkg status file for busybox'
 #  expectedContents: ['Package: busybox-static',
 #                     'Version: 1:1.22.0-15ubuntu1']


### PR DESCRIPTION
Fixes #386.

When run with Python 3, this will prefer the built-in `lzma` module to extract xz-compressed tarfiles in the `.deb`. Similar to the behavior of `tools.build_defs.pkg.archive` for compatibility with Python 2, this will use `xzcat` (technically with `xz` and specific flags so it behaves as `xzcat`).

I've tested this with `.deb` files with `control.tar.gz` and `control.tar.xz` from stretch and buster, under Python 2.7 and 3.6.