### PR TITLE
Use incremental loader in container_test

### DIFF
--- a/contrib/structure-test.sh.tpl
+++ b/contrib/structure-test.sh.tpl
@@ -6,4 +6,4 @@ set -ex
 
 %{test_executable} version
 
-%{test_executable} test --driver %{driver} --image %{image} %{configs} %{quiet}
+%{test_executable} %{args}

--- a/contrib/test.bzl
+++ b/contrib/test.bzl
@@ -23,25 +23,31 @@ load(
 )
 
 def _impl(ctx):
-    toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
+    if len([x for x in [ctx.attr.image, ctx.file.image_tar] if x]) != 1:
+        fail("Exactly one of 'image', 'image_tar' must be specified")
 
-    config_str = " ".join(["--config $(pwd)/" + c.short_path for c in ctx.files.configs])
+    args = ["test", "--driver", ctx.attr.driver]
 
-    if ctx.attr.driver == "tar":
+    if ctx.file.image_tar:
         # no need to load if we're using raw tar
         load_statement = ""
-        image_name = "$(pwd)/" + ctx.file.image_tar.short_path
-
+        args += ["--image", ctx.file.image_tar.short_path]
+        runfiles = ctx.runfiles(
+            files = [ctx.executable._structure_test, ctx.file.image_tar] + ctx.files.configs,
+        )
     else:
-        # Since we're always bundling/renaming the image in the macro, this is valid.
-        if not toolchain_info.tool_path:
-            fail("docker not found, required when using \"docker\" test driver")
-        load_statement = "%s load -i %s" % (toolchain_info.tool_path, ctx.file.image_tar.short_path)
-        image_name = ctx.attr.image_name
+        load_statement = "%s --norun" % ctx.executable.image.short_path
+        args += ["--image", ctx.attr.loaded_name]
+        runfiles = ctx.runfiles(
+            files = [ctx.executable._structure_test, ctx.executable.image] + ctx.files.configs,
+            transitive_files = ctx.attr.image.files,
+        ).merge(ctx.attr.image.data_runfiles)
 
-    quiet_str = "--quiet"
-    if ctx.attr.verbose:
-        quiet_str = ""
+    if not ctx.attr.verbose:
+        args += ["--quiet"]
+
+    for c in ctx.files.configs:
+        args += ["--config", c.short_path]
 
     # Generate a shell script to execute structure_tests with the correct flags.
     ctx.actions.expand_template(
@@ -49,39 +55,30 @@ def _impl(ctx):
         output = ctx.outputs.executable,
         substitutions = {
             "%{load_statement}": load_statement,
-            "%{configs}": config_str,
             "%{test_executable}": ctx.executable._structure_test.short_path,
-            "%{image}": image_name,
-            "%{driver}": ctx.attr.driver,
-            "%{quiet}": quiet_str,
+            "%{args}": " ".join(args),
         },
         is_executable = True,
     )
 
     return struct(
-        runfiles = ctx.runfiles(
-            files = [
-                        ctx.executable._structure_test,
-                        ctx.executable.image_tar,
-                        ctx.file.image_tar,
-                    ] +
-                    ctx.attr.image_tar.files.to_list() +
-                    ctx.attr.image_tar.data_runfiles.files.to_list() +
-                    ctx.files.configs,
-        ),
+        runfiles = runfiles,
     )
 
 _container_test = rule(
     attrs = {
-        "image_tar": attr.label(
+        "image": attr.label(
+            doc = "When using the docker driver, label of the incremental loader",
             executable = True,
-            allow_files = True,
-            mandatory = True,
-            single_file = True,
             cfg = "target",
         ),
-        "image_name": attr.string(
-            mandatory = True,
+        "image_tar": attr.label(
+            doc = "When using the tar driver, label of the container image tarball",
+            allow_files = [".tar"],
+            single_file = True,
+        ),
+        "loaded_name": attr.string(
+            doc = "When using the docker driver, the name:tag of the image when loaded into the docker daemon",
         ),
         "configs": attr.label_list(
             mandatory = True,
@@ -122,30 +119,28 @@ def container_test(name, image, configs, driver = None, verbose = None, **kwargs
     """A macro to predictably rename the image under test before threading
     it to the container test rule."""
 
-    # Remove commonly encountered characters that Docker will choke on.
-    # Include the package name in the new image tag to avoid conflicts on naming
-    # when running multiple container_test on images with the same target name
-    # from different packages.
-    sanitized_name = (native.package_name() + image).replace(":", "").replace("@", "").replace("/", "")
-    intermediate_image_name = "%s:intermediate" % sanitized_name
-    image_tar_name = "intermediate_bundle_%s" % name
+    image_loader = None
+    image_tar = None
+    loaded_name = None
 
     if driver == "tar":
-        intermediate_image_name = image
-        image_tar_name = image
+        image_tar = image + ".tar"
     else:
         # Give the image a predictable name when loaded
+        image_loader = "%s.image" % name
+        loaded_name = "%s:%s" % (native.package_name().replace("@", "external__"), name)
         container_bundle(
-            name = image_tar_name,
+            name = image_loader,
             images = {
-                intermediate_image_name: image,
+                loaded_name: image,
             },
         )
 
     _container_test(
         name = name,
-        image_name = intermediate_image_name,
-        image_tar = image_tar_name + ".tar",
+        loaded_name = loaded_name,
+        image = image_loader,
+        image_tar = image_tar,
         configs = configs,
         verbose = verbose,
         driver = driver,


### PR DESCRIPTION
When using the docker driver to run container_tests, use the
fast incremental loader instead of "docker loading" the tarball.
Producing the tarball can be very expensive for large images.

Also rewrite container_test runfiles assembly to avoid calls to
depset.to_list().