### PR TITLE
Remove unnecessary imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,10 +445,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_go/archive/{HEAD}.tar.gz"],
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
-
-go_repositories()
-
 load(
     "@io_bazel_rules_docker//go:image.bzl",
     _go_image_repos = "repositories",


### PR DESCRIPTION
Importing `go_repositories()` appears to be no longer necessary for using the `go_image` rule and, in fact, produces an error.