### PR TITLE
Update container_structure_test to 1.4.0 release.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -127,9 +127,9 @@ groovy_repositories()
 # For our go_image test.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "6dcc2cb319da10d33a810f4b330896de9beebbdd3d3392f6a19cf32bcc1b908d",
-    strip_prefix = "rules_go-0.12.0",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/0.12.0.tar.gz"],
+    sha256 = "50207a04b74fe30218b06ac4467ea3862b9a3c99d3df7686be0eae02108ea06f",
+    strip_prefix = "rules_go-0.13.0",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/0.13.0.tar.gz"],
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -21,6 +21,7 @@ load("//container:import.bzl", "container_import")
 load("//container:load.bzl", "container_load")
 load("//container:pull.bzl", "container_pull")
 load("//container:push.bzl", "container_push")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 container = struct(
     image = image,
@@ -28,10 +29,6 @@ container = struct(
 
 # The release of the github.com/google/containerregistry to consume.
 CONTAINERREGISTRY_RELEASE = "v0.0.28"
-
-# The release of the container-structure-test repository to use.
-# Updated on June 29, 2018.
-STRUCTURE_TEST_COMMIT = "5714a926044ab8b0f947ba031f56da3698d954d2"
 
 _local_tool_build_template = """
 sh_binary(
@@ -180,24 +177,20 @@ py_library(
             commit = "7e12cc130eb8f09c8cb02c3585a91a4043753c56",
         )
 
-    if "structure_test" not in excludes:
-        native.git_repository(
-            name = "structure_test",
-            remote = "https://github.com/GoogleContainerTools/container-structure-test.git",
-            commit = STRUCTURE_TEST_COMMIT,
+    if "structure_test_linux" not in excludes:
+        http_file(
+            name = "structure_test_linux",
+            executable = True,
+            sha256 = "543577685b33f0483bd4df72534ac9f84c17c9315d8afdcc536cce3591bb8f7c",
+            urls = ["https://storage.googleapis.com/container-structure-test/v1.4.0/container-structure-test-linux-amd64"],
         )
-        native.git_repository(
-            name = "runtimes_common",
-            commit = "9828ee5659320cebbfd8d34707c36648ca087888",
-            remote = "https://github.com/GoogleCloudPlatform/runtimes-common.git",
-        )
-        native.new_http_archive(
-            name = "docker_credential_gcr",
-            build_file_content = """package(default_visibility = ["//visibility:public"])
-exports_files(["docker-credential-gcr"])""",
-            sha256 = "3f02de988d69dc9c8d242b02cc10d4beb6bab151e31d63cb6af09dd604f75fce",
-            type = "tar.gz",
-            url = "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v1.4.3/docker-credential-gcr_linux_amd64-1.4.3.tar.gz",
+
+    if "structure_test_darwin" not in excludes:
+        http_file(
+            name = "structure_test_darwin",
+            executable = True,
+            sha256 = "c1bc8664d411c6df23c002b41ab1b9a3d72ae930f194a997468bfae2f54ca751",
+            urls = ["https://storage.googleapis.com/container-structure-test/v1.4.0/container-structure-test-darwin-amd64"],
         )
 
     # For skylark_library.

--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -24,3 +24,12 @@ exports_files(["compare_ids_test.sh.tpl"])
 exports_files(["compare_ids_test.bzl"])
 
 exports_files(["extract_image_id.sh"])
+
+alias(
+    name = "structure_test_executable",
+    actual = select({
+        "@bazel_tools//src/conditions:darwin": "@structure_test_darwin//file",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@structure_test_darwin//file",
+        "//conditions:default": "@structure_test_linux//file",
+    }),
+)

--- a/contrib/test.bzl
+++ b/contrib/test.bzl
@@ -97,7 +97,7 @@ _container_test = rule(
             ],
         ),
         "_structure_test": attr.label(
-            default = Label("@structure_test//:container_structure_test"),
+            default = Label("//contrib:structure_test_executable"),
             cfg = "target",
             executable = True,
             allow_files = True,


### PR DESCRIPTION
This reverts commit 7be17569de00477c2fcaae8f0e64371ebcd6fa58 and uses container structure test 1.4.0.