### PR TITLE
remove use of bazel tools from external workspace

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -70,8 +70,8 @@ py_binary(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_source//tools/build_defs/pkg:archive",
         "@bazel_tools//third_party/py/gflags",
+        "@bazel_tools//tools/build_defs/pkg:archive",
     ],
 )
 

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -24,7 +24,7 @@ import re
 import tarfile
 import tempfile
 
-from bazel_source.tools.build_defs.pkg import archive
+from tools.build_defs.pkg import archive
 from third_party.py import gflags
 
 gflags.DEFINE_string('output', None, 'The output file, mandatory')

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -91,14 +91,6 @@ def repositories():
             strip_prefix = "containerregistry-" + CONTAINERREGISTRY_RELEASE[1:],
         )
 
-    # TODO(nichow): Remove after bazel 0.17.0 is released
-    if "bazel_source" not in excludes:
-        http_archive(
-            name = "bazel_source",
-            urls = [("https://releases.bazel.build/0.17.0/rc1/bazel-0.17.0rc1-dist.zip")],
-            sha256 = "46dfffac884ccd51fcb493dd86463cb8c21be949fdb17634ca37805fd544beae",
-        )
-
     # TODO(mattmoor): Remove all of this (copied from google/containerregistry)
     # once transitive workspace instantiation lands.
 


### PR DESCRIPTION
* This was added in https://github.com/bazelbuild/rules_docker/commit/e9e2809b7099f92e46f9e8336cda041ab78fcf35 to access a feature not available in bazel release, should not be needed anymore