### PR TITLE
Fix builds with python3 as default python

### DIFF
--- a/python/BUILD
+++ b/python/BUILD
@@ -15,6 +15,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+
+# Python2 is a dependency of rules_docker due to its dependency on
+# containerregistry. To run builds on environments in which 'which python'
+# points to python3, you can use the py_runtime target below.
+# To use this target, simply add the following flag to your build commands:
+# --python_top=//python:py_runtime_2
+# Note you need to have a symlink to a valid python2 version in
+# '/usr/bin/python2' for this to work.
 py_runtime(
     name = "py_runtime_2",
     files = [],

--- a/python/BUILD
+++ b/python/BUILD
@@ -15,7 +15,6 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-
 # Python2 is a dependency of rules_docker due to its dependency on
 # containerregistry. To run builds on environments in which 'which python'
 # points to python3, you can use the py_runtime target below.

--- a/python/BUILD
+++ b/python/BUILD
@@ -14,3 +14,9 @@
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
+
+py_runtime(
+    name = "py_runtime_2",
+    files = [],
+    interpreter_path = "/usr/bin/python2",
+)


### PR DESCRIPTION
Create py_runtime rule to use with envs that have python pointing to python2 version

To run a build in an environment that has which python point to a version python3 you need to add the following flag:
--python_top=//python:py_runtime_2

You must also make sure to have a symlink to a valid python 2 binary in "/usr/bin/python2"

Solves:
https://github.com/bazelbuild/rules_docker/issues/454
Replaces:
https://github.com/bazelbuild/rules_docker/pull/481

Note. PYTHON2 IS A DEPENDENCY OF THESE RULES (due to deps of container regsitry). While theoretically it should be possible to refactor container registry to remove this dependency, that is a big refactoring we do not need atm. This PR solves the issue that Bazel by default picks the python binary found with "which python". If which python points to a python3 version, then you could not build with these rules. With this PR, you need to have a py2 version installed, but can have "which python" point to whatever you want.
Note, you can add the flag --python_top=//python:py_runtime_2 to a bazelrc file in your project to avoid having to write it every time (if the expectation in your project is that most host environments will have which python point to python3)