### PR TITLE
Add 'launcher' attr to container_image & lang_image

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,6 +920,10 @@ and see <a href=#go_image-custom-base>go_image (custom base)</a> example.
 > attribute.  If specified, they will be appended directly after the
 > container ENTRYPOINT binary name.
 
+> NOTE: all application image rules support the `launcher` label and
+> `launcher_args` string_list attributes. If specified, they will be
+> prepended to the container ENTRYPOINT.
+
 ### container_bundle
 
 ```python
@@ -1745,6 +1749,21 @@ container_image(name, base, data_path, directory, files, legacy_repository_namin
         in tags.</p>
         <p>These fields are specified in attributes using using Python format
         syntax, e.g. <code>foo{BUILD_USER}bar</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>launcher</code></td>
+      <td>
+        <p><code>Label; optional</code></p>
+        <p>If present, prefix the image's ENTRYPOINT with this file.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>launcher_args</code></td>
+      <td>
+        <p><code>String list; optional</code></p>
+        <p>Optional arguments for the <code>launcher</code> attribute.
+        Only valid when <code>launcher</code> is specified.</p>
       </td>
     </tr>
   </tbody>

--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -57,7 +57,15 @@ DEFAULT_BASE = select({
     "//conditions:default": "@cc_image_base//image",
 })
 
-def cc_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+def cc_image(
+        name,
+        base = None,
+        launcher = None,
+        launcher_args = [],
+        deps = [],
+        layers = [],
+        binary = None,
+        **kwargs):
     """Constructs a container image wrapping a cc_binary target.
 
   Args:
@@ -90,4 +98,6 @@ def cc_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        launcher = launcher,
+        launcher_args = launcher_args,
     )

--- a/container/create_image_config.py
+++ b/container/create_image_config.py
@@ -86,6 +86,9 @@ parser.add_argument('--operating_system', action='store', default='linux',
                     choices=['linux', 'windows'],
                     help=('Operating system to create docker image for, e.g. {linux}'))
 
+parser.add_argument('--entrypoint_prefix', action='append', default=[],
+                    help='Prefix the "Entrypoint" with the specified arguments.')
+
 _PROCESSOR_ARCHITECTURE = 'amd64'
 
 def KeyValueToDict(pair):
@@ -194,6 +197,10 @@ def main():
   if ('config' in output and 'Entrypoint' in output['config'] and
       args.null_entrypoint == "True"):
     del (output['config']['Entrypoint'])
+
+  if args.entrypoint_prefix:
+    output['config']['Entrypoint'] = (args.entrypoint_prefix +
+                                      output['config'].get('Entrypoint', []))
 
   with open(args.output, 'w') as fp:
     json.dump(output, fp, sort_keys=True)

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -183,6 +183,14 @@ def _image_config(
         args += ["--stamp-info-file=%s" % f.path for f in stamp_inputs]
         inputs += stamp_inputs
 
+    if ctx.attr.launcher_args and not ctx.attr.launcher:
+        fail("launcher_args does nothing when launcher is not specified.", attr = "launcher_args")
+    if ctx.attr.launcher:
+        args += [
+            "--entrypoint_prefix=%s" % x
+            for x in ["/" + ctx.file.launcher.basename] + ctx.attr.launcher_args
+        ]
+
     ctx.action(
         executable = ctx.executable.create_image_config,
         arguments = args,
@@ -298,6 +306,11 @@ def _impl(
     if ctx.attr.base and ImageInfo in ctx.attr.base:
         legacy_run_behavior = ctx.attr.base[ImageInfo].legacy_run_behavior
         docker_run_flags = ctx.attr.base[ImageInfo].docker_run_flags
+
+    if ctx.attr.launcher:
+        if not file_map:
+            file_map = {}
+        file_map["/" + ctx.file.launcher.basename] = ctx.file.launcher
 
     # composite a layer from the container_image rule attrs,
     image_layer = _layer.implementation(
@@ -454,6 +467,8 @@ _attrs = dict(_layer.attrs.items() + {
     "layers": attr.label_list(providers = [LayerInfo]),
     "repository": attr.string(default = "bazel"),
     "stamp": attr.bool(default = False),
+    "launcher": attr.label(allow_single_file = True),
+    "launcher_args": attr.string_list(default = []),
     # Implicit/Undocumented dependencies.
     "label_files": attr.label_list(
         allow_files = True,

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -30,7 +30,15 @@ load("@io_bazel_rules_d//d:d.bzl", "d_binary")
 def repositories():
     _repositories()
 
-def d_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+def d_image(
+        name,
+        base = None,
+        launcher = None,
+        launcher_args = [],
+        deps = [],
+        layers = [],
+        binary = None,
+        **kwargs):
     """Constructs a container image wrapping a d_binary target.
 
   Args:
@@ -63,4 +71,6 @@ def d_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        launcher = launcher,
+        launcher_args = launcher_args,
     )

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -62,7 +62,15 @@ DEFAULT_BASE = select({
     "//conditions:default": "@go_image_base//image",
 })
 
-def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+def go_image(
+        name,
+        base = None,
+        launcher = None,
+        launcher_args = [],
+        deps = [],
+        layers = [],
+        binary = None,
+        **kwargs):
     """Constructs a container image wrapping a go_binary target.
 
   Args:
@@ -94,4 +102,6 @@ def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        launcher = launcher,
+        launcher_args = launcher_args,
     )

--- a/groovy/image.bzl
+++ b/groovy/image.bzl
@@ -29,6 +29,8 @@ load(
 def groovy_image(
         name,
         base = None,
+        launcher = None,
+        launcher_args = [],
         main_class = None,
         srcs = [],
         deps = [],
@@ -86,6 +88,8 @@ def groovy_image(
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        launcher = launcher,
+        launcher_args = launcher_args,
     )
 
 def repositories():

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -250,6 +250,8 @@ jar_app_layer = rule(
 def java_image(
         name,
         base = None,
+        launcher = None,
+        launcher_args = [],
         main_class = None,
         deps = [],
         runtime_deps = [],
@@ -311,6 +313,8 @@ def java_image(
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        launcher = launcher,
+        launcher_args = launcher_args,
     )
 
 def _war_dep_layer_impl(ctx):
@@ -388,7 +392,14 @@ _war_app_layer = rule(
     implementation = _war_app_layer_impl,
 )
 
-def war_image(name, base = None, deps = [], layers = [], **kwargs):
+def war_image(
+        name,
+        base = None,
+        launcher = None,
+        launcher_args = [],
+        deps = [],
+        layers = [],
+        **kwargs):
     """Builds a container image overlaying the java_library as an exploded WAR.
 
   TODO(mattmoor): For `bazel run` of this to be useful, we need to be able
@@ -419,4 +430,6 @@ def war_image(name, base = None, deps = [], layers = [], **kwargs):
         jar_layers = layers,
         visibility = visibility,
         tags = tags,
+        launcher = launcher,
+        launcher_args = launcher_args,
     )

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -98,6 +98,8 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 def nodejs_image(
         name,
         base = None,
+        launcher = None,
+        launcher_args = [],
         data = [],
         layers = [],
         node_modules = "//:node_modules",
@@ -143,4 +145,6 @@ def nodejs_image(
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        launcher = launcher,
+        launcher_args = launcher_args,
     )

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -63,7 +63,14 @@ def py_layer(name, deps, filter = "", **kwargs):
     native.py_library(name = binary_name, deps = deps, **kwargs)
     filter_layer(name = name, dep = binary_name, filter = filter)
 
-def py_image(name, base = None, deps = [], layers = [], **kwargs):
+def py_image(
+        name,
+        base = None,
+        launcher = None,
+        launcher_args = [],
+        deps = [],
+        layers = [],
+        **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
     Args:
@@ -98,4 +105,6 @@ def py_image(name, base = None, deps = [], layers = [], **kwargs):
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        launcher = launcher,
+        launcher_args = launcher_args,
     )

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -57,7 +57,14 @@ DEFAULT_BASE = select({
     "//conditions:default": "@py3_image_base//image",
 })
 
-def py3_image(name, base = None, deps = [], layers = [], **kwargs):
+def py3_image(
+        name,
+        base = None,
+        launcher = None,
+        launcher_args = [],
+        deps = [],
+        layers = [],
+        **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
   Args:
@@ -93,4 +100,6 @@ def py3_image(name, base = None, deps = [], layers = [], **kwargs):
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        launcher = launcher,
+        launcher_args = launcher_args,
     )

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -30,7 +30,15 @@ load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
 def repositories():
     _repositories()
 
-def rust_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+def rust_image(
+        name,
+        base = None,
+        launcher = None,
+        launcher_args = [],
+        deps = [],
+        layers = [],
+        binary = None,
+        **kwargs):
     """Constructs a container image wrapping a rust_binary target.
 
   Args:
@@ -63,4 +71,6 @@ def rust_image(name, base = None, deps = [], layers = [], binary = None, **kwarg
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        launcher = launcher,
+        launcher_args = launcher_args,
     )

--- a/scala/image.bzl
+++ b/scala/image.bzl
@@ -29,6 +29,8 @@ load(
 def scala_image(
         name,
         base = None,
+        launcher = None,
+        launcher_args = [],
         main_class = None,
         deps = [],
         runtime_deps = [],
@@ -78,6 +80,8 @@ def scala_image(
         tags = tags,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
+        launcher = launcher,
+        launcher_args = launcher_args,
     )
 
 def repositories():


### PR DESCRIPTION
This PR adds two attributes to `container_image` and each `lang_image` rule:
- `launcher`: Optional. If present, prefix the image's ENTRYPOINT with this file.
- `launcher_args`: Optional arguments for the launcher attribute. Only valid when launcher is specified.

### Motivation
The lang_image rules make containerizing *_binary rules very easy, which is great. However, when deploying to some container orchestrators (eg ECS), a common practice is to use a "launcher" like [chamber](https://github.com/segmentio/chamber#exec) to securely provision secrets and configuration into the environment (because ECS does not have a mechanism to securely inject secrets or config files). The launcher then `exec`s the actual application and gets out of the way.

The current lang_image rules do not play nice with this pattern. It's certainly possible to use container_image rules and manually construct an image, but then we'd be giving up all the smooth user experience of the lang_image rules.

This is my take at enabling the use of a launcher with the lang_image rules; does it seem reasonable? (If it does, I'd like to think through what a good test would look like and get this thing merged!)