### PR TITLE
Include custom runfile symlinks in layers

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -139,6 +139,7 @@ TEST_TARGETS = [
     ":nodejs_image",
     ":py3_image",
     ":py_image",
+    ":py_image_with_symlinks_in_data",
     ":py_image_complex",
     ":rust_image",
     ":scala_image",

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -499,6 +499,51 @@ class ImageTest(unittest.TestCase):
         './app/io_bazel_rules_docker/testdata/py_image_library.py',
       ])
 
+  def test_py_image_with_symlinks_in_data(self):
+    with TestImage('py_image_with_symlinks_in_data') as img:
+      # Check the application layer, which is on top.
+      self.assertTopLayerContains(img, [
+        '.',
+        './app',
+        './app/testdata',
+        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles',
+        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker',
+        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata',
+        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata/py_image.py',
+        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata/py_image_with_symlinks_in_data.binary',
+        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata/foo.txt',
+        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata/__init__.py',
+        # TODO(mattmoor): The path normalization for symlinks should match
+        # files to avoid this redundancy.
+        '/app',
+        '/app/testdata',
+        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles',
+        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker',
+        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/foo-symlink.txt',
+        '/app/testdata/py_image_with_symlinks_in_data.binary',
+        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/external',
+      ])
+
+      # Below that, we have a layer that generates symlinks for the library layer.
+      self.assertLayerNContains(img, 1, [
+        '.',
+        '/app',
+        '/app/testdata',
+        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles',
+        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker',
+        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata',
+        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata/py_image_library.py',
+      ])
+
+      # Check the library layer, which is two below our application layer.
+      self.assertLayerNContains(img, 2, [
+        '.',
+        './app',
+        './app/io_bazel_rules_docker',
+        './app/io_bazel_rules_docker/testdata',
+        './app/io_bazel_rules_docker/testdata/py_image_library.py',
+      ])
+
   def test_py_image_complex(self):
     with TestImage('py_image_complex') as img:
       # bazel-bin/testdata/py_image_complex-layer.tar

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -652,6 +652,24 @@ py_image(
     main = "py_image.py",
 )
 
+load("//testdata:utils.bzl", "rule_with_symlinks")
+
+rule_with_symlinks(
+    name = "data_with_symlinks",
+)
+
+py_image(
+    name = "py_image_with_symlinks_in_data",
+    srcs = ["py_image.py"],
+    data = [
+        ":data_with_symlinks",
+    ],
+    layers = [
+        ":py_image_library",
+    ],
+    main = "py_image.py",
+)
+
 load("@pip_deps//:requirements.bzl", "requirement")
 
 py_library(

--- a/testdata/utils.bzl
+++ b/testdata/utils.bzl
@@ -26,3 +26,13 @@ def generate_deb(name, args = [], metadata_compression_type = "none"):
         ),
         tools = [":gen_deb"],
     )
+
+def _rule_with_symlinks_impl(ctx):
+    f = ctx.actions.declare_file("foo.txt")
+    ctx.actions.write(f, "test content")
+    runfiles = ctx.runfiles(files = [f], symlinks = {"foo-symlink.txt": f})
+    return DefaultInfo(runfiles = runfiles)
+
+rule_with_symlinks = rule(
+    implementation = _rule_with_symlinks_impl,
+)


### PR DESCRIPTION
Include any symlinks in *_image layers that were added to dependent
runfiles with ctx.runfiles(symlinks=...).

The new feature only works for bazel >= 0.21.0 which has
https://github.com/bazelbuild/bazel/issues/3880 fixed, and for older
versions such symlinks will silently be dropped (like today).