### PR TITLE
Load data files in java_image 

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -14,6 +14,12 @@ platforms:
     - "..."
     - "-//tests/container/..."
     - "-//tests/docker/..."
+    build_flags:
+    - "--define=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
+    - "--action_env=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
+    test_flags:
+    - "--define=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
+    - "--action_env=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
   ubuntu1604:
     build_targets:
     # We are running the skipped targets remotely only.
@@ -28,6 +34,12 @@ platforms:
     - "..."
     - "-//tests/container/..."
     - "-//tests/docker/..."
+    build_flags:
+    - "--define=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
+    - "--action_env=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
+    test_flags:
+    - "--define=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
+    - "--action_env=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
   macos:
     build_targets:
     - "..."
@@ -35,6 +47,12 @@ platforms:
     - "--"
     - "..."
     - "-//tests/docker/..."
+    build_flags:
+    - "--define=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
+    - "--action_env=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
+    test_flags:
+    - "--define=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
+    - "--action_env=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
   # We are selecting to test only the targets that build on RBE
   # because the default image does not support `docker`.
   rbe_ubuntu1604:
@@ -155,7 +173,12 @@ platforms:
     - "-//tests/contrib:test_compare_ids_test_no_images_with_id_fails"
     - "-//tests/contrib:test_compare_ids_test_one_tar_no_id_fails"
     - "-//tests/contrib:test_compare_ids_test_wrong_id_fails"
+    build_flags:
+    - "--define=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
+    - "--action_env=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
     test_flags:
+    - "--define=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
+    - "--action_env=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1"
     - "--extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:nosla_xenial_docker"
     - "--host_platform=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:nosla_xenial_docker"
     - "--platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:nosla_xenial_docker"

--- a/.bazelrc
+++ b/.bazelrc
@@ -4,5 +4,5 @@
 # the default is overriden. java_image rules will work without use of
 # these flags but will be notoriously bigger.
 build --javabase=@local_config_java//:jdk
-build --javabase=@local_config_java//:jdk
-build --javabase=@local_config_java//:jdk
+test --javabase=@local_config_java//:jdk
+run --javabase=@local_config_java//:jdk

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,8 @@
+# By default the javabase set in Bazel points to the @local_jdk.
+# In order to build java_images with all their dependencies set we
+# include all transitive deps, which will include the @local_jdk unless
+# the default is overriden. java_image rules will work without use of
+# these flags but will be notoriously bigger.
+build --javabase=//java:jdk
+run --javabase=//java:jdk
+test --javabase=//java:jdk

--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,6 @@
 # include all transitive deps, which will include the @local_jdk unless
 # the default is overriden. java_image rules will work without use of
 # these flags but will be notoriously bigger.
-build --javabase=//java:jdk
-run --javabase=//java:jdk
-test --javabase=//java:jdk
+build --javabase=@local_config_java//:jdk
+build --javabase=@local_config_java//:jdk
+build --javabase=@local_config_java//:jdk

--- a/README.md
+++ b/README.md
@@ -554,6 +554,14 @@ java_image(
 )
 ```
 
+**NEW: starting v0.5.2 use of java_image requires a custom javabase (see [.bazelrc](.bazelrc))**
+
+By default the `javabase` set in Bazel points to the `@local_jdk`.
+In order to build `java_images` with all their dependencies set we
+include all transitive deps, which will include the `@local_jdk` unless
+the default is overriden. Note `java_image` rules will work without use of
+these flags but will be notoriously bigger.
+
 ### war_image
 
 To use `war_image`, add the following to `WORKSPACE`:

--- a/README.md
+++ b/README.md
@@ -554,7 +554,10 @@ java_image(
 )
 ```
 
-**NEW: starting v0.5.2 use of java_image requires a custom javabase (see [.bazelrc](.bazelrc))**
+**NEW: starting v0.5.2 `java_image` includes all transitive deps if
+`EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1` is set in the env (e.g., via `--define`
+flag and --action_env flag or directly via export).
+This feature also requires `JAVA_HOME` to be set in the env.**
 
 By default the `javabase` set in Bazel points to the `@local_jdk`.
 In order to build `java_images` with all their dependencies set we

