### PR TITLE
Proposal/WIP: adding support for external cacerts.txt file

### DIFF
--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -56,6 +56,12 @@ container_import(
         repository_ctx.path("image"),
     ]
 
+    if repository_ctx.attr.cacerts:
+        args += [
+            "--cacert",
+            repository_ctx.path(repository_ctx.attr.cacerts),
+        ]
+
     # If a digest is specified, then pull by digest.  Otherwise, pull by tag.
     if repository_ctx.attr.digest:
         args += [
@@ -90,6 +96,10 @@ container_pull = repository_rule(
         "repository": attr.string(mandatory = True),
         "digest": attr.string(),
         "tag": attr.string(default = "latest"),
+        "cacerts": attr.label(
+            allow_single_file = True,
+            mandatory = False,
+        ),
         "_puller": attr.label(
             executable = True,
             default = Label("@puller//file:downloaded"),

--- a/container/push-tag.sh.tpl
+++ b/container/push-tag.sh.tpl
@@ -28,4 +28,4 @@ function guess_runfiles() {
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
-%{container_pusher} %{format} --name=%{tag} %{stamp} %{image} "$@"
+%{container_pusher} %{format} %{cacerts} --name=%{tag} %{stamp} %{image} "$@"

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -87,6 +87,8 @@ def _impl(ctx):
                 layer_arg,
             ),
             "%{format}": "--oci" if ctx.attr.format == "OCI" else "",
+            "%{cacerts}": ( "--cacert " + ctx.file.cacerts.path ) \
+                 if ctx.file.cacerts else "",
             "%{container_pusher}": _get_runfile_path(ctx, ctx.executable._pusher),
         },
         output = ctx.outputs.executable,
@@ -100,6 +102,7 @@ def _impl(ctx):
                     image["manifest"],
                 ] + image.get("blobsum", []) + image.get("zipped_layer", []) +
                 stamp_inputs + ([image["legacy"]] if image.get("legacy") else []) +
+                ([ctx.file.cacerts] if ctx.file.cacerts else []) +
                 list(ctx.attr._pusher.default_runfiles.files),
     )
 
@@ -144,6 +147,10 @@ container_push = rule(
         ),
         "stamp": attr.bool(
             default = False,
+            mandatory = False,
+        ),
+        "cacerts": attr.label(
+            allow_single_file = True,
             mandatory = False,
         ),
     }.items() + _layer_tools.items()),


### PR DESCRIPTION
**Note: Work based on (and depends on) https://github.com/google/containerregistry/pull/89**

Addresses  #273 

Wanted to optimistically start the ball rolling on a possible implementation to take advantage of google/containerregistry#89 providing a `--cacert` flag. _I don't believe this is a complete implementation._

Proposal: manage cacerts.txt like any other external dependency: in the WORKSPACE.

Non-working example for illustration:

```
# WORKSPACE
http_file(
    name='cacerts',
    urls=['https://example.com/cacerts.txt'],
    sha256='<sha256 here>',
)

container_pull(
    name = "favorite",
    registry = "private.myregistry.com",
    repository = "favorites/container",
    digest = "sha256:<digest>",
    cacerts = "@cacerts//file:downloaded",
)
```

I was able to make this work and resolve the issue described in #273 using this approach. (Due to `container_pull` dependency on a prebuilt `puller` artifact from google/containerregistry, in order to _really_ make this work, you also have to separately `bazel build //:puller.par` in containerregistry and add it to your workspace as `puller`.)

I'm open to alternative suggestions as well, this just seemed like a reasonable and reasonably quick route to get from the changes proposed to containerregistry and me having a working build :)

Feedback welcome!