### PR TITLE
cleanup: use the new Python octal integer literals notation consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ passwd_file(
 pkg_tar(
     name = "passwd_tar",
     srcs = [":passwd"],
-    mode = "0644",
+    mode = "0o644",
     package_dir = "etc",
 )
 
@@ -1156,7 +1156,7 @@ A rule that assembles data into a tarball which can be use as in `layers` attr i
     <tr>
       <td><code>mode</code></td>
       <td>
-        <code>String, default to 0555</code>
+        <code>String, default to 0o555</code>
         <p>
           Set the mode of files added by the <code>files</code> attribute.
         </p>
@@ -1365,7 +1365,7 @@ container_image(name, base, data_path, directory, files, legacy_repository_namin
     <tr>
       <td><code>mode</code></td>
       <td>
-        <code>String, default to 0555</code>
+        <code>String, default to 0o555</code>
         <p>
           Set the mode of files added by the <code>files</code> attribute.
         </p>

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -67,7 +67,7 @@ gflags.DEFINE_string(
 gflags.DEFINE_multistring(
     'modes', None,
     'Specific mode to apply to specific file (from the file argument),'
-    ' e.g., path/to/file=0455.')
+    ' e.g., path/to/file=0o455.')
 
 gflags.DEFINE_multistring('owners', None,
                           'Specify the numeric owners of individual files, '

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -23,8 +23,8 @@ from containerregistry.client import docker_name
 from containerregistry.client.v2_2 import docker_image as v2_2_image
 
 TEST_DATA_TARGET_BASE='testdata'
-DIR_PERMISSION=448 # decimal for oct 0700
-PASSWD_FILE_MODE=420  # decimal for oct 0644
+DIR_PERMISSION=0o700
+PASSWD_FILE_MODE=0o644
 
 def TestData(name):
   return os.path.join(os.environ['TEST_SRCDIR'], 'io_bazel_rules_docker',

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -201,7 +201,7 @@ _layer_attrs = dict({
     "data_path": attr.string(),
     "directory": attr.string(default = "/"),
     "files": attr.label_list(allow_files = True),
-    "mode": attr.string(default = "0555"),  # 0555 == a+rx
+    "mode": attr.string(default = "0o555"),  # 0o555 == a+rx
     "tars": attr.label_list(allow_files = tar_filetype),
     "debs": attr.label_list(allow_files = deb_filetype),
     "symlinks": attr.string_dict(),

--- a/contrib/passwd.bzl
+++ b/contrib/passwd.bzl
@@ -71,7 +71,7 @@ def _build_homedirs_tar(ctx, passwd_file):
     )
     args = [
         "--output=" + ctx.outputs.passwd_tar.path,
-        "--mode=0700",
+        "--mode=0o700",
         "--file=%s=%s" % (passwd_file.path, dest_file),
         "--modes=%s=%s" % (dest_file, ctx.attr.passwd_file_mode),
     ]
@@ -133,7 +133,7 @@ passwd_tar = rule(
             providers = [PasswdFileContentProvider],
         ),
         "passwd_file_pkg_dir": attr.string(mandatory = True),
-        "passwd_file_mode": attr.string(default = "0644"),
+        "passwd_file_mode": attr.string(default = "0o644"),
         "build_tar": attr.label(
             default = Label("//container:build_tar"),
             cfg = "host",

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -42,47 +42,47 @@ container_image(
 container_image(
     name = "no_data_path_image",
     files = ["//testdata/test:test-data"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_image(
     name = "data_path_image",
     data_path = ".",
     files = ["//testdata/test:test-data"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_image(
     name = "absolute_data_path_image",
     data_path = "/tools/build_defs",
     files = ["//testdata/test:test-data"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_image(
     name = "root_data_path_image",
     data_path = "/",
     files = ["//testdata/test:test-data"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_image(
     name = "gen_image",
     files = [":gen"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_image(
     name = "files_base",
     files = ["foo"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_image(
     name = "files_with_files_base",
     base = ":files_base",
     files = ["bar"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_image(
@@ -90,13 +90,13 @@ container_image(
     base = ":files_base",
     files = ["bar"],
     layers = [":files_in_layer"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_layer(
     name = "files_in_layer",
     files = ["baz"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_image(
@@ -140,7 +140,7 @@ container_image(
     name = "files_with_tar_base",
     base = ":tar_base",
     files = ["bar"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_image(
@@ -153,7 +153,7 @@ container_image(
     name = "docker_tarball_base",
     base = "@pause_tar//image",
     files = ["foo"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_image(
@@ -164,7 +164,7 @@ container_image(
         ":files_in_layer",
         ":tars_in_layer",
     ],
-    mode = "0644",
+    mode = "0o644",
 )
 
 # TODO(mattmoor): Test scalar entrypoint
@@ -172,7 +172,7 @@ container_image(
     name = "base_with_entrypoint",
     entrypoint = ["/bar"],
     files = ["bar"],
-    mode = "0644",
+    mode = "0o644",
     ports = ["8080"],
     tars = ["two.tar"],
 )
@@ -191,7 +191,7 @@ container_image(
     base = ":base_with_entrypoint",
     cmd = ["shadowed-arg"],
     files = ["foo"],
-    mode = "0644",
+    mode = "0o644",
 )
 
 container_image(
@@ -211,7 +211,7 @@ container_image(
         "bar",
         "foo",
     ],
-    mode = "0644",
+    mode = "0o644",
     volumes = ["/logs"],
 )
 
@@ -525,7 +525,7 @@ passwd_file(
 pkg_tar(
     name = "passwd_tar",
     srcs = [":passwd"],
-    mode = "0644",
+    mode = "0o644",
     package_dir = "etc",
 )
 
@@ -580,7 +580,7 @@ group_file(
 pkg_tar(
     name = "group_tar",
     srcs = [":group"],
-    mode = "0644",
+    mode = "0o644",
     package_dir = "etc",
 )
 


### PR DESCRIPTION
Python supports two notations for octal integer literals: 0X and 0oX. According to PEP-3127, the former is deprecated and will be dropped in Python 3. Update rules_docker to use the new notation consistently.

https://www.python.org/dev/peps/pep-3127/#grammar-specification