### PR TITLE
Do not rely on Bazel transtive loads

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -109,9 +109,9 @@ _py_image_repos()
 
 http_archive(
     name = "io_bazel_rules_python",
-    sha256 = "8b32d2dbb0b0dca02e0410da81499eef8ff051dad167d6931a92579e3b2a1d48",
-    strip_prefix = "rules_python-8b5d0683a7d878b28fffe464779c8a53659fc645",
-    urls = ["https://github.com/bazelbuild/rules_python/archive/8b5d0683a7d878b28fffe464779c8a53659fc645.tar.gz"],
+    sha256 = "da960ee6f0e2e08556d0e0c307896b0ea6ebc8d86f50c649ceda361b71df74a1",
+    strip_prefix = "rules_python-f3a6a8d00a51a1f0e6d61bc7065c19fea2b3dd7a",
+    urls = ["https://github.com/bazelbuild/rules_python/archive/f3a6a8d00a51a1f0e6d61bc7065c19fea2b3dd7a.tar.gz"],
 )
 
 load("@io_bazel_rules_python//python:pip.bzl", "pip_import", "pip_repositories")
@@ -160,9 +160,9 @@ maven_jar(
 # For our scala_image test.
 http_archive(
     name = "io_bazel_rules_scala",
-    sha256 = "50465838809fee66cab66fa20ed3d68c667f663958ede10fbe504a0d18481016",
-    strip_prefix = "rules_scala-5874a2441596fe9a0bf80e167a4d7edd945c221e",
-    urls = ["https://github.com/bazelbuild/rules_scala/archive/5874a2441596fe9a0bf80e167a4d7edd945c221e.tar.gz"],
+    sha256 = "83d40e0bc7377e77fa0d32af6c4b276374b4efbcb3120c437e425947cdb3ce38",
+    strip_prefix = "rules_scala-5130b97524684beceba729b9dab1528e2a90cdfb",
+    urls = ["https://github.com/bazelbuild/rules_scala/archive/5130b97524684beceba729b9dab1528e2a90cdfb.tar.gz"],
 )
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
@@ -176,9 +176,9 @@ scala_register_toolchains()
 # For our groovy_image test.
 http_archive(
     name = "io_bazel_rules_groovy",
-    sha256 = "8c28a8f45b6d83cb2e3f3e4851618a429544603ff040a261c48602fabcea7bfc",
-    strip_prefix = "rules_groovy-a95e89c59716c5bc132ebb407f97b173fb2510e7",
-    urls = ["https://github.com/bazelbuild/rules_groovy/archive/a95e89c59716c5bc132ebb407f97b173fb2510e7.tar.gz"],
+    sha256 = "22669b0379e496555f574612043c6c3f1f6145c18d2697ddd308937d6d96f9ad",
+    strip_prefix = "rules_groovy-cb174f4e7d6b9cbda06d4a0f538214f947747736",
+    urls = ["https://github.com/bazelbuild/rules_groovy/archive/cb174f4e7d6b9cbda06d4a0f538214f947747736.tar.gz"],
 )
 
 load("@io_bazel_rules_groovy//groovy:groovy.bzl", "groovy_repositories")
@@ -188,8 +188,8 @@ groovy_repositories()
 # For our go_image test.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "ee5fe78fe417c685ecb77a0a725dc9f6040ae5beb44a0ba4ddb55453aad23a8a",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.0/rules_go-0.16.0.tar.gz",
+    sha256 = "62ec3496a00445889a843062de9930c228b770218c735eca89c67949cd967c3f",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.4/rules_go-0.16.4.tar.gz",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -13,14 +13,14 @@
 # limitations under the License.
 """Rules for manipulation container images."""
 
-load("//container:bundle.bzl", "container_bundle")
-load("//container:flatten.bzl", "container_flatten")
-load("//container:image.bzl", "container_image", "image")
-load("//container:layer.bzl", "container_layer")
-load("//container:import.bzl", "container_import")
-load("//container:load.bzl", "container_load")
-load("//container:pull.bzl", "container_pull")
-load("//container:push.bzl", "container_push")
+load("//container:bundle.bzl", _container_bundle = "container_bundle")
+load("//container:flatten.bzl", _container_flatten = "container_flatten")
+load("//container:image.bzl", _container_image = "container_image", _image = "image")
+load("//container:layer.bzl", _container_layer = "container_layer")
+load("//container:import.bzl", _container_import = "container_import")
+load("//container:load.bzl", _container_load = "container_load")
+load("//container:pull.bzl", _container_pull = "container_pull")
+load("//container:push.bzl", _container_push = "container_push")
 load(
     "@bazel_tools//tools/build_defs/repo:http.bzl",
     "http_archive",
@@ -30,6 +30,18 @@ load(
     "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
     _docker_toolchain_configure = "toolchain_configure",
 )
+
+# Explicitly re-export the functions
+container_bundle = _container_bundle
+container_flatten = _container_flatten
+container_image = _container_image
+image = _image
+container_layer = _container_layer
+container_import = _container_import
+container_pull = _container_pull
+container_push = _container_push
+
+container_load = _container_load
 
 container = struct(
     image = image,

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -67,8 +67,11 @@ load(
     _layer_tools = "tools",
 )
 load(
-    "//container:layer.bzl",
+    "//container:providers.bzl",
     "LayerInfo",
+)
+load(
+    "//container:layer.bzl",
     _layer = "layer",
 )
 load(

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -27,6 +27,7 @@ load(
     _container = "container",
     _repositories = "repositories",
 )
+load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 
 # Load the resolved digests.
 load(":nodejs.bzl", "DIGESTS")
@@ -92,8 +93,6 @@ _dep_layer = rule(
     toolchains = ["@io_bazel_rules_docker//toolchains/docker:toolchain_type"],
     implementation = _dep_layer_impl,
 )
-
-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 
 def nodejs_image(
         name,


### PR DESCRIPTION
If a symbol should be re-exported, that should be explicit.
Also, update the dependencies to get their recent fixes.

Progress towards #621