### PR TITLE
Fix bazel run image arg duplication (#374)

### DIFF
--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -173,10 +173,9 @@ def incremental_load(
             ),
         ]
         if run:
-            # bazel automatically passes ctx.attr.args to the binary on run, so args get passed in
-            # twice. See https://github.com/bazelbuild/rules_docker/issues/374
+            # Args are embedded into the image, so omitted here.
             run_statements += [
-                "docker run %s %s \"$@\"" % (run_flags, tag_reference),
+                "docker run %s %s" % (run_flags, tag_reference),
             ]
 
     ctx.template_action(

--- a/testdata/ArgEcho.java
+++ b/testdata/ArgEcho.java
@@ -1,0 +1,21 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples.images;
+
+public class ArgEcho {
+    public static void main(String[] args) {
+        System.out.println(String.join(" ", args));
+    }
+}

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -859,6 +859,13 @@ java_image(
     runtime_deps = [":java_bin_as_lib"],
 )
 
+java_image(
+    name = "java_image_arg_echo",
+    srcs = ["ArgEcho.java"],
+    args = ["arg0"],
+    main_class = "examples.images.ArgEcho",
+)
+
 war_image(
     name = "war_image",
     srcs = ["Servlet.java"],

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -42,6 +42,13 @@ function NOT_CONTAINS() {
   echo "${complete}" | grep -Fsqv -- "${substring}"
 }
 
+function COUNT() {
+  local complete="${1}"
+  local substring="${2}"
+
+  echo "${complete}" | grep -Fso -- "${substring}" | wc -l
+}
+
 function EXPECT_CONTAINS() {
   local complete="${1}"
   local substring="${2}"
@@ -49,6 +56,17 @@ function EXPECT_CONTAINS() {
 
   echo Checking "$1" contains "$2"
   CONTAINS "${complete}" "${substring}" || fail "$message"
+}
+
+function EXPECT_CONTAINS_ONCE() {
+  local complete="${1}"
+  local substring="${2}"
+  local count=$(COUNT "${complete}" "${substring}")
+
+  echo Checking "$1" contains "$2" exactly once
+  if [[ count -ne "1" ]]; then
+    fail "${3:-Expected '${substring}' found ${count} in '${complete}'}"
+  fi
 }
 
 function EXPECT_NOT_CONTAINS() {
@@ -294,6 +312,13 @@ function test_java_bin_as_lib_image() {
   docker run -ti --rm bazel/testdata:java_bin_as_lib_image
 }
 
+function test_java_image_arg_echo() {
+  cd "${ROOT}"
+  clear_docker
+  EXPECT_CONTAINS_ONCE "$(bazel run "$@" testdata:java_image_arg_echo)" "arg0"
+  EXPECT_CONTAINS_ONCE "$(docker run -ti --rm bazel/testdata:java_image_arg_echo | tr '\r' '\n')" "arg0"
+}
+
 function test_war_image() {
   cd "${ROOT}"
   clear_docker
@@ -387,6 +412,7 @@ test_java_image_with_custom_run_flags -c dbg
 test_java_sandwich_image -c opt
 test_java_sandwich_image -c dbg
 test_java_bin_as_lib_image
+test_java_image_arg_echo
 test_war_image
 test_war_image_with_custom_run_flags
 test_scala_image -c opt


### PR DESCRIPTION
Fixes #374 

Remove `args` passed to the generated run image script
Bazel forwards the `args` param passed to a rule automatically to the resulting image when using bazel run.
Images already contain these args in the form of container args, as a result the args were getting duplicated.

For now I've only created arg handling checks for java, if you want I can implement them for the other languages as well.
