### PR TITLE
adding mac CI tests again with --loading_phase_thread=1 flag

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -26,14 +26,14 @@ platforms:
     # tests/contrib/test_compare_ids_test_* expect 'bazel' on path
     build_flags:
     - "--action_env=PATH"
-    - "--loading_phase_thread=1"
+    - "--loading_phase_threads=1"
     test_targets:
     - "--"
     - "..."
     - "-//tests/docker/..."
     test_flags:
     - "--action_env=PATH"
-    - "--loading_phase_thread=1"
+    - "--loading_phase_threads=1"
   rbe_ubuntu1604:
     build_targets:
     - "--"


### PR DESCRIPTION
Lets see if loading_phase_thread=1  can fix flakiness pulling the docker images