### PR TITLE
Remove exec constraint for docker toolchain

### DIFF
--- a/toolchains/docker/BUILD
+++ b/toolchains/docker/BUILD
@@ -30,10 +30,6 @@ docker_toolchain(
 
 toolchain(
     name = "default_linux_toolchain",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
-    ],
     target_compatible_with = [
         "@bazel_tools//platforms:linux",
         "@bazel_tools//platforms:x86_64",
@@ -44,10 +40,6 @@ toolchain(
 
 toolchain(
     name = "default_windows_toolchain",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:windows",
-        "@bazel_tools//platforms:x86_64",
-    ],
     target_compatible_with = [
         "@bazel_tools//platforms:windows",
         "@bazel_tools//platforms:x86_64",
@@ -58,10 +50,6 @@ toolchain(
 
 toolchain(
     name = "default_osx_toolchain",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
-    ],
     target_compatible_with = [
         "@bazel_tools//platforms:osx",
         "@bazel_tools//platforms:x86_64",


### PR DESCRIPTION
The docker toolchain is only meant to be used in the target platform.
Thus the host environment is irrelevant and the registered toolchains
shouldn't include constraints from those

See https://github.com/bazelbuild/rules_k8s/issues/215 which lead to the discovery of this issue. Specifically https://github.com/bazelbuild/rules_k8s/issues/215#issuecomment-437059049 explains why.

https://github.com/bazelbuild/rules_k8s/pull/218 makes the same fix for rules_k8s