### PR TITLE
Update image.bzl

### DIFF
--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -54,7 +54,7 @@ def repositories():
         )
 
 DEFAULT_BASE = select({
-    "@io_bazel_rules_docker//:fastbuild": "@nodejs_image_base//image",
+    "@io_bazel_rules_docker//:fastbuild": "@nodejs_image_base//image", #This image is not present
     "@io_bazel_rules_docker//:debug": "@nodejs_debug_image_base//image",
     "@io_bazel_rules_docker//:optimized": "@nodejs_image_base//image",
     "//conditions:default": "@nodejs_debug_image_base//image",


### PR DESCRIPTION
error in finding the image location
```
ERROR: /home/harora37/cognitive-data-platform/projects/common/examples/javascript/nodejs/BUILD.bazel:48:1: no such package '@nodejs_image_base//image': The repository could not be resolved and referenced by '//projects/common/examples/javascript/nodejs:nodejs_image.0'
ERROR: Analysis of target '//projects/common/examples/javascript/nodejs:nodejs_image' failed; build aborted: no such package '@nodejs_image_base//image': The repository could not be resolved
```