### PR TITLE
makes java_image rule main_class parameter optional

### DIFF
--- a/java/image.bzl
+++ b/java/image.bzl
@@ -261,6 +261,14 @@ def java_image(
   Args:
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
+    main_class: This parameter is optional. If provided it will be used in the
+                compilation of any additional sources, and as part of the
+                construction of the container entrypoint. If not provided, the
+                name parameter is used as the main_class when compiling any
+                additional sources, and the main_class is not included in the
+                construction of the container entrypoint. Omitting main_class
+                allows the user to specify additional arguments to the JVM at
+                runtime.
     **kwargs: See java_binary.
   """
     binary_name = name + ".binary"

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -266,11 +266,11 @@ def java_image(
     binary_name = name + ".binary"
     native.java_binary(
         name = binary_name,
-        # Calling java_binary with main_class = None will work if the package binary_name
-        # contains java or javatest.  In this case, the main_class is guessed to be the
-        # same as the name parameter.  To avoid assumptions about package locations, if
-        # the main_class is None we are passing in the value of the name parameter to allow
-        # the build to proceed.
+        # Calling java_binary with main_class = None will work if the package
+        # name contains java or javatest. In this case, the main_class is
+        # guessed by the java_binary implementation. To avoid assumptions about
+        # package locations, if the main_class is None we use the value of
+        # the name parameter as main_class to allow the build to proceed.
         main_class = main_class if main_class != None else binary_name,
         # If the rule is turning a JAR built with java_library into
         # a binary, then it will appear in runtime_deps.  We are

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -192,7 +192,7 @@ def _jar_app_layer_impl(ctx):
         "-cp",
         # Support optionally passing the classpath as a file.
         "@" + classpath_path if ctx.attr._classpath_as_file else classpath,
-    ] + jvm_flags + [ctx.attr.main_class] + args
+    ] + jvm_flags + ([ctx.attr.main_class] + args if ctx.attr.main_class != None else [])
 
     file_map = {
         layer_file_path(ctx, f): f
@@ -224,7 +224,7 @@ jar_app_layer = rule(
         # The base image on which to overlay the dependency layers.
         "base": attr.label(mandatory = True),
         # The main class to invoke on startup.
-        "main_class": attr.string(mandatory = True),
+        "main_class": attr.string(mandatory = False),
 
         # Whether the classpath should be passed as a file.
         "_classpath_as_file": attr.bool(default = False),

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -816,6 +816,14 @@ java_image(
 )
 
 java_image(
+    name = "java_partial_entrypoint_image",
+    srcs = ["Binary.java"],
+    main_class = "examples.images.Binary",
+    partial_entrypoint = True,
+    layers = [":java_image_library"],
+)
+
+java_image(
     name = "java_sandwich_image",
     srcs = ["Binary.java"],
     layers = [":scala_image_library"],

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -818,8 +818,6 @@ java_image(
 java_image(
     name = "java_partial_entrypoint_image",
     srcs = ["Binary.java"],
-    main_class = "examples.images.Binary",
-    partial_entrypoint = True,
     layers = [":java_image_library"],
 )
 

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -268,6 +268,12 @@ function test_java_image() {
   EXPECT_CONTAINS "$(bazel run "$@" testdata:java_image)" "Hello World"
 }
 
+function test_java_partial_entrypoint_image() {
+  cd "${ROOT}"
+  clear_docker
+  EXPECT_CONTAINS "$(bazel run "$@" testdata:java_partial_entrypoint_image examples.images.Binary)" "Hello World"
+}
+
 function test_java_image_with_custom_run_flags() {
   cd "${ROOT}"
   clear_docker

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -19,6 +19,7 @@ load(
     "@bazel_tools//tools/build_rules:test_rules.bzl",
     "file_test",
 )
+load("//java:image.bzl", "java_image")
 
 container_test(
     name = "structure_test",
@@ -142,6 +143,29 @@ container_test(
     name = "set_cmd_and_entrypoint_null_on_base_test",
     configs = ["//tests/docker/configs:set_cmd_and_entrypoint.yaml"],
     image = ":set_cmd_and_entrypoint_null_on_base",
+)
+
+java_image(
+    name = "java_partial_entrypoint_image",
+    runtime_deps = ["//testdata:java_bin_as_lib"],
+)
+
+container_test(
+    name = "java_partial_entrypoint_image_test",
+    configs = ["//tests/docker/configs:java_partial_entrypoint.yaml"],
+    image = ":java_partial_entrypoint_image",
+)
+
+java_image(
+    name = "java_image",
+    main_class = "examples.images.Binary",
+    runtime_deps = ["//testdata:java_bin_as_lib"],
+)
+
+container_test(
+    name = "java_entrypoint_image_test",
+    configs = ["//tests/docker/configs:java_entrypoint.yaml"],
+    image = ":java_image",
 )
 
 container_import(

--- a/tests/docker/configs/java_entrypoint.yaml
+++ b/tests/docker/configs/java_entrypoint.yaml
@@ -1,0 +1,4 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  entrypoint: ["/usr/bin/java -cp /app/io_bazel_rules_docker/testdata/libjava_bin_as_lib.jar:/app/io_bazel_rules_docker/testdata/libjava_image_library.jar:/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:/app/io_bazel_rules_docker/tests/docker/java_image.binary.jar:/app/io_bazel_rules_docker/tests/docker/java_image.binary examples.images.Binary"]

--- a/tests/docker/configs/java_entrypoint.yaml
+++ b/tests/docker/configs/java_entrypoint.yaml
@@ -1,4 +1,8 @@
 schemaVersion: 2.0.0
 
 metadataTest:
-  entrypoint: ["/usr/bin/java -cp /app/io_bazel_rules_docker/testdata/libjava_bin_as_lib.jar:/app/io_bazel_rules_docker/testdata/libjava_image_library.jar:/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:/app/io_bazel_rules_docker/tests/docker/java_image.binary.jar:/app/io_bazel_rules_docker/tests/docker/java_image.binary examples.images.Binary"]
+  entrypoint: 
+    - "/usr/bin/java"
+    - "-cp"
+    - "/app/io_bazel_rules_docker/testdata/libjava_bin_as_lib.jar:/app/io_bazel_rules_docker/testdata/libjava_image_library.jar:/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:/app/io_bazel_rules_docker/tests/docker/java_image.binary.jar:/app/io_bazel_rules_docker/tests/docker/java_image.binary"
+    - "examples.images.Binary"

--- a/tests/docker/configs/java_partial_entrypoint.yaml
+++ b/tests/docker/configs/java_partial_entrypoint.yaml
@@ -1,4 +1,7 @@
 schemaVersion: 2.0.0
 
 metadataTest:
-  entrypoint: ["/usr/bin/java -cp /app/io_bazel_rules_docker/testdata/libjava_bin_as_lib.jar:/app/io_bazel_rules_docker/testdata/libjava_image_library.jar:/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:/app/io_bazel_rules_docker/tests/docker/java_partial_entrypoint_image.binary.jar:/app/io_bazel_rules_docker/tests/docker/java_partial_entrypoint_image.binary"]
+  entrypoint: 
+    - "/usr/bin/java"
+    - "-cp"
+    - "/app/io_bazel_rules_docker/testdata/libjava_bin_as_lib.jar:/app/io_bazel_rules_docker/testdata/libjava_image_library.jar:/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:/app/io_bazel_rules_docker/tests/docker/java_partial_entrypoint_image.binary.jar:/app/io_bazel_rules_docker/tests/docker/java_partial_entrypoint_image.binary"

--- a/tests/docker/configs/java_partial_entrypoint.yaml
+++ b/tests/docker/configs/java_partial_entrypoint.yaml
@@ -1,0 +1,4 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  entrypoint: ["/usr/bin/java -cp /app/io_bazel_rules_docker/testdata/libjava_bin_as_lib.jar:/app/io_bazel_rules_docker/testdata/libjava_image_library.jar:/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:/app/io_bazel_rules_docker/tests/docker/java_partial_entrypoint_image.binary.jar:/app/io_bazel_rules_docker/tests/docker/java_partial_entrypoint_image.binary"]


### PR DESCRIPTION
Allows additional jvm_flags to be provided at runtime. Example of this in kubernetes would look something like:

```
      - name: myapp
        image: myapp
        args:
          - '-Xmx10g'
          - '-Xms10g'
          - 'com.mycompany.MyApp'
          - 'applicationArgument1'
          - 'applicationAgument2'
```
Based on some initial discussion here: https://github.com/bazelbuild/rules_docker/issues/548
The intent here is to allow users to build a single image with the java_image rule, but to have the ability to add JVM parameters at runtime based on the context in which they are running the image (size of pod, production vs test environment). This is preferable to having to build an image per combination of possible flags they would require. If there is a better way to supply these flags at runtime I am happy to discuss alternatives.

The idea in the issue linked above was based on possible variable expansion and requires images have a shell, which the distroless images do not.  The solution in this PR aims to be simple, backwards compatible, and compatible with images that do not include a shell