### PR TITLE
migrate first java_image tests from image_test.py to container_test

### DIFF
--- a/container/image_test.py
+++ b/container/image_test.py
@@ -687,23 +687,6 @@ class ImageTest(unittest.TestCase):
         './app/com_google_guava_guava/jar/guava-18.0.jar',
       ])
 
-      self.assertConfigEqual(img, 'Entrypoint', [
-        '/usr/bin/java', '-cp',
-        ':'.join([
-          '/app/io_bazel_rules_docker/testdata/libjava_image_library.jar',
-          '/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar',
-          '/app/io_bazel_rules_docker/testdata/java_image.binary.jar',
-          '/app/io_bazel_rules_docker/testdata/java_image.binary',
-          '/app/io_bazel_rules_docker/testdata/BUILD',
-        ]),
-        '-XX:MaxPermSize=128M',
-        '-Dbuild.location=testdata/BUILD',
-        'examples.images.Binary',
-        'arg0',
-        'arg1',
-        'testdata/BUILD'
-      ])
-
   def test_java_runfiles_image(self):
     with TestImage('java_runfiles_image') as img:
       # Check the application layer, which is on top.
@@ -829,24 +812,6 @@ class ImageTest(unittest.TestCase):
         '/app/testdata/py3_image.binary',
       ])
       self.assertConfigEqual(img, 'Cmd', [
-        'arg0',
-        'arg1',
-        'testdata/BUILD',
-      ])
-
-  def test_java_image_args(self):
-    with TestImage('java_image') as img:
-      self.assertConfigEqual(img, 'Entrypoint', [
-        '/usr/bin/java',
-        '-cp',
-        '/app/io_bazel_rules_docker/testdata/libjava_image_library.jar:'
-        +'/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:'
-        +'/app/io_bazel_rules_docker/testdata/java_image.binary.jar:'
-        +'/app/io_bazel_rules_docker/testdata/java_image.binary:'
-        +'/app/io_bazel_rules_docker/testdata/BUILD',
-        '-XX:MaxPermSize=128M',
-        '-Dbuild.location=testdata/BUILD',
-        'examples.images.Binary',
         'arg0',
         'arg1',
         'testdata/BUILD',

--- a/tests/docker/java/BUILD
+++ b/tests/docker/java/BUILD
@@ -1,0 +1,47 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+load("//container:container.bzl", "container_image", "container_import")
+load("//java:image.bzl", "java_image")
+load("//contrib:test.bzl", "container_test")
+
+java_library(
+    name = "java_image_library",
+    srcs = ["//testdata:Library.java"],
+    deps = ["@com_google_guava_guava//jar"],
+)
+
+java_image(
+    name = "java_image",
+    srcs = ["//testdata:Binary.java"],
+    args = [
+        "arg0",
+        "arg1",
+        "$(location :BUILD)",
+    ],
+    data = [":BUILD"],
+    jvm_flags = [
+        "-XX:MaxPermSize=128M",
+        "-Dbuild.location=$(location :BUILD)",
+    ],
+    layers = [":java_image_library"],
+    main_class = "examples.images.Binary",
+)
+
+container_test(
+    name = "java_image_entrypoint_test",
+    configs = ["//tests/docker/java/configs:java_image_entrypoint.yaml"],
+    image = ":java_image",
+)

--- a/tests/docker/java/configs/BUILD
+++ b/tests/docker/java/configs/BUILD
@@ -13,4 +13,3 @@
 # limitations under the License.
 
 exports_files(glob(["*.yaml"]))
-

--- a/tests/docker/java/configs/BUILD
+++ b/tests/docker/java/configs/BUILD
@@ -1,0 +1,16 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exports_files(glob(["*.yaml"]))
+

--- a/tests/docker/java/configs/java_image_entrypoint.yaml
+++ b/tests/docker/java/configs/java_image_entrypoint.yaml
@@ -1,0 +1,13 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  entrypoint: [
+        '/usr/bin/java',
+        '-cp',
+        '/app/io_bazel_rules_docker/tests/docker/java/libjava_image_library.jar:/app/io_bazel_rules_docker/../com_google_guava_guava/jar/guava-18.0.jar:/app/io_bazel_rules_docker/tests/docker/java/java_image.binary.jar:/app/io_bazel_rules_docker/tests/docker/java/java_image.binary:/app/io_bazel_rules_docker/tests/docker/java/BUILD',
+        '-XX:MaxPermSize=128M',
+        '-Dbuild.location=tests/docker/java/BUILD',
+        'examples.images.Binary',
+        'arg0',
+        'arg1',
+        'tests/docker/java/BUILD']


### PR DESCRIPTION
lets try to reduce the use of image_test.py for as many use cases as possible now that container_test can do equivalent functionality. The one use case I think we dont support now is finding files by layers, but for almost everything else we should be able to use container_test. This PR is an example so other tests can be migrated or added in the future in a similar way.