### PR TITLE
makes java_image rule main_class parameter optional

### DIFF
--- a/java/image.bzl
+++ b/java/image.bzl
@@ -192,7 +192,7 @@ def _jar_app_layer_impl(ctx):
         "-cp",
         # Support optionally passing the classpath as a file.
         "@" + classpath_path if ctx.attr._classpath_as_file else classpath,
-    ] + jvm_flags + [ctx.attr.main_class] + args
+    ] + jvm_flags + ([ctx.attr.main_class] + args if ctx.attr.main_class != None else [])
 
     file_map = {
         layer_file_path(ctx, f): f
@@ -224,7 +224,7 @@ jar_app_layer = rule(
         # The base image on which to overlay the dependency layers.
         "base": attr.label(mandatory = True),
         # The main class to invoke on startup.
-        "main_class": attr.string(mandatory = True),
+        "main_class": attr.string(mandatory = False),
 
         # Whether the classpath should be passed as a file.
         "_classpath_as_file": attr.bool(default = False),


### PR DESCRIPTION
Allows additional jvm_flags to be provided at runtime.  Example of this in kubernetes would look something like:
```
      - name: myapp
        image: myapp
        args:
          - '-Xmx10g'
          - '-Xms10g'
          - 'com.mycompany.MyApp'
          - 'applicationArgument1'
          - 'applicationAgument2'
```

The intent here is to allow users to build a single image with the `java_image` rule, but to have the ability to add JVM parameters at runtime based on the context in which they are running the image (size of pod, production vs test environment).  This is preferable to having to build an image per combination of possible flags they would require.  If there is a better way to supply these flags at runtime I am happy to discuss alternatives.