### PR TITLE
exposing pull for extensibility in other workspace repo rules

### DIFF
--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -152,6 +152,11 @@ Args:
                      multi-platform manifest list.
 """
 
+pull = struct(
+    attrs = _container_pull_attrs,
+    implementation = _impl,
+)
+
 container_pull = repository_rule(
     attrs = _container_pull_attrs,
     implementation = _impl,


### PR DESCRIPTION
e.g., to use it in repo rule version of docker autoconfig 