### PR TITLE
Automatically infer stamping for container_{push,bundle}

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ at present for doing this.
 
 ### Stamping
 
-The first option is to use `stamp = True`.
+The first option is to use stamping.
 
 ```python
 # A common pattern when users want to avoid trampling
@@ -214,10 +214,6 @@ container_push(
   registry = "gcr.io",
   repository = "my-project/my-image",
   tag = "{BUILD_USER}",
-  creation_time = "{BUILD_TIMESTAMP}",
-
-  # Trigger stamping.
-  stamp = True,
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ at present for doing this.
 
 ### Stamping
 
-The first option is to use stamping.
+The first option is to use stamping. Stamping is enabled when a supported
+attribute contains a python format placeholder (eg `{BUILD_USER}`).
 
 ```python
 # A common pattern when users want to avoid trampling

--- a/container/bundle.bzl
+++ b/container/bundle.bzl
@@ -43,6 +43,7 @@ def _container_bundle_impl(ctx):
     for unresolved_tag in ctx.attr.images:
         # Allow users to put make variables into the tag name.
         tag = ctx.expand_make_variables("images", unresolved_tag, {})
+
         # If any tag contains python format syntax (which is how users
         # configure stamping), we enable stamping.
         if "{" in tag:

--- a/container/bundle.bzl
+++ b/container/bundle.bzl
@@ -37,9 +37,14 @@ def _container_bundle_impl(ctx):
 
     images = {}
     runfiles = []
+    if ctx.attr.stamp:
+        print("Attr 'stamp' is deprecated; it is now automatically inferred. Please remove it from %s" % ctx.label)
+    stamp = False
     for unresolved_tag in ctx.attr.images:
         # Allow users to put make variables into the tag name.
         tag = ctx.expand_make_variables("images", unresolved_tag, {})
+        if "{" in tag:
+            stamp = True
 
         target = ctx.attr.images[unresolved_tag]
 
@@ -54,21 +59,19 @@ def _container_bundle_impl(ctx):
         ctx,
         images,
         ctx.outputs.executable,
-        stamp = ctx.attr.stamp,
+        stamp = stamp,
     )
-    _assemble_image(ctx, images, ctx.outputs.out, stamp = ctx.attr.stamp)
+    _assemble_image(ctx, images, ctx.outputs.out, stamp = stamp)
 
