### PR TITLE
bazel_skylib: update reference to @bazel_skylib//:bzl_library.bzl

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -15,7 +15,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(["push-tag.sh.tpl"])
 
@@ -161,7 +161,7 @@ py_test(
     deps = ["@containerregistry"],
 )
 
-skylark_library(
+bzl_library(
     name = "bundle",
     srcs = ["bundle.bzl"],
     deps = [
@@ -171,7 +171,7 @@ skylark_library(
     ],
 )
 
-skylark_library(
+bzl_library(
     name = "container",
     srcs = ["container.bzl"],
     deps = [
@@ -184,7 +184,7 @@ skylark_library(
     ],
 )
 
-skylark_library(
+bzl_library(
     name = "flatten",
     srcs = ["flatten.bzl"],
     deps = [
@@ -194,7 +194,7 @@ skylark_library(
     ],
 )
 
-skylark_library(
+bzl_library(
     name = "image",
     srcs = ["image.bzl"],
     deps = [
@@ -208,7 +208,7 @@ skylark_library(
     ],
 )
 
-skylark_library(
+bzl_library(
     name = "import",
     srcs = ["import.bzl"],
     deps = [
@@ -221,7 +221,7 @@ skylark_library(
     ],
 )
 
-skylark_library(
+bzl_library(
     name = "layer",
     srcs = ["layer.bzl"],
     deps = [
@@ -234,29 +234,29 @@ skylark_library(
     ],
 )
 
-skylark_library(
+bzl_library(
     name = "layer_tools",
     srcs = ["layer_tools.bzl"],
     deps = ["//skylib:path"],
 )
 
-skylark_library(
+bzl_library(
     name = "load",
     srcs = ["load.bzl"],
     deps = [":pull"],
 )
 
-skylark_library(
+bzl_library(
     name = "providers",
     srcs = ["providers.bzl"],
 )
 
-skylark_library(
+bzl_library(
     name = "pull",
     srcs = ["pull.bzl"],
 )
 
-skylark_library(
+bzl_library(
     name = "push",
     srcs = ["push.bzl"],
     deps = [

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -202,7 +202,7 @@ py_library(
             urls = ["https://storage.googleapis.com/container-structure-test/v1.4.0/container-structure-test-darwin-amd64"],
         )
 
-    # For skylark_library.
+    # For bzl_library.
     if "bazel_skylib" not in excludes:
         http_archive(
             name = "bazel_skylib",

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -15,9 +15,9 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-skylark_library(
+bzl_library(
     name = "docker",
     srcs = ["docker.bzl"],
     deps = [

--- a/skylib/BUILD
+++ b/skylib/BUILD
@@ -15,24 +15,24 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-skylark_library(
+bzl_library(
     name = "filetype",
     srcs = ["filetype.bzl"],
 )
 
-skylark_library(
+bzl_library(
     name = "label",
     srcs = ["label.bzl"],
 )
 
-skylark_library(
+bzl_library(
     name = "path",
     srcs = ["path.bzl"],
 )
 
-skylark_library(
+bzl_library(
     name = "zip",
     srcs = ["zip.bzl"],
 )

--- a/toolchains/docker/BUILD
+++ b/toolchains/docker/BUILD
@@ -14,9 +14,9 @@
 package(default_visibility = ["//visibility:private"])
 
 load(":toolchain.bzl", "docker_toolchain")
-load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-skylark_library(
+bzl_library(
     name = "docker",
     srcs = ["toolchain.bzl"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This was deprecated in https://github.com/bazelbuild/bazel-skylib/commit/6e2d7e4a75b8ec0c307cf2ff2ca3d837633413ca