### PR TITLE
Update structure test pin.

### DIFF
--- a/container/container.bzl
+++ b/container/container.bzl
@@ -30,8 +30,8 @@ container = struct(
 CONTAINERREGISTRY_RELEASE = "v0.0.27"
 
 # The release of the container-structure-test repository to use.
-# Updated on June 8, 2018.
-STRUCTURE_TEST_COMMIT = "2cf1a517baea7d6705619f6acab580ce01d3489d"
+# Updated on June 27, 2018.
+STRUCTURE_TEST_COMMIT = "439a22aa83c758fe0abc78dde5612de446aeb457"
 
 _local_tool_build_template = """
 sh_binary(

--- a/tests/docker/configs/test.yaml
+++ b/tests/docker/configs/test.yaml
@@ -1,11 +1,11 @@
 schemaVersion: 2.0.0
 
 fileExistenceTests:
-  - name: foo
+  - name: "foo"
     path: "/foo"
     shouldExist: true
 
 fileContentTests:
-  - name: foo
+  - name: "foo"
     path: "/foo"
-    expectedContents: "asdf$"
+    expectedContents: ["asdf$"]


### PR DESCRIPTION
This fix the container_test giving false negative test results issue.

For more context, please see
https://github.com/GoogleContainerTools/container-structure-test/issues/146