-    stamp_files = []
-    if ctx.attr.stamp:
-        stamp_files = [ctx.info_file, ctx.version_file]
+    stamp_files = [ctx.info_file, ctx.version_file] if stamp else []
 
     return struct(
         container_images = images,
-        stamp = ctx.attr.stamp,
+        stamp = stamp,
         providers = [
             BundleInfo(
                 container_images = images,
-                stamp = ctx.attr.stamp,
+                stamp = stamp,
             ),
             DefaultInfo(
                 files = depset(),

--- a/container/bundle.bzl
+++ b/container/bundle.bzl
@@ -43,6 +43,8 @@ def _container_bundle_impl(ctx):
     for unresolved_tag in ctx.attr.images:
         # Allow users to put make variables into the tag name.
         tag = ctx.expand_make_variables("images", unresolved_tag, {})
+        # If any tag contains python format syntax (which is how users
+        # configure stamping), we enable stamping.
         if "{" in tag:
             stamp = True
 

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -347,6 +347,10 @@ class ImageTest(unittest.TestCase):
         '.', '/usr', '/usr/bin', '/usr/bin/java', './foo'])
 
   def test_bundle(self):
+    with TestBundleImage('stamped_bundle_test', "example.com/aaaaa{BUILD_USER}:stamped".format(
+        BUILD_USER=os.environ['USER']
+    )) as img:
+        self.assertDigest(img, '31d7d27f5e63516de98a3f67c382b7f86cfa1000d75c04a9e04c136162daa98b')
     with TestBundleImage('bundle_test', 'docker.io/ubuntu:latest') as img:
       self.assertDigest(img, '813cb4af1c3f73cc2b5f837a61dca6a62335b87e5cd762e780286ca99f71ac83')
       self.assertEqual(1, len(img.fs_layers()))

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -89,6 +89,7 @@ def _impl(ctx):
     tag = ctx.expand_make_variables("tag", ctx.attr.tag, {})
     if ctx.attr.stamp:
         print("Attr 'stamp' is deprecated; it is now automatically inferred. Please remove it from %s" % ctx.label)
+
     # If any stampable attr contains python format syntax (which is how users
     # configure stamping), we enable stamping.
     stamp = "{" in tag or "{" in registry or "{" in repository

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -87,7 +87,10 @@ def _impl(ctx):
     registry = ctx.expand_make_variables("registry", ctx.attr.registry, {})
     repository = ctx.expand_make_variables("repository", ctx.attr.repository, {})
     tag = ctx.expand_make_variables("tag", ctx.attr.tag, {})
-    stamp_inputs = [ctx.info_file, ctx.version_file] if ctx.attr.stamp else []
+    if ctx.attr.stamp:
+        print("Attr 'stamp' is deprecated; it is now automatically inferred. Please remove it from %s" % ctx.label)
+    stamp = "{" in tag or "{" in registry or "{" in repository
+    stamp_inputs = [ctx.info_file, ctx.version_file] if stamp else []
     pusher_args += [
         "--stamp-info-file=%s" % _get_runfile_path(ctx, f)
         for f in stamp_inputs
@@ -122,7 +125,7 @@ def _impl(ctx):
             registry = registry,
             repository = repository,
             tag = tag,
-            stamp = ctx.attr.stamp,
+            stamp = stamp,
             stamp_inputs = stamp_inputs,
             digest = ctx.outputs.digest,
         ),

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -89,6 +89,8 @@ def _impl(ctx):
     tag = ctx.expand_make_variables("tag", ctx.attr.tag, {})
     if ctx.attr.stamp:
         print("Attr 'stamp' is deprecated; it is now automatically inferred. Please remove it from %s" % ctx.label)
+    # If any stampable attr contains python format syntax (which is how users
+    # configure stamping), we enable stamping.
     stamp = "{" in tag or "{" in registry or "{" in repository
     stamp_inputs = [ctx.info_file, ctx.version_file] if stamp else []
     pusher_args += [

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -377,7 +377,6 @@ docker_push(
     image = ":link_with_files_base",
     registry = "gcr.io",
     repository = "convoy-adapter/bazel-oci-test",
-    stamp = True,
     tag = "{BUILD_USER}",
 )
 
@@ -388,7 +387,6 @@ oci_push(
     image = ":link_with_files_base",
     registry = "gcr.io",
     repository = "convoy-adapter/bazel-oci-test",
-    stamp = True,
     tag = "{BUILD_USER}",
 )
 
@@ -431,7 +429,6 @@ container_bundle(
         # Pad username so that it is long enough.
         "example.com/aaaaa{BUILD_USER}:stamped": ":with_user",
     },
-    stamp = True,
 )
 
 # Generate a dummy debian package with a test/ directory
@@ -481,7 +478,6 @@ container_bundle(
         "eu.gcr.io/convoy-adapter/bazel-test/{BUILD_USER}:bar": ":with_double_env",
         "asia.gcr.io/convoy-adapter/bazel-test/{BUILD_USER}:baz": ":with_user",
     },
-    stamp = True,
 )
 
 docker_pushall(

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -457,6 +457,15 @@ function test_container_pull_with_auth() {
   EXPECT_CONTAINS "$(bazel run $bazel_opts @local_pull//image 2>&1)" "Error pulling and saving image localhost:5000/docker/test:test"
 }
 
+function test_container_push_with_stamp() {
+  cd "${ROOT}"
+  clear_docker
+  cid=$(docker run --rm -d -p 5000:5000 --name registry registry:2)
+  bazel run tests/docker:push_stamped_test
+  docker stop -t 0 $cid
+}
+
+test_container_push_with_stamp
 test_container_push_with_auth
 test_container_pull_with_auth
 test_top_level

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -226,6 +226,16 @@ container_push(
     tags = ["manual"],
 )
 
+container_push(
+    name = "push_stamped_test",
+    format = "Docker",
+    image = ":set_cmd",
+    registry = "localhost:5000",
+    repository = "docker/test/{BUILD_USER}",
+    tag = "{BUILD_USER}",
+    tags = ["manual"],
+)
+
 file_test(
     name = "test_push_digest_output",
     content = "sha256:515b5206d4232e54ac4a0c2b45fb9fbe678ccc4f6c228e59024ac3ef61e08133",


### PR DESCRIPTION
This PR deprecates the `stamp` attr for the `container_push` and `container_bundle` rules. Given that the stamp format (ie python format syntax) is mutually exclusive with a valid image name (per the [image specification](https://github.com/moby/moby/blob/master/image/spec/v1.md) `{` and `}` are not valid characters), I believe we can safely infer a user's intent to stamp without a separate 'stamp' attr.
