### PR TITLE
Use docker path from toolchain in incremental loader

### DIFF
--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -175,7 +175,7 @@ def incremental_load(
         if run:
             # Args are embedded into the image, so omitted here.
             run_statements += [
-                "docker run %s %s" % (run_flags, tag_reference),
+                "\"${DOCKER}\" run %s %s" % (run_flags, tag_reference),
             ]
 
     ctx.actions.expand_template(


### PR DESCRIPTION
`incremental_load.sh.tpl` was updated in bazelbuild/rules_docker#559 to use the path from the toolchain, but there was a `docker run` being dynamically added in `incremental_load()` when `run` was `True`.