### PR TITLE
Add support for print_progress to container_pull

### DIFF
--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -80,6 +80,10 @@ container_import(
     if "PULLER_TIMEOUT" in repository_ctx.os.environ:
         kwargs["timeout"] = int(repository_ctx.os.environ.get("PULLER_TIMEOUT"))
 
+    if repository_ctx.attr.print_progress:
+        kwargs["quiet"] = False
+        args += ["--print-progress"]
+
     result = repository_ctx.execute(args, **kwargs)
     if result.return_code:
         fail("Pull command failed: %s (%s)" % (result.stderr, " ".join(args)))
@@ -90,6 +94,7 @@ container_pull = repository_rule(
         "repository": attr.string(mandatory = True),
         "digest": attr.string(),
         "tag": attr.string(default = "latest"),
+        "print_progress": attr.bool(),
         "_puller": attr.label(
             executable = True,
             default = Label("@puller//file:downloaded"),


### PR DESCRIPTION
Add minimal prints to indicate puller progress if container_pull
has print_progress=True attribute.  The intention is that the pull
operation would provide some feedback to the user, instead of bazel
getting seemingly stuck for 10 minutes when pulling an image that is
many gigabytes in size.

Pending pull request to upstream puller.par is here:
https://github.com/google/containerregistry/pull/66