### PR TITLE
Use pusher based on go-containerregistry

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -31,3 +31,8 @@ config_setting(
     name = "optimized",
     values = {"compilation_mode": "opt"},
 )
+
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# gazelle:prefix github.com/bazelbuild/rules_docker
+gazelle(name = "gazelle")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,6 +25,36 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # instantiated recursively.
 container_repositories()
 
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "ba79c532ac400cefd1859cbc8a9829346aa69e3b99482cd5a54432092cbc3933",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.13.0/rules_go-0.13.0.tar.gz"],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "bc653d3e058964a5a26dcad02b6c72d7d63e6bb88d94704990b908a1445b8758",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.13.0/bazel-gazelle-0.13.0.tar.gz"],
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+gazelle_dependencies()
+
+go_repository(
+    name = "com_github_google_go_containerregistry",
+    importpath = "github.com/google/go-containerregistry",
+    sha256 = "f3e372ccbfa283e3c00ede015b11c620a5e4f5a79858a66a2c58c520f18dd225",
+    strip_prefix = "go-containerregistry-5f7b0e4895413d785ff15b84d218d73e8a47866a",
+    urls = ["https://github.com/google/go-containerregistry/archive/5f7b0e4895413d785ff15b84d218d73e8a47866a.tar.gz"],
+)
+
 # These are for testing.
 container_pull(
     name = "distroless_base",

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -67,28 +67,28 @@ def repositories():
     if "puller" not in excludes:
         http_file(
             name = "puller",
+            executable = True,
+            sha256 = "c834a311a1d2ade959c38c262dfead3b180ba022d196c4a96453d4bfa01e83da",
             urls = [("https://storage.googleapis.com/containerregistry-releases/" +
                      CONTAINERREGISTRY_RELEASE + "/puller.par")],
-            sha256 = "c834a311a1d2ade959c38c262dfead3b180ba022d196c4a96453d4bfa01e83da",
-            executable = True,
         )
 
     if "importer" not in excludes:
         http_file(
             name = "importer",
+            executable = True,
+            sha256 = "19643df59bb1dc750e97991e7071c601aa2debe94f6ad72e5f23ab8ae77da46f",
             urls = [("https://storage.googleapis.com/containerregistry-releases/" +
                      CONTAINERREGISTRY_RELEASE + "/importer.par")],
-            sha256 = "19643df59bb1dc750e97991e7071c601aa2debe94f6ad72e5f23ab8ae77da46f",
-            executable = True,
         )
 
     if "containerregistry" not in excludes:
         http_archive(
             name = "containerregistry",
-            urls = [("https://github.com/google/containerregistry/archive/" +
-                     CONTAINERREGISTRY_RELEASE + ".tar.gz")],
             sha256 = "07b9d06e46a9838bef712116bbda7e094ede37be010c1f8c0a3f32f2eeca6384",
             strip_prefix = "containerregistry-" + CONTAINERREGISTRY_RELEASE[1:],
+            urls = [("https://github.com/google/containerregistry/archive/" +
+                     CONTAINERREGISTRY_RELEASE + ".tar.gz")],
         )
 
     # TODO(mattmoor): Remove all of this (copied from google/containerregistry)
@@ -98,10 +98,6 @@ def repositories():
         # TODO(mattmoor): Is there a clean way to override?
         http_archive(
             name = "httplib2",
-            url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.11.3",
-            sha256 = "d9f568c183d1230f271e9c60bd99f3f2b67637c3478c9068fea29f7cca3d911f",
-            strip_prefix = "httplib2-0.11.3/python2/httplib2/",
-            type = "tar.gz",
             build_file_content = """
 py_library(
    name = "httplib2",
@@ -109,6 +105,10 @@ py_library(
    data = ["cacerts.txt"],
    visibility = ["//visibility:public"]
 )""",
+            sha256 = "d9f568c183d1230f271e9c60bd99f3f2b67637c3478c9068fea29f7cca3d911f",
+            strip_prefix = "httplib2-0.11.3/python2/httplib2/",
+            type = "tar.gz",
+            url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.11.3",
         )
 
     # Used by oauth2client
@@ -116,10 +116,6 @@ py_library(
         # TODO(mattmoor): Is there a clean way to override?
         http_archive(
             name = "six",
-            url = "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz",
-            sha256 = "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5",
-            strip_prefix = "six-1.9.0/",
-            type = "tar.gz",
             build_file_content = """
 # Rename six.py to __init__.py
 genrule(
@@ -133,6 +129,10 @@ py_library(
    srcs = [":__init__.py"],
    visibility = ["//visibility:public"],
 )""",
+            sha256 = "e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5",
+            strip_prefix = "six-1.9.0/",
+            type = "tar.gz",
+            url = "https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz",
         )
 
     # Used for authentication in containerregistry
@@ -140,10 +140,6 @@ py_library(
         # TODO(mattmoor): Is there a clean way to override?
         http_archive(
             name = "oauth2client",
-            url = "https://codeload.github.com/google/oauth2client/tar.gz/v4.0.0",
-            sha256 = "7230f52f7f1d4566a3f9c3aeb5ffe2ed80302843ce5605853bee1f08098ede46",
-            strip_prefix = "oauth2client-4.0.0/oauth2client/",
-            type = "tar.gz",
             build_file_content = """
 py_library(
    name = "oauth2client",
@@ -154,6 +150,10 @@ py_library(
      "@six//:six",
    ]
 )""",
+            sha256 = "7230f52f7f1d4566a3f9c3aeb5ffe2ed80302843ce5605853bee1f08098ede46",
+            strip_prefix = "oauth2client-4.0.0/oauth2client/",
+            type = "tar.gz",
+            url = "https://codeload.github.com/google/oauth2client/tar.gz/v4.0.0",
         )
 
     # Used for parallel execution in containerregistry
@@ -161,16 +161,16 @@ py_library(
         # TODO(mattmoor): Is there a clean way to override?
         http_archive(
             name = "concurrent",
-            url = "https://codeload.github.com/agronholm/pythonfutures/tar.gz/3.0.5",
-            sha256 = "a7086ddf3c36203da7816f7e903ce43d042831f41a9705bc6b4206c574fcb765",
-            strip_prefix = "pythonfutures-3.0.5/concurrent/",
-            type = "tar.gz",
             build_file_content = """
 py_library(
    name = "concurrent",
    srcs = glob(["**/*.py"]),
    visibility = ["//visibility:public"]
 )""",
+            sha256 = "a7086ddf3c36203da7816f7e903ce43d042831f41a9705bc6b4206c574fcb765",
+            strip_prefix = "pythonfutures-3.0.5/concurrent/",
+            type = "tar.gz",
+            url = "https://codeload.github.com/agronholm/pythonfutures/tar.gz/3.0.5",
         )
 
     # For packaging python tools.

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""An implementation of container_push based on google/containerregistry.
+"""An implementation of container_push based on google/go-containerregistry.
 
-This wraps the containerregistry.tools.fast_pusher executable in a
-Bazel rule for publishing images.
+This wraps the container/pusher go executable in a Bazel rule for publishing
+images.
 """
 
 load(
@@ -105,9 +105,9 @@ def _impl(ctx):
             PushInfo(
                 registry = ctx.expand_make_variables("registry", ctx.attr.registry, {}),
                 repository = ctx.expand_make_variables("repository", ctx.attr.repository, {}),
-                tag = ctx.expand_make_variables("tag", ctx.attr.tag, {}),
                 stamp = ctx.attr.stamp,
                 stamp_inputs = stamp_inputs,
+                tag = ctx.expand_make_variables("tag", ctx.attr.tag, {}),
             ),
             DefaultInfo(executable = ctx.outputs.executable, runfiles = runfiles),
         ],
@@ -136,7 +136,7 @@ container_push = rule(
             allow_files = True,
         ),
         "_pusher": attr.label(
-            default = Label("@containerregistry//:pusher"),
+            default = Label("//container/pusher"),
             cfg = "host",
             executable = True,
             allow_files = True,

--- a/container/pusher/BUILD.bazel
+++ b/container/pusher/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "image.go",
+        "main.go",
+        "stamp.go",
+    ],
+    importpath = "github.com/bazelbuild/rules_docker/container/pusher",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_google_go_containerregistry//pkg/authn:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/name:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/partial:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/remote:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/types:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "pusher",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/container/pusher/image.go
+++ b/container/pusher/image.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// image is an optimal representation of an on-disk collection of compressed
+// image layers and a config file.
+type image struct {
+	rawConfigFile []byte
+	rawManifest   []byte
+	configDigest  v1.Hash
+	layers        map[v1.Hash]partial.CompressedLayer
+}
+
+var _ partial.CompressedImageCore = (*image)(nil)
+
+// RawConfigFile implements partial.CompressedImageCore
+func (i *image) RawConfigFile() ([]byte, error) {
+	return i.rawConfigFile, nil
+}
+
+// MediaType implements partial.CompressedImageCore
+func (i *image) MediaType() (types.MediaType, error) {
+	return types.DockerManifestSchema2, nil
+}
+
+// RawManifest implements partial.CompressedImageCore
+func (i *image) RawManifest() ([]byte, error) {
+	return i.rawManifest, nil
+}
+
+// LayerByDigest implements partial.CompressedImageCore
+func (i *image) LayerByDigest(h v1.Hash) (partial.CompressedLayer, error) {
+	if h == i.configDigest {
+		return partial.ConfigLayer(i)
+	}
+	l, ok := i.layers[h]
+	if !ok {
+		return nil, fmt.Errorf("unexpected hash when getting layers: %v", h)
+	}
+	return l, nil
+}
+
+type layer struct {
+	hash     v1.Hash
+	filePath string
+	size     int64
+}
+
+var _ partial.CompressedLayer = (*layer)(nil)
+
+// Digest implements partial.CompressedLayer
+func (l *layer) Digest() (v1.Hash, error) {
+	return l.hash, nil
+}
+
+// Compressed implements partial.CompressedLayer
+func (l *layer) Compressed() (io.ReadCloser, error) {
+	return os.Open(l.filePath)
+}
+
+// Size implements partial.CompressedLayer
+func (l *layer) Size() (int64, error) {
+	return l.size, nil
+}
+
+func fileSize(filePath string) (int64, error) {
+	fi, err := os.Stat(filePath)
+	if err != nil {
+		return -1, err
+	}
+	return fi.Size(), nil
+}
+
+func fromDisk(configFilePath string, compressedLayerPaths, layerDigestPaths []string) (v1.Image, error) {
+	if len(compressedLayerPaths) != len(layerDigestPaths) {
+		return nil, fmt.Errorf("layer digest paths and file paths must have the same length")
+	}
+	var err error
+
+	img := image{layers: make(map[v1.Hash]partial.CompressedLayer)}
+	img.rawConfigFile, err = ioutil.ReadFile(configFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading file %q: %v", configFilePath, err)
+	}
+
+	img.configDigest, _, err = v1.SHA256(bytes.NewReader(img.rawConfigFile))
+	if err != nil {
+		return nil, err
+	}
+	m := v1.Manifest{
+		SchemaVersion: 2,
+		MediaType:     types.DockerManifestSchema2,
+		Config: v1.Descriptor{
+			MediaType: types.DockerConfigJSON,
+			Size:      int64(len(img.rawConfigFile)),
+			Digest:    img.configDigest,
+		},
+		Layers: make([]v1.Descriptor, 0, len(layerDigestPaths)),
+	}
+
+	// Layers
+	for i, lPath := range compressedLayerPaths {
+		hash, err := readDigest(layerDigestPaths[i])
+		if err != nil {
+			return nil, err
+		}
+		size, err := fileSize(lPath)
+		if err != nil {
+			return nil, err
+		}
+
+		m.Layers = append(m.Layers, v1.Descriptor{
+			MediaType: types.DockerLayer,
+			Size:      size,
+			Digest:    hash,
+		})
+
+		img.layers[hash] = &layer{
+			hash:     hash,
+			filePath: lPath,
+			size:     size,
+		}
+	}
+
+	// Manifest
+	img.rawManifest, err = json.Marshal(&m)
+	if err != nil {
+		return nil, err
+	}
+
+	return partial.CompressedToImage(&img)
+}
+
+func readDigest(layerDigestPath string) (v1.Hash, error) {
+	b, err := ioutil.ReadFile(layerDigestPath)
+	if err != nil {
+		return v1.Hash{}, fmt.Errorf("reading file %q: %v", layerDigestPath, err)
+	}
+	return v1.NewHash("sha256:" + string(b))
+}

--- a/container/pusher/main.go
+++ b/container/pusher/main.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+type stringSliceFlag []string
+
+func (i *stringSliceFlag) String() string {
+	return fmt.Sprintf("%q", *i)
+}
+
+func (i *stringSliceFlag) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+func pushImage(dstRef, configFile string, layerFilePaths, layerDigestPaths []string) error {
+	dstTag, err := name.NewTag(dstRef, name.WeakValidation)
+	if err != nil {
+		return fmt.Errorf("parsing tag %q: %v", dstRef, err)
+	}
+
+	// Auth (through docker's config file)
+	dstAuth, err := authn.DefaultKeychain.Resolve(dstTag.Context().Registry)
+	if err != nil {
+		return fmt.Errorf("getting creds for %q: %v", dstTag, err)
+	}
+
+	img, err := fromDisk(configFile, layerFilePaths, layerDigestPaths)
+	if err != nil {
+		return err
+	}
+
+	// Push
+	opts := remote.WriteOptions{}
+	if err := remote.Write(dstTag, img, dstAuth, http.DefaultTransport, opts); err != nil {
+		return fmt.Errorf("writing image %q: %v", dstTag, err)
+	}
+
+	return nil
+}
+
+func readClosers(paths []string) (readers []io.ReadCloser) {
+	for _, p := range paths {
+		f, err := os.Open(p)
+		if err != nil {
+			log.Fatalf("opening file %q: %v", p, err)
+		}
+		readers = append(readers, f)
+	}
+	return
+}
+
+func main() {
+	// These flag values must be compatible with the expectations at
+	// https://github.com/bazelbuild/rules_docker/blob/4338ecf45187a848d55a3651b6c1d70fe1ef6cce/container/push-tag.sh.tpl#L26
+	dstName := flag.String("name", "", "Destination reference of the image")
+	configFilePath := flag.String("config", "", "Docker config file")
+
+	var (
+		layerFilePaths   stringSliceFlag
+		layerDigestPaths stringSliceFlag
+		stampFiles       stringSliceFlag
+	)
+	flag.Var(&layerFilePaths, "layer", "Paths to compressed image layers")
+	flag.Var(&layerDigestPaths, "digest", "Paths to files containing layer digests")
+	flag.Var(&stampFiles, "stamp-info-file", "Bazel stamp variable files")
+
+	_ = flag.String("format", "", "Unused")
+	flag.Parse()
+
+	dstRef := stampReference(*dstName, readClosers(stampFiles))
+	if err := pushImage(dstRef, *configFilePath, layerFilePaths, layerDigestPaths); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/container/pusher/stamp.go
+++ b/container/pusher/stamp.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// oldnew returns a slice of strings to be used with strings.NewReplacer
+func oldnew(r io.ReadCloser, s []string) []string {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		tokens := strings.SplitN(line, " ", 2)
+		if len(tokens) == 0 {
+			continue
+		}
+		key := "{" + tokens[0] + "}"
+
+		var val string
+		if len(tokens) > 1 {
+			val = tokens[1]
+		}
+		s = append(s, key, val)
+	}
+	_ = r.Close()
+	return s
+}
+
+func stampReference(dstName string, stampFiles []io.ReadCloser) string {
+	var replacements []string
+	for _, stampFile := range stampFiles {
+		replacements = oldnew(stampFile, replacements)
+	}
+
+	r := strings.NewReplacer(replacements...)
+	return r.Replace(dstName)
+}

--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""An implementation of container_push based on google/containerregistry.
+"""An implementation of container_push based on google/go-containerregistry.
 
 This variant of container_push accepts a container_bundle target and publishes
 the embedded image references.
@@ -119,7 +119,7 @@ container_push = rule(
             allow_files = True,
         ),
         "_pusher": attr.label(
-            default = Label("@containerregistry//:pusher"),
+            default = Label("//container/pusher"),
             cfg = "host",
             executable = True,
             allow_files = True,


### PR DESCRIPTION
This pull request is merely to share work that I had to do for avoiding python2 code paths in containerregistry.

This will still need more work, namely
1. legacy base images are not supported.
2. WORKSPACE dependency management is incomplete.
3. go-containerregistry does not do HEAD checks, so could be a performance regression for some.

Happy to take it forward if people are interested.