### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ https://docs.bazel.build/versions/master/be/python.html#py_binary))
 https://docs.bazel.build/versions/master/be/python.html#py_binary))
 * [nodejs_image](#nodejs_image) ([usage](
 https://github.com/bazelbuild/rules_nodejs#usage))
-* [java_image](#java_image) ([signature](
+* [java_image](#java_image) ([signature](see <a href=#go_image-custom-base>go_image (custom base)</a> example.
 https://docs.bazel.build/versions/master/be/java.html#java_binary))
 * [war_image](#war_image) ([signature](
 https://docs.bazel.build/versions/master/be/java.html#java_library))
 * [scala_image](#scala_image) ([signature](
 https://github.com/bazelbuild/rules_scala#scala_binary))
 * [groovy_image](#groovy_image) ([signature](
-https://github.com/bazelbuok, not sure if you want to publish ild/rules_groovy#groovy_binary))
+https://github.com/bazelbuild/rules_groovy#groovy_binary))
 * [cc_image](#cc_image) ([signature](
 https://docs.bazel.build/versions/master/be/c-cpp.html#cc_binary))
 * [go_image](#go_image) ([signature](
@@ -79,10 +79,9 @@ or `container_image` target).
 
 Note also that these rules do not expose any docker related attributes. If you
 need to add a custom `env` or `symlink` to a `lang_image`, you must use
-`container_image` targets for this purpose. You can either use as base for your
-`lang_image` target the `container_image` that adds e.g., custom `env` or `symlink`
-or create a `container_image` target (with the `env` or `symlink`) and set as
-base the `lang_image` target.
+`container_image` targets for this purpose. Specifically, you can use as base for your
+`lang_image` target a `container_image` target that adds e.g., custom `env` or `symlink`.
+Please see <a href=#go_image-custom-base>go_image (custom base)</a> for an example.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ container_pull(
 )
 ```
 
-Note: Bazel does not deal with diamond dependencies. If the repositories that
+Note: Bazel does not deal well with diamond dependencies. If the repositories that
 are imported by `container_repositories()` have already been imported (at a
-different version) by other rules you called in your `WORKSPACE` which are
-placed above the call to `container_repositories()` arbitrary errors might
+different version) by other rules you called in your `WORKSPACE`, which are
+placed above the call to `container_repositories()`, arbitrary errors might
 ocurr. If you get errors related to external repositories, you will likely
 not be able to use `container_repositories()` and will have to import
 directly in your `WORKSPACE` all the required dependencies (see the most up
@@ -306,7 +306,7 @@ to create the desired directory structure and pass that to `container_image` via
 `tars` attribute. Note you might need to set `strip_prefix = "."` or `strip_prefix = "{some directory}"`
 in your rule for the files to not be flattened.
 See <a href="https://github.com/bazelbuild/bazel/issues/2176">Bazel upstream issue 2176</a> and
- <a href="issues/317">rules_docker issue 317</a>
+ <a href="https://github.com/nlopezgi/rules_docker/issues/317">rules_docker issue 317</a>
 for more details.
 
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ https://docs.bazel.build/versions/master/be/python.html#py_binary))
 https://docs.bazel.build/versions/master/be/python.html#py_binary))
 * [nodejs_image](#nodejs_image) ([usage](
 https://github.com/bazelbuild/rules_nodejs#usage))
-* [java_image](#java_image) ([signature]
+* [java_image](#java_image) ([signature](
 https://docs.bazel.build/versions/master/be/java.html#java_binary))
 * [war_image](#war_image) ([signature](
 https://docs.bazel.build/versions/master/be/java.html#java_library))

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ https://docs.bazel.build/versions/master/be/python.html#py_binary))
 https://docs.bazel.build/versions/master/be/python.html#py_binary))
 * [nodejs_image](#nodejs_image) ([usage](
 https://github.com/bazelbuild/rules_nodejs#usage))
-* [java_image](#java_image) ([signature](see <a href=#go_image-custom-base>go_image (custom base)</a> example.
+* [java_image](#java_image) ([signature]
 https://docs.bazel.build/versions/master/be/java.html#java_binary))
 * [war_image](#war_image) ([signature](
 https://docs.bazel.build/versions/master/be/java.html#java_library))

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ to create the desired directory structure and pass that to `container_image` via
 `tars` attribute. Note you might need to set `strip_prefix = "."` or `strip_prefix = "{some directory}"`
 in your rule for the files to not be flattened.
 See <a href="https://github.com/bazelbuild/bazel/issues/2176">Bazel upstream issue 2176</a> and
- <a href="https://github.com/nlopezgi/rules_docker/issues/317">rules_docker issue 317</a>
+ <a href="https://github.com/bazelbuild/rules_docker/issues/317">rules_docker issue 317</a>
 for more details.
 
 

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -206,7 +206,7 @@ py_library(
     if "bazel_skylib" not in excludes:
         http_archive(
             name = "bazel_skylib",
-            #sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
+            sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
             strip_prefix = "bazel-skylib-0.6.0",
             urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz"],
         )


### PR DESCRIPTION
* fix https://github.com/bazelbuild/rules_docker/issues/597
* fix https://github.com/bazelbuild/rules_docker/issues/598
* provide docs for recommended fix for https://github.com/bazelbuild/rules_docker/issues/317
* Improve documentation for xx_image rules to make more explicit that args such as env and symlinks will never be added to xx_image and container_image must be used in conjunction with xx_image for these use cases. 
