### PR TITLE
join_layers read blobs as binary (py3 support)

### DIFF
--- a/container/join_layers.py
+++ b/container/join_layers.py
@@ -109,7 +109,7 @@ class FromParts(v2_2_image.DockerImage):
     elif digest not in self._blobsum_to_unzipped:
       return self._blobsum_to_legacy[digest].uncompressed_blob(digest)
 
-    with open(self._blobsum_to_unzipped[digest], 'r') as reader:
+    with open(self._blobsum_to_unzipped[digest], 'rb') as reader:
       return reader.read()
 
   # Could be large, do not memoize
@@ -117,7 +117,7 @@ class FromParts(v2_2_image.DockerImage):
     """Override."""
     if digest not in self._blobsum_to_zipped:
       return self._blobsum_to_legacy[digest].blob(digest)
-    with open(self._blobsum_to_zipped[digest], 'r') as reader:
+    with open(self._blobsum_to_zipped[digest], 'rb') as reader:
       return reader.read()
 
   def blob_size(self, digest):


### PR DESCRIPTION
My default python runtime is python3. When building a container.tar with

`bazel build //container_image:container_image.tar`

following error is thrown

```
File "......../execroot/__main__/bazel-out/host/bin/external/io_bazel_rules_docker/container/join_layers.runfiles/io_bazel_rules_docker/container/join_layers.py", line 113, in uncompressed_blob
    return reader.read()
  File "/usr/lib64/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xaf in position 1049: invalid start byte
Target //container-images/app-detector:app-detector.tar failed to build
Use --verbose_failures to see the command lines of failed build steps.
```


This PR modifies open arguments in **container/join_layers.py** from "r" to "rb" which has no effect on python2 but fixes building image tarballs with python3
