### PR TITLE
Add ports option to go_image rule

### DIFF
--- a/go/image.bzl
+++ b/go/image.bzl
@@ -97,4 +97,5 @@ def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        ports = kwargs.get("ports"),
     )

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -260,6 +260,7 @@ app_layer = rule(
         "directory": attr.string(default = "/app"),
         "legacy_run_behavior": attr.bool(default = False),
         "data": attr.label_list(allow_files = True),
+        "ports": attr.string_list(default = []),
     }.items()),
     executable = True,
     outputs = _container.image.outputs,


### PR DESCRIPTION
We've been creating a docker image from a go application which exposes a network port for other services to communicate with it. Unfortunately it looks like the current go_image rule does not support exposed port data, so I've added it in.