### PR TITLE
add test for container_push

### DIFF
--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -372,7 +372,15 @@ function test_d_image() {
 function test_nodejs_image() {
   cd "${ROOT}"
   clear_docker
-  EXPECT_CONTAINS "$(bazel run "$@" testdata:nodejs_image)" "Hello World!"
+  EXPECT_CONTAINS "$(bazel run testdata:nodejs_image)" "Hello World!"
+}
+
+function test_container_push() {
+  cd "${ROOT}"
+  clear_docker
+  run -d -p 5000:5000 --name registry registry:2
+  bazel build tests/docker:push_test
+  # run here file_test targets to verify test outputs of push_test
 }
 
 test_top_level
@@ -423,3 +431,4 @@ test_rust_image -c dbg
 # test_d_image -c dbg
 test_nodejs_image -c opt
 test_nodejs_image -c dbg
+test_container_push

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -378,7 +378,7 @@ function test_nodejs_image() {
 function test_container_push() {
   cd "${ROOT}"
   clear_docker
-  run -d -p 5000:5000 --name registry registry:2
+  docker run -d -p 5000:5000 --name registry registry:2
   bazel build tests/docker:push_test
   # run here file_test targets to verify test outputs of push_test
 }

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -13,7 +13,12 @@
 # limitations under the License.
 package(default_visibility = ["//visibility:public"])
 
-load("//container:container.bzl", "container_image", "container_import")
+load(
+    "//container:container.bzl",
+    "container_image",
+    "container_import",
+    "container_push",
+)
 load("//contrib:test.bzl", "container_test")
 load(
     "@bazel_tools//tools/build_rules:test_rules.bzl",
@@ -191,4 +196,13 @@ container_test(
     name = "set_env_csv_test",
     configs = ["//tests/docker/configs:set_env_csv.yaml"],
     image = ":set_env_csv",
+)
+
+container_push(
+    name = "push_test",
+    format = "Docker",
+    image = ":set_cmd",
+    registry = "localhost:5000",
+    repository = "docker/test",
+    tag = "test",
 )

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -205,4 +205,5 @@ container_push(
     registry = "localhost:5000",
     repository = "docker/test",
     tag = "test",
+    tags = ["manual"],
 )


### PR DESCRIPTION
Add a simple test for container_push by starting up a local registry and using that to push the image. We are using a hardcoded port, not sure if that will work on travis. Lets let it run...


fyi @ceason this PR should enable you to test https://github.com/bazelbuild/rules_docker/pull/591 easily