### PR TITLE
Use lzma to decompress .tar.xz debian files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ install: true
 services:
   - docker
 
-before_install:
-  - sudo apt-get install liblzma-dev
-  - sudo pip install backports.lzma
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ install: true
 services:
   - docker
 
+before_install:
+  - sudo apt-get install liblzma-dev
+  - sudo pip install backports.lzma
 addons:
   apt:
     sources:

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -23,7 +23,6 @@ import sys
 import re
 import tarfile
 import tempfile
-import warnings
 
 from tools.build_defs.pkg import archive
 from third_party.py import gflags

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -272,17 +272,7 @@ class TarFile(object):
         parts = current.filename.split(".")
         name = parts[0]
         if parts[-1].lower() == 'xz':
-          try:
-            import lzma
-          except ImportError:
-            try:
-              from backports import lzma
-            except ImportError:
-              raise self.DebError(
-                "You are trying to build package {deb} from a .xz file "
-                "without lzma installed".format(deb=deb)
-              )
-          current.data = lzma.decompress(current.data)
+          current.data = self._xz_decompress(current.data)
           ext = '.'.join(parts[1:-1])
         else:
             ext = '.'.join(parts[1:])
@@ -321,7 +311,11 @@ class TarFile(object):
       import lzma
       decompress = lzma.decompress
     except ImportError:
-      decompress = self._xzcat_decompress
+      try:
+        from backports import lzma
+        decompress = lzma.decompress
+      except ImportError:
+        decompress = self._xzcat_decompress
     return decompress(data)
 
 

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -28,6 +28,7 @@ import warnings
 from tools.build_defs.pkg import archive
 from third_party.py import gflags
 
+lzma = None
 try:
   import lzma
 except ImportError:
@@ -38,7 +39,6 @@ except ImportError:
       "Could not find the lzma module. Building from XZ compressed tar files"
       " will fail."
     )
-    lzma = None
 
 gflags.DEFINE_string('output', None, 'The output file, mandatory')
 gflags.MarkFlagAsRequired('output')

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -248,6 +248,7 @@ class TarFile(object):
     except (KeyError, TypeError) as e:
       raise self.DebError(deb + ' contains invalid Metadata! Exeception {0}'.format(e))
     except Exception as e:
+      print("Exception dealing with file {}, {}".format(metadata_tar, deb))
       raise self.DebError('Unknown Exception {0}. Please report an issue at'
                           ' github.com/bazelbuild/rules_docker.'.format(e))
 

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -27,6 +27,11 @@ import tempfile
 from tools.build_defs.pkg import archive
 from third_party.py import gflags
 
+try:
+    import lzma
+except ImportError:
+    from backports import lzma
+
 gflags.DEFINE_string('output', None, 'The output file, mandatory')
 gflags.MarkFlagAsRequired('output')
 
@@ -272,7 +277,11 @@ class TarFile(object):
       while current:
         parts = current.filename.split(".")
         name = parts[0]
-        ext = '.'.join(parts[1:])
+        if parts[-1] == 'xz':
+          current.data = lzma.decompress(current.data)
+          ext = '.'.join(parts[1:-1])
+        else:
+            ext = '.'.join(parts[1:])
         if name == 'data':
           pkg_data_found = True
           # Add pkg_data to image tar

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -248,7 +248,6 @@ class TarFile(object):
     except (KeyError, TypeError) as e:
       raise self.DebError(deb + ' contains invalid Metadata! Exeception {0}'.format(e))
     except Exception as e:
-      print("Exception dealing with file {}, {}".format(metadata_tar, deb))
       raise self.DebError('Unknown Exception {0}. Please report an issue at'
                           ' github.com/bazelbuild/rules_docker.'.format(e))
 

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -281,7 +281,7 @@ class TarFile(object):
             except ImportError:
               raise self.DebError(
                 "You are trying to build package {deb} from a .xz file "
-                "without lzma installed".fromat(deb=deb)
+                "without lzma installed".format(deb=deb)
               )
           current.data = lzma.decompress(current.data)
           ext = '.'.join(parts[1:-1])


### PR DESCRIPTION
Recent debian packages from sid can come XZ compressed. This lets you use lzma to build these .debs if it is installed and gives a helpful error message if it isn't.