### PR TITLE
Image digest output for container_image rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1209,6 +1209,16 @@ container_image(name, base, data_path, directory, files, legacy_repository_namin
       </td>
     </tr>
     <tr>
+      <td><code><i>name</i>.digest</code></td>
+      <td>
+        <code>The full Docker image's digest</code>
+        <p>
+            An image digest that can be used to refer to that image. Unlike tags,
+            digest references are immutable i.e. always refer to the same content.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code><i>name</i>-layer.tar</code></td>
       <td>
         <code>An image of the current layer</code>

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -32,7 +32,7 @@ container = struct(
 )
 
 # The release of the github.com/google/containerregistry to consume.
-CONTAINERREGISTRY_RELEASE = "v0.0.31"
+CONTAINERREGISTRY_RELEASE = "v0.0.32"
 
 _local_tool_build_template = """
 sh_binary(
@@ -69,7 +69,7 @@ def repositories():
             name = "puller",
             urls = [("https://storage.googleapis.com/containerregistry-releases/" +
                      CONTAINERREGISTRY_RELEASE + "/puller.par")],
-            sha256 = "f4971a9127d6f3df16d820f84e78d7816b1c49be13d8d6d0176f80234c082814",
+            sha256 = "0aea6c53809846009f42f07eb569d8b3bfa79c073b16fe97312d592f45016924",
             executable = True,
         )
 
@@ -78,7 +78,7 @@ def repositories():
             name = "importer",
             urls = [("https://storage.googleapis.com/containerregistry-releases/" +
                      CONTAINERREGISTRY_RELEASE + "/importer.par")],
-            sha256 = "ca8644c21f2eb99b4e14d9966fe1e31c8baf5d7e277526c2a216955ee858cfd6",
+            sha256 = "52dd0628fe13c698772d982279db443e70585cb9912e2825e58a88eac6e0ca8c",
             executable = True,
         )
 
@@ -87,7 +87,7 @@ def repositories():
             name = "containerregistry",
             urls = [("https://github.com/google/containerregistry/archive/" +
                      CONTAINERREGISTRY_RELEASE + ".tar.gz")],
-            sha256 = "54a0caf9ad3c0bfd832d454cba40e277be1febcf9b135d889e93af4c643b1660",
+            sha256 = "48408e0d1861c47aac88d06efda089c46bfb3265bf3a51081853963460fbcb49",
             strip_prefix = "containerregistry-" + CONTAINERREGISTRY_RELEASE[1:],
         )
 

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -15,6 +15,10 @@ package(default_visibility = ["//visibility:public"])
 
 load("//container:container.bzl", "container_image", "container_import")
 load("//contrib:test.bzl", "container_test")
+load(
+    "@bazel_tools//tools/build_rules:test_rules.bzl",
+    "file_test",
+)
 
 container_test(
     name = "structure_test",
@@ -159,4 +163,16 @@ container_test(
     configs = ["//tests/docker/configs:windows_image.yaml"],
     driver = "tar",
     image = ":basic_windows_image",
+)
+
+file_test(
+    name = "test_digest_output1",
+    content = "sha256:fd90e88f1c5dfedf89df4469747ada0a28d7c34196bb2ac879cff6f259f65ba5",
+    file = ":deb_image_with_dpkgs.digest",
+)
+
+file_test(
+    name = "test_digest_output2",
+    content = "sha256:acff18cc59851acc448c0f106ccefdd13907a91835d61b8b34f85a974a2e540a",
+    file = ":null_cmd_and_entrypoint_none.digest",
 )


### PR DESCRIPTION
This PR adds an additional predeclared output to the `container_image` rule which contains image digest of that image.

This PR depends on https://github.com/google/containerregistry/pull/87 and needs to be updated with a version of containerregistry that contains those changes.

Fixes #271.

```bzl
go_binary(
    name = "smith",
    embed = [":go_default_library"],
    pure = "on",
    visibility = ["//visibility:public"],
)

container_push(
    name = "smith.push_docker",
    format = "Docker",
    image = ":smith",
    registry = ...,
    repository = ...,
    stamp = True,
    tag = ...,
)
```
```console
$ bazel build  --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64  //cmd/smith:container.digest
INFO: Analysed target //cmd/smith:container.digest (0 packages loaded).
INFO: Found 1 target...
Target //cmd/smith:container.digest up-to-date:
  bazel-bin/cmd/smith/container.digest
INFO: Elapsed time: 1.026s, Critical Path: 0.61s
INFO: 1 process: 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions

$ cat bazel-bin/cmd/smith/container.digest
sha256:73122a2d81d57895f5740efa9030c25045a9a797cd118c8f9867c8de02d57425

$ bazel run  --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64  //cmd/smith:smith.push_docker
INFO: Analysed target //cmd/smith:smith.push_docker (1 packages loaded).
INFO: Found 1 target...
Target //cmd/smith:smith.push_docker up-to-date:
  bazel-bin/cmd/smith/smith.push_docker
INFO: Elapsed time: 0.538s, Critical Path: 0.19s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
<bla-bla-bla-stamping> was resolved to <bla-bla-bla-stamping>/smith:e4cd67ec0-6ebc8057e7619aba8e3c63f4392f1e44
<bla-bla-bla-stamping>/smith:e4cd67ec0-6ebc8057e7619aba8e3c63f4392f1e44 was published with digest: sha256:73122a2d81d57895f5740efa9030c25045a9a797cd118c8f9867c8de02d57425
```