### PR TITLE
Support '=' character in path names

### DIFF
--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -216,6 +216,29 @@ container_test(
     image = ":set_env_csv",
 )
 
+genrule(
+    name = "special_characters_file",
+    outs = ["gen= foo.out"],
+    cmd = "echo generated > \"$@\"",
+)
+
+container_image(
+    name = "special_characters",
+    base = "@distroless_fixed_id//image",
+    directory = "root= dir",
+    empty_dirs = ["/empty= dir"],
+    empty_files = ["/empty= file"],
+    files = [":special_characters_file"],
+    symlinks = {"foo= symlink": "root= dir/gen= foo.out"},
+)
+
+container_test(
+    name = "special_characters_test",
+    configs = ["//tests/docker/configs:special_characters.yaml"],
+    driver = "tar",
+    image = ":special_characters",
+)
+
 container_push(
     name = "push_test",
     format = "Docker",

--- a/tests/docker/configs/special_characters.yaml
+++ b/tests/docker/configs/special_characters.yaml
@@ -1,0 +1,17 @@
+schemaVersion: 2.0.0
+
+fileContentTests:
+  - name: "special characters can be used in files"
+    path: "/root= dir/gen= foo.out"
+    expectedContents: ["generated"]
+  - name: "special characters can be used in symlinks"
+    path: "/foo= symlink"
+    expectedContents: ["generated"]
+
+fileExistenceTests:
+  - name: "special characters can be used in emptyfiles"
+    path: '/empty= file'
+    shouldExist: true
+  - name: "special characters can be used in emptydirs"
+    path: '/empty= dir'
+    shouldExist: true


### PR DESCRIPTION
Equals sign is a valid character in paths, so it should not be used
as a delimiter when passing file map to build_tar.py.  For example,
pyspark python package contains directories like 'cls=kittens'
(see https://github.com/apache/spark/tree/master/data/mllib/images/partitioned).

Pass contents as a json manifest file to build_tar.py to resolve the
issue.