### PR TITLE
Run ./update_deps.sh to pull in latest security fixes from distroless.

### DIFF
--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2018-08-29 13:10 -0400
-    "debug": "sha256:1163dca22892a205394bdc5e8c2acb857a59d7ff8b53c4f52692112366d8596c",
-    # "gcr.io/distroless/cc:latest" circa 2018-08-29 13:10 -0400
+    # "gcr.io/distroless/cc:debug" circa 2018-10-15 14:08 +0200
+    "debug": "sha256:d8f6bf07bc352cf691f1de3d17d42282f007e631dbad7c973d2c478167afa302",
+    # "gcr.io/distroless/cc:latest" circa 2018-10-15 14:08 +0200
     "latest": "sha256:923564f1d33ac659c15edf538b62f716ed436d7cc5f6a9d64460b8affba9ccd9",
 }

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2018-08-29 13:10 -0400
-    "debug": "sha256:333a18407c0e2d46b264a240175284b3bd2482892f4273bacb63a5d37a7adea2",
-    # "gcr.io/distroless/base:latest" circa 2018-08-29 13:10 -0400
+    # "gcr.io/distroless/base:debug" circa 2018-10-15 14:08 +0200
+    "debug": "sha256:f1220177b570f74608e2b5868220c6c1ca190b51ceb8db26a131ff7c13b1e648",
+    # "gcr.io/distroless/base:latest" circa 2018-10-15 14:08 +0200
     "latest": "sha256:628939ac8bf3f49571d05c6c76b8688cb4a851af6c7088e599388259875bde20",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2018-08-29 13:10 -0400
-    "debug": "sha256:3eda0efe25b65616ab253ae64795fec265c3f922de055c4dc2cb1523486e1e84",
-    # "gcr.io/distroless/java:latest" circa 2018-08-29 13:10 -0400
+    # "gcr.io/distroless/java:debug" circa 2018-10-15 14:08 +0200
+    "debug": "sha256:fd8c084651e6b55e0d3597a46deee97514d4cc22dd5fcb2e73501207200c443b",
+    # "gcr.io/distroless/java:latest" circa 2018-10-15 14:08 +0200
     "latest": "sha256:b430543bea1d8326e767058bdab3a2482ea45f59d7af5c5c61334cd29ede88a1",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2018-08-29 13:10 -0400
-    "debug": "sha256:4bec71e275183f6306ea1bfe490dcf54732fcc7e37c137129ad30ed9dc62b99d",
-    # "gcr.io/distroless/java/jetty:latest" circa 2018-08-29 13:10 -0400
-    "latest": "sha256:74c340787cae1ad681a467cc04e1162f9cdc84082d7e4211a860b00891b71391",
+    # "gcr.io/distroless/java/jetty:debug" circa 2018-10-15 14:08 +0200
+    "debug": "sha256:c5668a1a44695a5c42da894ebde838e2135c34787db7d1da0f7a1b982ae6435e",
+    # "gcr.io/distroless/java/jetty:latest" circa 2018-10-15 14:08 +0200
+    "latest": "sha256:94cfea7ce6d77464a415d11a89302da8a6e1ae6a1cdc7aaa5884c776a8c9eaeb",
 }

--- a/nodejs/nodejs.bzl
+++ b/nodejs/nodejs.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/google-appengine/debian9:debug" circa 2018-08-29 13:10 -0400
+    # "gcr.io/google-appengine/debian9:debug" circa 2018-10-15 14:08 +0200
     "debug": "sha256:741d18b41622814ae6eab29b0679dd45318437998213a5cb5532003846b435e1",
-    # "gcr.io/google-appengine/debian9:latest" circa 2018-08-29 13:10 -0400
+    # "gcr.io/google-appengine/debian9:latest" circa 2018-10-15 14:08 +0200
     "latest": "sha256:741d18b41622814ae6eab29b0679dd45318437998213a5cb5532003846b435e1",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2018-08-29 13:10 -0400
-    "debug": "sha256:84af63da51ccdb212f7e056c435752af598f68df9b443a6960c19548f004a611",
-    # "gcr.io/distroless/python2.7:latest" circa 2018-08-29 13:10 -0400
+    # "gcr.io/distroless/python2.7:debug" circa 2018-10-15 14:08 +0200
+    "debug": "sha256:5955bb353698ce30f35e4c238e3abd88ecff3079131d7263f18452ae61a4a758",
+    # "gcr.io/distroless/python2.7:latest" circa 2018-10-15 14:08 +0200
     "latest": "sha256:05d6f4e90bb4924daa00639a4b47cf172718347f41b999cd8a8ab2665a8fdf09",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -18,8 +18,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2018-08-29 13:10 -0400
-    "debug": "sha256:8fc8c9055459ede89337c843556e3aaa22dd88b6ef9b2df8f0a67cfdf4fc40bd",
-    # "gcr.io/distroless/python3:latest" circa 2018-08-29 13:10 -0400
+    # "gcr.io/distroless/python3:debug" circa 2018-10-15 14:08 +0200
+    "debug": "sha256:8aa7cf7ed8ecaddbae9dfeb10d610ef1316e62498f41bbd86f88be491a8498b8",
+    # "gcr.io/distroless/python3:latest" circa 2018-10-15 14:08 +0200
     "latest": "sha256:e6f8bdb32b8640ba7f8d11603f64d5efaf673ac050100c5314650878f36f092d",
 }


### PR DESCRIPTION
Make sure we have the changes from GoogleContainerTools/distroless@464d1ef

Fixes #546