### PR TITLE
Remove usages of deprecated Bazel features

### DIFF
--- a/container/flatten.bzl
+++ b/container/flatten.bzl
@@ -62,8 +62,7 @@ def _impl(ctx):
 container_flatten = rule(
     attrs = dict({
         "image": attr.label(
-            allow_files = [".tar"],
-            single_file = True,
+            allow_single_file = [".tar"],
             mandatory = True,
         ),
         "_flattener": attr.label(

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -185,8 +185,7 @@ def incremental_load(
 tools = {
     "incremental_load_template": attr.label(
         default = Label("//container:incremental_load_template"),
-        single_file = True,
-        allow_files = True,
+        allow_single_file = True,
     ),
     "join_layers": attr.label(
         default = Label("//container:join_layers"),

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -116,8 +116,7 @@ def _impl(ctx):
 container_push = rule(
     attrs = dict({
         "image": attr.label(
-            allow_files = [".tar"],
-            single_file = True,
+            allow_single_file = [".tar"],
             mandatory = True,
         ),
         "registry": attr.string(mandatory = True),
@@ -132,8 +131,7 @@ container_push = rule(
         ),
         "_tag_tpl": attr.label(
             default = Label("//container:push-tag.sh.tpl"),
-            single_file = True,
-            allow_files = True,
+            allow_single_file = True,
         ),
         "_pusher": attr.label(
             default = Label("@containerregistry//:pusher"),

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -21,7 +21,14 @@ The signature of war_image is compatible with java_library.
 load(
     "//container:container.bzl",
     "container_pull",
+    _container = "container",
     _repositories = "repositories",
+)
+load(
+    "//lang:image.bzl",
+    "dep_layer_impl",
+    "layer_file_path",
+    "runfiles_dir",
 )
 
 # Load the resolved digests.
@@ -88,11 +95,6 @@ DEFAULT_JETTY_BASE = select({
     "//conditions:default": "@jetty_image_base//image",
 })
 
-load(
-    "//container:container.bzl",
-    _container = "container",
-)
-
 def java_files(f):
     files = []
     if java_common.provider in f:
@@ -101,13 +103,6 @@ def java_files(f):
     if hasattr(f, "files"):  # a jar file
         files += list(f.files)
     return files
-
-load(
-    "//lang:image.bzl",
-    "dep_layer_impl",
-    "layer_file_path",
-    "runfiles_dir",
-)
 
 def _jar_dep_layer_impl(ctx):
     """Appends a layer for a single dependency's runfiles."""


### PR DESCRIPTION
replaces https://github.com/bazelbuild/rules_docker/pull/489