--- a/README.md
+++ b/README.md
@@ -557,13 +557,15 @@ java_image(
 **NEW: starting v0.5.2 `java_image` includes all transitive deps if
 `EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1` is set in the env (e.g., via `--define`
 flag and --action_env flag or directly via export).
-This feature also requires `JAVA_HOME` to be set in the env.**
+This feature also requires `JAVA_HOME` to be set in the env
+and requires using `--javabase=@local_config_java//:jdk.`**
 
 By default the `javabase` set in Bazel points to the `@local_jdk`.
 In order to build `java_images` with all their dependencies set we
 include all transitive deps, which will include the `@local_jdk` unless
 the default is overriden. Note `java_image` rules will work without use of
-these flags but will be notoriously bigger.
+these flags but will be notoriously bigger if
+`EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1` is set.
 
 ### war_image
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,10 @@
 # limitations under the License.
 workspace(name = "io_bazel_rules_docker")
 
+load("//skylib:java_configure.bzl", "java_configure")
+
+java_configure()
+
 load(
     "//container:container.bzl",
     "container_load",

--- a/container/BUILD
+++ b/container/BUILD
@@ -136,6 +136,7 @@ TEST_TARGETS = [
     ":go_image",
     ":groovy_image",
     ":java_image",
+    ":java_runfiles_as_lib_image",
     ":nodejs_image",
     ":py3_image",
     ":py_image",

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -40,7 +40,7 @@ def TestBundleImage(name, image_name):
 class ImageTest(unittest.TestCase):
 
   def assertTarballContains(self, tar, paths):
-    self.assertEqual(paths, tar.getnames())
+    self.assertEqual(paths, tar.getnames(), msg = str(tar.getnames()))
 
   def assertLayerNContains(self, img, n, paths):
     buf = cStringIO.StringIO(img.blob(img.fs_layers()[n]))
@@ -521,7 +521,8 @@ class ImageTest(unittest.TestCase):
         './app/io_bazel_rules_docker/testdata',
         './app/io_bazel_rules_docker/testdata/java_image.binary.jar',
         './app/io_bazel_rules_docker/testdata/java_image.binary',
-        './app/io_bazel_rules_docker/testdata/java_image.classpath'
+        './app/io_bazel_rules_docker/testdata/java_image.classpath',
+        './app/io_bazel_rules_docker/testdata/BUILD',
       ])
 
       self.assertLayerNContains(img, 1, [

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -519,10 +519,10 @@ class ImageTest(unittest.TestCase):
         './app',
         './app/io_bazel_rules_docker',
         './app/io_bazel_rules_docker/testdata',
+        './app/io_bazel_rules_docker/testdata/BUILD',
         './app/io_bazel_rules_docker/testdata/java_image.binary.jar',
         './app/io_bazel_rules_docker/testdata/java_image.binary',
         './app/io_bazel_rules_docker/testdata/java_image.classpath',
-        './app/io_bazel_rules_docker/testdata/BUILD',
       ])
 
       self.assertLayerNContains(img, 1, [
@@ -538,9 +538,10 @@ class ImageTest(unittest.TestCase):
 
       self.assertConfigEqual(img, 'Entrypoint', [
         '/usr/bin/java', '-cp',
-        ':'.join([
+        u':'.join([
           '/app/io_bazel_rules_docker/testdata/libjava_image_library.jar',
           '/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar',
+          '/app/io_bazel_rules_docker/testdata/BUILD',
           '/app/io_bazel_rules_docker/testdata/java_image.binary.jar',
           '/app/io_bazel_rules_docker/testdata/java_image.binary'
         ]),
@@ -550,6 +551,38 @@ class ImageTest(unittest.TestCase):
         'arg0',
         'arg1',
         'testdata/BUILD'
+      ])
+
+  def test_java_runfiles_as_lib_image(self):
+    with TestImage('java_runfiles_as_lib_image') as img:
+      # Check the application layer, which is on top.
+      self.assertTopLayerContains(img, [
+        '.',
+        './app',
+        './app/io_bazel_rules_docker',
+        './app/io_bazel_rules_docker/testdata',
+        './app/io_bazel_rules_docker/testdata/libjava_runfiles_as_lib.jar',
+        './app/bazel_tools',
+        './app/bazel_tools/tools',
+        './app/bazel_tools/tools/java',
+        './app/bazel_tools/tools/java/runfiles',
+        './app/bazel_tools/tools/java/runfiles/librunfiles.jar',
+        './app/io_bazel_rules_docker/testdata/foo',
+        './app/io_bazel_rules_docker/testdata/java_runfiles_as_lib_image.binary.jar',
+        './app/io_bazel_rules_docker/testdata/java_runfiles_as_lib_image.binary',
+        './app/io_bazel_rules_docker/testdata/java_runfiles_as_lib_image.classpath',
+      ])
+
+      self.assertConfigEqual(img, 'Entrypoint', [
+        u'/usr/bin/java', u'-cp',
+        u':'.join([
+          '/app/io_bazel_rules_docker/testdata/libjava_runfiles_as_lib.jar',
+          '/app/io_bazel_rules_docker/../bazel_tools/tools/java/runfiles/librunfiles.jar',
+          '/app/io_bazel_rules_docker/testdata/foo',
+          '/app/io_bazel_rules_docker/testdata/java_runfiles_as_lib_image.binary.jar',
+          '/app/io_bazel_rules_docker/testdata/java_runfiles_as_lib_image.binary',
+        ]),
+        u'examples.images.Runfiles'
       ])
 
   def test_war_image(self):
@@ -624,8 +657,9 @@ class ImageTest(unittest.TestCase):
       self.assertConfigEqual(img, 'Entrypoint', [
         '/usr/bin/java',
         '-cp',
-        '/app/io_bazel_rules_docker/testdata/libjava_image_library.jar:'
+        u'/app/io_bazel_rules_docker/testdata/libjava_image_library.jar:'
         +'/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:'
+        +'/app/io_bazel_rules_docker/testdata/BUILD:'
         +'/app/io_bazel_rules_docker/testdata/java_image.binary.jar:'
         +'/app/io_bazel_rules_docker/testdata/java_image.binary',
         '-XX:MaxPermSize=128M',
@@ -663,12 +697,14 @@ class ImageTest(unittest.TestCase):
       self.assertConfigEqual(img, 'Entrypoint', [
         '/usr/bin/java',
         '-cp',
-        '/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:'+
+        u'/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:'+
         '/app/io_bazel_rules_docker/../io_bazel_rules_scala_scala_library/scala-library-2.11.12.jar:'+
         '/app/io_bazel_rules_docker/../io_bazel_rules_scala_scala_reflect/scala-reflect-2.11.12.jar:'+
         '/app/io_bazel_rules_docker/testdata/scala_image_library.jar:'+
         '/app/io_bazel_rules_docker/testdata/scala_image.binary.jar:'+
-        '/app/io_bazel_rules_docker/testdata/scala_image.binary',
+        '/app/io_bazel_rules_docker/testdata/BUILD:'+
+        '/app/io_bazel_rules_docker/testdata/scala_image.binary:'+
+        '/app/io_bazel_rules_docker/testdata/scala_image.binary_wrapper.sh',
         '-Dbuild.location=testdata/BUILD',
         'examples.images.Binary',
         'arg0',
@@ -681,10 +717,11 @@ class ImageTest(unittest.TestCase):
       self.assertConfigEqual(img, 'Entrypoint', [
         '/usr/bin/java',
         '-cp',
-        '/app/io_bazel_rules_docker/testdata/libgroovy_image_library-impl.jar:'+
+        u'/app/io_bazel_rules_docker/testdata/libgroovy_image_library-impl.jar:'+
         '/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:'+
         '/app/io_bazel_rules_docker/../groovy_sdk_artifact/groovy-2.4.4/lib/groovy-2.4.4.jar:'+
         '/app/io_bazel_rules_docker/testdata/libgroovy_image.binary-lib-impl.jar:'+
+        '/app/io_bazel_rules_docker/testdata/BUILD:'+
         '/app/io_bazel_rules_docker/testdata/groovy_image.binary.jar:'+
         '/app/io_bazel_rules_docker/testdata/groovy_image.binary',
         '-Dbuild.location=testdata/BUILD',

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -40,7 +40,7 @@ def TestBundleImage(name, image_name):
 class ImageTest(unittest.TestCase):
 
   def assertTarballContains(self, tar, paths):
-    self.assertEqual(paths, tar.getnames(), msg = str(tar.getnames()))
+    self.assertEqual(paths, tar.getnames())
 
   def assertLayerNContains(self, img, n, paths):
     buf = cStringIO.StringIO(img.blob(img.fs_layers()[n]))

--- a/java/BUILD
+++ b/java/BUILD
@@ -15,14 +15,3 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-# A java_runtime to use as --javabase for building/running java_image targets
-# By default the javabase set in Bazel points to the @local_jdk.
-# In order to build java_images with all their dependencies set we
-# include all transitive deps, which will include the @local_jdk unless
-# the default is overriden. Note java_image rules will work without use of
-# these flags but will be notoriously bigger.
-java_runtime(
-    name = "jdk",
-    srcs = [],
-    java_home = "/usr/lib/jvm/java-8-oracle",
-)

--- a/java/BUILD
+++ b/java/BUILD
@@ -14,3 +14,15 @@
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
+
+# A java_runtime to use as --javabase for building/running java_image targets
+# By default the javabase set in Bazel points to the @local_jdk.
+# In order to build java_images with all their dependencies set we
+# include all transitive deps, which will include the @local_jdk unless
+# the default is overriden. Note java_image rules will work without use of
+# these flags but will be notoriously bigger.
+java_runtime(
+    name = "jdk",
+    srcs = [],
+    java_home = "/usr/lib/jvm/java-8-openjdk-amd64",
+)

--- a/java/BUILD
+++ b/java/BUILD
@@ -14,4 +14,3 @@
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
-

--- a/java/BUILD
+++ b/java/BUILD
@@ -24,5 +24,5 @@ licenses(["notice"])  # Apache 2.0
 java_runtime(
     name = "jdk",
     srcs = [],
-    java_home = "/usr/lib/jvm/java-8-openjdk-amd64",
+    java_home = "/usr/lib/jvm/java-8-oracle",
 )

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -134,6 +134,7 @@ jar_dep_layer = rule(
 def _jar_app_layer_impl(ctx):
     """Appends the app layer with all remaining runfiles."""
 
+    workdir = ctx.attr.workdir or "/".join([ctx.attr.directory, ctx.workspace_name])
     available = depset()
     for jar in ctx.attr.jar_layers:
         available += java_files(jar)
@@ -188,6 +189,7 @@ def _jar_app_layer_impl(ctx):
         directory = "/",
         file_map = file_map,
         entrypoint = entrypoint,
+        workdir = workdir,
     )
 
 jar_app_layer = rule(

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -177,6 +177,9 @@ def _jar_app_layer_impl(ctx):
     file_map = {
         layer_file_path(ctx, f): f
         for f in unavailable + [classpath_file]
+    } + {
+        layer_file_path(ctx, f): f
+        for f in ctx.files.data
     }
 
     return _container.image.implementation(

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -99,9 +99,9 @@ def _java_files(f, transitive_deps):
     if java_common.provider in f:
         java_provider = f[java_common.provider]
         files += list(java_provider.transitive_runtime_jars)
-    #if transitive_deps:
-    if hasattr(f, "data_runfiles"):
-        files += list(f.data_runfiles.files)
+    if transitive_deps:
+        if hasattr(f, "data_runfiles"):
+            files += list(f.data_runfiles.files)
     if hasattr(f, "files"):  # a jar file
         files += list(f.files)
     return files
@@ -114,6 +114,7 @@ def _java_files_with_transitive_deps(f):
 
 def _jar_dep_layer_impl(ctx):
     """Appends a layer for a single dependency's runfiles."""
+
     # if EXPERIMENTAL_TRANSITIVE_JAVA_DEPS is set in the env as '1' then
     # we will add to the files all the data_runfiles for this file.
     # This effectively supports all the same deps as in the java_xx rule
@@ -125,7 +126,7 @@ def _jar_dep_layer_impl(ctx):
     # See also: //skylib/java_configure.bzl
     java_files = _java_files_no_transitive_deps
     if "EXPERIMENTAL_TRANSITIVE_JAVA_DEPS" in ctx.var and ctx.var["EXPERIMENTAL_TRANSITIVE_JAVA_DEPS"] == "1":
-      java_files = _java_files_with_transitive_deps
+        java_files = _java_files_with_transitive_deps
     return dep_layer_impl(ctx, runfiles = java_files)
 
 jar_dep_layer = rule(
@@ -156,6 +157,7 @@ def _jar_app_layer_impl(ctx):
     """Appends the app layer with all remaining runfiles."""
     workdir = ctx.attr.workdir or ctx.attr.directory
     available = depset()
+
     # if EXPERIMENTAL_TRANSITIVE_JAVA_DEPS is set in the env as '1' then
     # we will add to the files all the data_runfiles for this file.
     # This effectively supports all the same deps as in the java_xx rule
@@ -167,7 +169,7 @@ def _jar_app_layer_impl(ctx):
     # See also: //skylib/java_configure.bzl
     java_files = _java_files_no_transitive_deps
     if "EXPERIMENTAL_TRANSITIVE_JAVA_DEPS" in ctx.var and ctx.var["EXPERIMENTAL_TRANSITIVE_JAVA_DEPS"] == "1":
-      java_files = _java_files_with_transitive_deps
+        java_files = _java_files_with_transitive_deps
     for jar in ctx.attr.jar_layers:
         available += java_files(jar)
 
@@ -217,8 +219,8 @@ def _jar_app_layer_impl(ctx):
         # We use all absolute paths.
         directory = "/",
         env = {
-	  "JAVA_RUNFILES": ctx.attr.directory,
-	},
+            "JAVA_RUNFILES": ctx.attr.directory,
+        },
         file_map = file_map,
         entrypoint = entrypoint,
         workdir = workdir,
@@ -316,6 +318,7 @@ def java_image(
 
 def _war_dep_layer_impl(ctx):
     """Appends a layer for a single dependency's runfiles."""
+
     # if EXPERIMENTAL_TRANSITIVE_JAVA_DEPS is set in the env as '1' then
     # we will add to the files all the data_runfiles for this file.
     # This effectively supports all the same deps as in the java_xx rule
@@ -327,7 +330,8 @@ def _war_dep_layer_impl(ctx):
     # See also: //skylib/java_configure.bzl
     java_files = _java_files_no_transitive_deps
     if "EXPERIMENTAL_TRANSITIVE_JAVA_DEPS" in ctx.var and ctx.var["EXPERIMENTAL_TRANSITIVE_JAVA_DEPS"] == "1":
-      java_files = _java_files_with_transitive_deps
+        java_files = _java_files_with_transitive_deps
+
     # TODO(mattmoor): Today we run the risk of filenames colliding when
     # they get flattened.  Instead of just flattening and using basename
     # we should use a file_map based scheme.
@@ -362,6 +366,7 @@ _war_dep_layer = rule(
 
 def _war_app_layer_impl(ctx):
     """Appends the app layer with all remaining runfiles."""
+
     # if EXPERIMENTAL_TRANSITIVE_JAVA_DEPS is set in the env as '1' then
     # we will add to the files all the data_runfiles for this file.
     # This effectively supports all the same deps as in the java_xx rule
@@ -373,7 +378,7 @@ def _war_app_layer_impl(ctx):
     # See also: //skylib/java_configure.bzl
     java_files = _java_files_no_transitive_deps
     if "EXPERIMENTAL_TRANSITIVE_JAVA_DEPS" in ctx.var and ctx.var["EXPERIMENTAL_TRANSITIVE_JAVA_DEPS"] == "1":
-      java_files = _java_files_with_transitive_deps
+        java_files = _java_files_with_transitive_deps
     available = depset()
     for jar in ctx.attr.jar_layers:
         available += java_files(jar)

--- a/skylib/BUILD
+++ b/skylib/BUILD
@@ -23,6 +23,11 @@ skylark_library(
 )
 
 skylark_library(
+    name = "java_configure",
+    srcs = ["java_configure.bzl"],
+)
+
+skylark_library(
     name = "label",
     srcs = ["label.bzl"],
 )

--- a/skylib/java_configure.bzl
+++ b/skylib/java_configure.bzl
@@ -1,0 +1,72 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repository rule to create a javabase to use with rules_docker."""
+
+def auto_configure_fail(msg):
+    """Output failure message when auto configuration fails."""
+    red = "\033[0;31m"
+    no_color = "\033[0m"
+    fail("\n%sAuto-Configuration Error:%s %s\n" % (red, no_color, msg))
+
+def _find_java_home(repository_ctx):
+    env_value = repository_ctx.os.environ.get("JAVA_HOME")
+    if env_value != None:
+        return env_value
+    auto_configure_fail("Cannot find java or JAVA_HOME; please set the" +
+                        " JAVA_HOME environment variable")
+
+_BUILD = """
+package(default_visibility = ["//visibility:public"])
+
+java_runtime(
+    name = "jdk",
+    srcs = [],
+    java_home = "{}",
+)
+"""
+
+_DEFAULT_BUILD = """
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "jdk",
+    actual = "@local_jdk//:jdk"
+)
+"""
+
+def java_autoconf_impl(repository_ctx):
+    env = repository_ctx.os.environ
+    if "EXPERIMENTAL_TRANSITIVE_JAVA_DEPS" in env and env["EXPERIMENTAL_TRANSITIVE_JAVA_DEPS"] == "1":
+        java_home = _find_java_home(repository_ctx)
+        repository_ctx.file("BUILD", _BUILD.format(java_home))
+    else:
+        repository_ctx.file("BUILD", _DEFAULT_BUILD)
+
+java_autoconf = repository_rule(
+    environ = [
+        "EXPERIMENTAL_TRANSITIVE_JAVA_DEPS",
+        "JAVA_HOME",
+    ],
+    implementation = java_autoconf_impl,
+)
+
+def java_configure():
+    """A Java configuration rule that generates a target to be used as javabase.
+
+    This rule, by default, creates an alias that points to @local_jdk.
+    If EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1 is set in the environment, this
+    rule creates a java_runtime target with a java_home pointing to the
+    JAVA_HOME.
+    """
+    java_autoconf(name = "local_config_java")

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -796,6 +796,21 @@ java_image(
     runtime_deps = [":java_bin_as_lib"],
 )
 
+java_library(
+    name = "java_runfiles_as_lib",
+    srcs = ["Runfiles.java"],
+    data = ["foo"],
+    deps = [
+        "@bazel_tools//tools/runfiles:java-runfiles",
+    ],
+)
+
+java_image(
+    name = "java_runfiles_as_lib_image",
+    main_class = "examples.images.Runfiles",
+    runtime_deps = [":java_runfiles_as_lib"],
+)
+
 war_image(
     name = "war_image",
     srcs = ["Servlet.java"],

--- a/testdata/Runfiles.java
+++ b/testdata/Runfiles.java
@@ -1,0 +1,30 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples.images;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class Runfiles {
+    public static void main(String[] args) throws IOException {
+	String path = com.google.devtools.build.runfiles.Runfiles.create()
+	    .rlocation("io_bazel_rules_docker/testdata/foo");
+	byte[] encoded = Files.readAllBytes(Paths.get(path));
+	System.out.println(new String(encoded, StandardCharsets.UTF_8));
+    }
+}
+

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
UPDATE: this CL now adds all transitive data files in a java_image (feature guarded by env variable). Activating this feature enables a java_image rule to depend on a java_library rule and have files for the java_library made available inside the container. 
To achieve this, however, we are getting **all** transitive dependencies included in the image. Note, since the transitive deps of a java_xx rule include the java toolchain it is HEAVILY RECOMMENDED that build/run/test commands that will build a java_image rule do not use the @local_jdk.
To enable easy overriding of the @local_jdk, this PR also includes a repository rule that creates a remote repo @local_config_java//:jdk. This repo rule will point to the JAVA_HOME, overriding the @local_jdk. To use this target your build must pass flag --javabase=@local_config_java//:jdk (see bazelrc file added to this repo in this commit). Note: if feature is not enabled, @local_config_java//:jdk will point to the @local_jdk to avoid any breakages.

**To enable this feature the env variable EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1 must be set, JAVA_HOME must be set and --javabase=@local_config_java//:jdk must be passed )via bazel rc or directly). The easiest way to do this is to just export these env variables but its also feasible to do something like:

`bazel build --define=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1 --action_env=EXPERIMENTAL_TRANSITIVE_JAVA_DEPS=1 --javabase=@local_config_java//:jdk  <some target>`

(note both define and action_env must be used as this env var will be read in repository rule and skylark rule, sorry for this nastiness)
Note until java rules support selection of platform/toolchain on a per-target basis it is not possible to solve https://github.com/bazelbuild/rules_docker/issues/506 in any other way that I can think of (i.e., the main regression this feature has is that java_home must be present in the env, otherwise builds will fail, thus guarding it with the additional EXPERIMENTAL_TRANSITIVE_JAVA_DEPS env var).

This PR also adds the JAVA_RUNFILES env variable to java_image to get behavior on par with java_binary targets that require use of this env variable (not guarded by flag).

Previous description (for record):
https://github.com/nlopezgi/rules_docker/commit/f5ed963f7411f07efd6b0bd8667fe89d6a05077b added data files to lang_image (and transitively to all xx_image rules that use app_layer). 
java_image does not use app_layer so the change did not work in that case. 

Also setting workdir for java_image to "/app/io_bazel_rules_docker/" (experimental, please report any issues with this workdir change)

This fix partially addresses https://github.com/bazelbuild/rules_docker/issues/506