### PR TITLE
Issue511

### DIFF
--- a/contrib/push-all.sh.tpl
+++ b/contrib/push-all.sh.tpl
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 set -eu
-
 function guess_runfiles() {
     pushd ${BASH_SOURCE[0]}.runfiles > /dev/null 2>&1
     pwd
@@ -33,6 +32,8 @@ function async() {
 %{push_statements}
 
 # Wait for all of the subprocesses, failing the script if any of them failed.
-for pid in ${PIDS[@]}; do
+# See https://github.com/bazelbuild/rules_docker/issues/511 on why we do
+# the verbose expansion for the PIDS instead of just PIDS[@]
+for pid in ${PIDS[@]+"${PIDS[@]}"}; do
     wait ${pid}
 done

--- a/contrib/push-all.sh.tpl
+++ b/contrib/push-all.sh.tpl
@@ -32,8 +32,8 @@ function async() {
 %{push_statements}
 
 # Wait for all of the subprocesses, failing the script if any of them failed.
-# See https://github.com/bazelbuild/rules_docker/issues/511 on why we do
-# the verbose expansion for the PIDS instead of just PIDS[@]
-for pid in ${PIDS[@]+"${PIDS[@]}"}; do
-    wait ${pid}
-done
+if [ "${#PIDS[@]}" != 0 ]; then
+    for pid in ${PIDS[@]}; do
+        wait ${pid}
+    done
+fi

--- a/tests/contrib/BUILD
+++ b/tests/contrib/BUILD
@@ -20,6 +20,8 @@ load(
     "@bazel_tools//tools/build_rules:test_rules.bzl",
     "file_test",
 )
+load("//container:bundle.bzl", "container_bundle")
+load("//contrib:push-all.bzl", "docker_push")
 
 sh_test(
     name = "rename_image_test",
@@ -141,4 +143,14 @@ file_test(
     name = "test_idd_rule_output",
     file = ":test_idd_rule",
     regexp = "^set -x && python .*idd .*image.tar .*image.tar -v -d$",
+)
+
+container_bundle(
+  name= "create_empty_bundle",
+  images={}
+)
+
+docker_push(
+    name = "test_docker_push_empty_bundle",
+    bundle = ":create_empty_bundle"
 )

--- a/tests/contrib/BUILD
+++ b/tests/contrib/BUILD
@@ -146,11 +146,11 @@ file_test(
 )
 
 container_bundle(
-  name= "create_empty_bundle",
-  images={}
+    name = "create_empty_bundle",
+    images = {},
 )
 
 docker_push(
     name = "test_docker_push_empty_bundle",
-    bundle = ":create_empty_bundle"
+    bundle = ":create_empty_bundle",
 )


### PR DESCRIPTION
Add a test target to create an empty container and attempt to push it using docker_push which internally calls docker push. Verified bazel run passes on bash 4.4 and gives the unbound variable error on bash 4.3. Verified both versions pass after the fix