### PR TITLE
Update rules_go to 0.16.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -147,9 +147,9 @@ groovy_repositories()
 # For our go_image test.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "50207a04b74fe30218b06ac4467ea3862b9a3c99d3df7686be0eae02108ea06f",
+    sha256 = "ee5fe78fe417c685ecb77a0a725dc9f6040ae5beb44a0ba4ddb55453aad23a8a",
     strip_prefix = "rules_go-0.13.0",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/0.13.0.tar.gz"],
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.0/rules_go-0.16.0.tar.gz",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -148,7 +148,6 @@ groovy_repositories()
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "ee5fe78fe417c685ecb77a0a725dc9f6040ae5beb44a0ba4ddb55453aad23a8a",
-    strip_prefix = "rules_go-0.13.0",
     url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.0/rules_go-0.16.0.tar.gz",
 )
 

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -173,6 +173,6 @@ file_test(
 
 file_test(
     name = "test_digest_output2",
-    content = "sha256:acff18cc59851acc448c0f106ccefdd13907a91835d61b8b34f85a974a2e540a",
+    content = "sha256:8c70e530d7d9fd0018245579af25277d3ba0d47212b092225c391c41a82debef",
     file = ":null_cmd_and_entrypoint_none.digest",
 )


### PR DESCRIPTION
Needed as part of bazelbuild/bazel#6283.