### PR TITLE
Ignore python 2 compiled bytecode files in git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 *.mod
 *.smod
 
+# Python 2 bytecode files
+*.pyc
+
 # Compiled Static libraries
 *.lai
 *.la


### PR DESCRIPTION
Ignore object files generated by python 2 in the git repo