### PR TITLE
removing lots of mac targets from CI builds

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -21,20 +21,10 @@ platforms:
     test_flags:
     - "--action_env=PATH"
   macos:
-    build_targets:
-    - "..."
-    # tests/contrib/test_compare_ids_test_* expect 'bazel' on path
-    build_flags:
-    - "--action_env=PATH"
     test_targets:
-    - "--"
-    - "..."
-    - "-//tests/docker/..."
-    # tests/contrib/test_compare_ids_test_* expect 'bazel' on path
+    - //tests/docker:deb_image_with_dpkgs_test
+    - //tests/docker:test_digest_output1
     test_flags:
-    - "--action_env=PATH"
-  # We are selecting to test only the targets that build on RBE
-  # because the default image does not support `docker`.
   rbe_ubuntu1604:
     build_targets:
     - "--"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -22,8 +22,8 @@ platforms:
     - "--action_env=PATH"
   macos:
     test_targets:
-    - //tests/docker:deb_image_with_dpkgs_test
-    - //tests/docker:test_digest_output1
+    - "//tests/docker:deb_image_with_dpkgs_test"
+    - "//tests/docker:test_digest_output1"
   rbe_ubuntu1604:
     build_targets:
     - "--"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,7 +24,6 @@ platforms:
     test_targets:
     - //tests/docker:deb_image_with_dpkgs_test
     - //tests/docker:test_digest_output1
-    test_flags:
   rbe_ubuntu1604:
     build_targets:
     - "--"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -22,7 +22,6 @@ platforms:
     - "--action_env=PATH"
   macos:
     test_targets:
-    - "//tests/docker:deb_image_with_dpkgs_test"
     - "//tests/docker:test_digest_output1"
     test_flags:
     - "--action_env=PATH"    

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -21,6 +21,8 @@ platforms:
     test_flags:
     - "--action_env=PATH"
   macos:
+    build_targets:
+    - "//tests/docker:test_digest_output1"
     test_targets:
     - "//tests/docker:test_digest_output1"
     test_flags:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,6 +24,8 @@ platforms:
     test_targets:
     - "//tests/docker:deb_image_with_dpkgs_test"
     - "//tests/docker:test_digest_output1"
+    test_flags:
+    - "--action_env=PATH"    
   rbe_ubuntu1604:
     build_targets:
     - "--"


### PR DESCRIPTION
Mac is having issues pulling the base images, lets reduce the number of things we test on mac, sadly, our mac features might drift.