### PR TITLE
Update structure test pin.

### DIFF
--- a/container/container.bzl
+++ b/container/container.bzl
@@ -30,8 +30,8 @@ container = struct(
 CONTAINERREGISTRY_RELEASE = "v0.0.27"
 
 # The release of the container-structure-test repository to use.
-# Updated on June 27, 2018.
-STRUCTURE_TEST_COMMIT = "10895cbf60e8c7bc8940652da65ffc4630c52b42"
+# Updated on June 29, 2018.
+STRUCTURE_TEST_COMMIT = "5714a926044ab8b0f947ba031f56da3698d954d2"
 
 _local_tool_build_template = """
 sh_binary(


### PR DESCRIPTION
This includes fix in
https://github.com/GoogleContainerTools/container-structure-test/commit/5714a926044ab8b0f947ba031f56da3698d954d2.