### PR TITLE
Set path to xz in toolchain when possible

### DIFF
--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -91,6 +91,10 @@ gflags.DEFINE_string(
     'root_directory', './', 'Default root directory is named "."'
     'Windows docker images require this be named "Files" instead of "."')
 
+gflags.DEFINE_string('xz_path', None,
+                     'Specify the path to xz as a fallback when the Python '
+                     'lzma module is unavailable.')
+
 FLAGS = gflags.FLAGS
 
 
@@ -332,11 +336,11 @@ class TarFile(object):
   @staticmethod
   def _xzcat_decompress(data):
     """Decompresses the xz-encrypted bytes in data by piping to xz."""
-    if subprocess.call('which xz', shell=True, stdout=subprocess.PIPE):
+    if not FLAGS.xz_path:
       raise RuntimeError('Cannot handle .xz compression: xz not found.')
 
     xz_proc = subprocess.Popen(
-      ['xz', '--decompress', '--stdout'],
+      [FLAGS.xz_path, '--decompress', '--stdout'],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE)
     return xz_proc.communicate(data)[0]

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -77,6 +77,7 @@ def build_layer(
         tars = None,
         operating_system = None):
     """Build the current layer for appending it to the base layer"""
+    toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
     layer = output_layer
     build_layer_exec = ctx.executable.build_layer
     args = [
@@ -84,6 +85,9 @@ def build_layer(
         "--directory=" + directory,
         "--mode=" + ctx.attr.mode,
     ]
+
+    if toolchain_info.xz_path != "":
+        args += ["--xz_path=%s" % toolchain_info.xz_path]
 
     # Windows layer.tar require two separate root directories instead of just 1
     # 'Files' is the equivalent of '.' in Linux images.
@@ -232,6 +236,7 @@ layer = struct(
     attrs = _layer_attrs,
     outputs = _layer_outputs,
     implementation = _impl,
+    toolchains = ["@io_bazel_rules_docker//toolchains/docker:toolchain_type"],
 )
 
 container_layer_ = rule(
@@ -239,6 +244,7 @@ container_layer_ = rule(
     executable = False,
     outputs = _layer_outputs,
     implementation = _impl,
+    toolchains = ["@io_bazel_rules_docker//toolchains/docker:toolchain_type"],
 )
 
 def container_layer(**kwargs):

--- a/toolchains/docker/BUILD.tpl
+++ b/toolchains/docker/BUILD.tpl
@@ -22,4 +22,5 @@ docker_toolchain(
     name = "toolchain",
     tool_path = "%{DOCKER_TOOL}",
     client_config = "%{DOCKER_CONFIG}",
+    xz_path = "%{XZ_TOOL_PATH}",
 )

--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -24,6 +24,8 @@ DockerToolchainInfo = provider(
                          "the value of the DOCKER_CONFIG environment variable" +
                          " will be used. DOCKER_CONFIG is not defined, the" +
                          " home directory will be used.",
+        "xz_path": "Optional path to the xz binary. This is used by " +
+                   "build_tar.py when the Python lzma module is unavailable.",
     },
 )
 
@@ -32,6 +34,7 @@ def _docker_toolchain_impl(ctx):
         info = DockerToolchainInfo(
             tool_path = ctx.attr.tool_path,
             client_config = ctx.attr.client_config,
+            xz_path = ctx.attr.xz_path,
         ),
     )
     return [toolchain_info]
@@ -52,11 +55,16 @@ docker_toolchain = rule(
                   " DOCKER_CONFIG is not defined, the home directory will be" +
                   " used.",
         ),
+        "xz_path": attr.string(
+            doc = "Optional path to the xz binary. This is used by " +
+                  "build_tar.py when the Python lzma module is unavailable.",
+        ),
     },
 )
 
 def _toolchain_configure_impl(repository_ctx):
     tool_path = repository_ctx.which("docker") or ""
+    xz_path = repository_ctx.which("xz") or ""
 
     # If client_config is not set we need to pass an empty string to the
     # template.
@@ -67,6 +75,7 @@ def _toolchain_configure_impl(repository_ctx):
         {
             "%{DOCKER_TOOL}": "%s" % tool_path,
             "%{DOCKER_CONFIG}": "%s" % client_config,
+            "%{XZ_TOOL_PATH}": "%s" % xz_path,
         },
         False,
     )


### PR DESCRIPTION
The `xz` tool may be used in `build_tar.py` when Python 2 is used (which does not have a built-in `lzma` module) and `backports.lzma` is not installed. Bazel 0.21 flipped the default of `--incompatible_strict_action_env` to true, which means `which xz` is unlikely to work. This can be done in the repository rule to autoconfigure the docker toolchain.

I don't totally love that this is in the _docker_ toolchain, but it felt too heavyweight to separate it into its own, since other users of this toolchain can just ignore the new field.