### PR TITLE
Support stamp and creation_time in go_image

### DIFF
--- a/go/image.bzl
+++ b/go/image.bzl
@@ -62,7 +62,15 @@ DEFAULT_BASE = select({
     "//conditions:default": "@go_image_base//image",
 })
 
-def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+def go_image(
+    name,
+    base = None,
+    deps = [],
+    layers = [],
+    binary = None,
+    stamp = None,
+    creation_time = None,
+    **kwargs):
     """Constructs a container image wrapping a go_binary target.
 
   Args:
@@ -94,4 +102,6 @@ def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        stamp = stamp,
+        creation_time = creation_time,
     )

--- a/tests/go/BUILD.bazel
+++ b/tests/go/BUILD.bazel
@@ -1,0 +1,29 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("//go:image.bzl", "go_image")
+
+go_binary(
+    name = "app",
+    srcs = ["main.go"],
+)
+
+go_image(
+    name = "image",
+    binary = ":app",
+    pure = "on",
+    stamp = True,
+)
+
+go_image(
+    name = "image_build_binary",
+    srcs = ["main.go"],
+    pure = "on",
+    creation_time = "1540414141.367007",
+)
+
+py_test(
+    name = "test_go_image",
+    srcs = ["test_go_image.py"],
+    data = [":image", ":image_build_binary"],
+)

--- a/tests/go/main.go
+++ b/tests/go/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("success")
+}
+

--- a/tests/go/test_go_image.py
+++ b/tests/go/test_go_image.py
@@ -1,0 +1,38 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Basic validation of go_image targets."""
+
+import os
+import tarfile
+import unittest
+
+class TestGoImage(unittest.TestCase):
+
+
+  def _test_file(self, path):
+    tf = tarfile.open('tests/go/image-layer.tar')
+    for mem in tf.getmembers():
+      if mem.name == '/app/tests/go/app':
+        return
+    self.fail('failed to find /app/tests/go/app')
+
+  def test_image(self):
+    self._test_file('tests/go/image-layer.tar')
+
+  def test_image_build_binary(self):
+    self._test_file('tests/go/image_build_binary-layer.tar')
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
ref https://github.com/bazelbuild/rules_docker/issues/155

* Allow `go_image(creation_time="1540414141")` and `go_image(stamp=True)`
* Basic unit tests for `go_image()` that validates the tar file

/assign @nlopezgi 