### PR TITLE
Fix runfiles discovery

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -19,9 +19,14 @@ set -eu
 # This is a generated file that loads all docker layers built by "docker_build".
 
 function guess_runfiles() {
-    pushd ${BASH_SOURCE[0]}.runfiles > /dev/null 2>&1
-    pwd
-    popd > /dev/null 2>&1
+    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
+        # Runfiles are adjacent to the current script.
+        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
+    else
+        # The current script is within some other script's runfiles.
+        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
+    fi
 }
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"

--- a/container/push-tag.sh.tpl
+++ b/container/push-tag.sh.tpl
@@ -16,9 +16,14 @@
 set -eu
 
 function guess_runfiles() {
-    pushd ${BASH_SOURCE[0]}.runfiles > /dev/null 2>&1
-    pwd
-    popd > /dev/null 2>&1
+    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
+        # Runfiles are adjacent to the current script.
+        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
+    else
+        # The current script is within some other script's runfiles.
+        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
+    fi
 }
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"

--- a/contrib/push-all.sh.tpl
+++ b/contrib/push-all.sh.tpl
@@ -15,9 +15,14 @@
 
 set -eu
 function guess_runfiles() {
-    pushd ${BASH_SOURCE[0]}.runfiles > /dev/null 2>&1
-    pwd
-    popd > /dev/null 2>&1
+    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
+        # Runfiles are adjacent to the current script.
+        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
+    else
+        # The current script is within some other script's runfiles.
+        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
+    fi
 }
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -778,6 +778,14 @@ cc_image(
     binary = ":cc_binary",
 )
 
+# Test that we can also load image from within another script.
+sh_binary(
+    name = "cc_image_wrapper",
+    srcs = ["cc_image_wrapper.sh"],
+    args = ["$(location :cc_image)"],
+    data = [":cc_image"],
+)
+
 load(
     "//java:image.bzl",
     "java_image",

--- a/testdata/cc_image_wrapper.sh
+++ b/testdata/cc_image_wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+"$1" || { echo "FAIL!"; exit 1; }

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -233,6 +233,12 @@ function test_cc_binary_as_image() {
   EXPECT_CONTAINS "$(bazel run "$@" testdata:cc_binary_as_image)" "Hello World"
 }
 
+function test_cc_image_wrapper() {
+  cd "${ROOT}"
+  clear_docker
+  EXPECT_CONTAINS "$(bazel run "$@" testdata:cc_image_wrapper)" "Hello World"
+}
+
 function test_go_image() {
   cd "${ROOT}"
   clear_docker
@@ -375,6 +381,7 @@ test_cc_image -c opt
 test_cc_image -c dbg
 test_cc_binary_as_image -c opt
 test_cc_binary_as_image -c dbg
+test_cc_image_wrapper
 test_go_image -c opt
 test_go_image -c dbg
 test_go_image_busybox


### PR DESCRIPTION
The launcher scripts were not able to find runfiles when executed
deeper inside a runfile tree generated by another rule.  This
happens when another rule depends on the container image target
and wants to execute the scripts from its own runfiles tree.

Fix discovery to also account for this possibility, using similar
heuristics as FindModuleSpace in the python launcher.