### PR TITLE
Allow container_layer's data_path to work on directory output target names

### DIFF
--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -393,7 +393,7 @@ def main(unused_argv):
   # Add objects to the tar file
   with TarFile(FLAGS.output, FLAGS.directory, FLAGS.compression, FLAGS.root_directory) as output:
     def file_attributes(filename):
-      if filename[0] == '/':
+      if filename.startswith('/'):
         filename = filename[1:]
       return {
           'mode': mode_map.get(filename, default_mode),

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -259,3 +259,21 @@ file_test(
     content = "sha256:f365626a556e58189fc21d099fc64603db0f440bff07f77c740989515c544a39",
     file = "@k8s_pause_arm64//image:digest",
 )
+
+load(":apple.bzl", "create_banana_directory")
+
+create_banana_directory(
+    name = "banana_directory",
+)
+
+container_image(
+    name = "stripped_directory_name",
+    data_path = "banana",
+    files = [":banana_directory"],
+)
+
+container_test(
+    name = "stripped_directory_name_test",
+    configs = ["//tests/docker/configs:stripped_directory_name.yaml"],
+    image = ":stripped_directory_name",
+)

--- a/tests/docker/apple.bzl
+++ b/tests/docker/apple.bzl
@@ -1,0 +1,16 @@
+def _create_banana_directory_impl(ctx):
+    out = ctx.actions.declare_directory("banana")
+    ctx.actions.run(
+        executable = "bash",
+        arguments = ["-c", "mkdir -p %s/pear && touch %s/pear/grape" % (out.path, out.path)],
+        outputs = [out],
+    )
+    return [
+        DefaultInfo(
+            files = depset([out]),
+        ),
+    ]
+
+create_banana_directory = rule(
+    implementation = _create_banana_directory_impl,
+)

--- a/tests/docker/configs/stripped_directory_name.yaml
+++ b/tests/docker/configs/stripped_directory_name.yaml
@@ -1,0 +1,5 @@
+schemaVersion: '2.0.0'
+fileExistenceTests:
+- name: Output file that is placed in directory structure
+  path: /pear/grape
+  shouldExist: true


### PR DESCRIPTION
There is a tiny bug in pkg_tar's strip_prefix handling that prevents it
from stripping the full name of a file. Though this sounds weird at
first, it is pretty useful when creating tarballs from output
directories. A pull request for this has been sent to Bazel:

https://github.com/bazelbuild/bazel/pull/6980

The same issue applies to container_layer's data_path argument, which is
actually where we noticed this at first. Also apply this fix here.