### PR TITLE
Fix not contains in end-to-end tests

### DIFF
--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -35,13 +35,6 @@ function CONTAINS() {
   echo "${complete}" | grep -Fsq -- "${substring}"
 }
 
-function NOT_CONTAINS() {
-  local complete="${1}"
-  local substring="${2}"
-
-  echo "${complete}" | grep -Fsqv -- "${substring}"
-}
-
 function EXPECT_CONTAINS() {
   local complete="${1}"
   local substring="${2}"
@@ -57,7 +50,7 @@ function EXPECT_NOT_CONTAINS() {
   local message="${3:-Expected '${substring}' found in '${complete}'}"
 
   echo Checking "$1" does not contain "$2"
-  NOT_CONTAINS "${complete}" "${substring}" || fail "$message"
+  ! (CONTAINS "${complete}" "${substring}") || fail "$message"
 }
 
 function stop_containers() {


### PR DESCRIPTION
The function NOT CONTAINS would output success if any line in the output did not contain substring.
The new version outputs success if no line in the output contains substring.

Not sure if this was intentional, naming seems to suggest it wasn't.