### PR TITLE
Changed name of a function

### DIFF
--- a/container/image_test.py
+++ b/container/image_test.py
@@ -619,7 +619,7 @@ class ImageTest(unittest.TestCase):
         'arg0',
         'arg1'])
 
-  def test_go_image_args(self):
+  def test_rust_image_args(self):
     with TestImage('rust_image') as img:
       self.assertConfigEqual(img, 'Entrypoint', [
         '/app/testdata/rust_image_binary',


### PR DESCRIPTION
Two python functions had the same name, so one was overriding the other. Probably a copy/paste error.