### PR TITLE
Make obtainer build user in tests remote execution compatible

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -151,6 +151,7 @@ TEST_DATA = [
     for t in TEST_TARGETS
 ] + [
     "//testdata:stamped_bundle_test",
+    "//testdata:stamp_info_file.txt",
 ]
 
 py_test(

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -25,6 +25,8 @@ from containerregistry.client.v2_2 import docker_image as v2_2_image
 TEST_DATA_TARGET_BASE='testdata'
 DIR_PERMISSION=0o700
 PASSWD_FILE_MODE=0o644
+# Dictionary of key to value mappings in the Bazel stamp file
+STAMP_DICT = {}
 
 def TestData(name):
   return os.path.join(os.environ['TEST_SRCDIR'], 'io_bazel_rules_docker',
@@ -348,7 +350,7 @@ class ImageTest(unittest.TestCase):
 
   def test_bundle(self):
     with TestBundleImage('stamped_bundle_test', "example.com/aaaaa{BUILD_USER}:stamped".format(
-        BUILD_USER=os.environ['USER']
+        BUILD_USER=STAMP_DICT['BUILD_USER']
     )) as img:
         self.assertDigest(img, '31d7d27f5e63516de98a3f67c382b7f86cfa1000d75c04a9e04c136162daa98b')
     with TestBundleImage('bundle_test', 'docker.io/ubuntu:latest') as img:
@@ -366,7 +368,7 @@ class ImageTest(unittest.TestCase):
   def test_with_stamped_label(self):
     with TestImage('with_stamp_label') as img:
       self.assertEqual(2, len(img.fs_layers()))
-      self.assertConfigEqual(img, 'Labels', {'BUILDER': os.environ['USER']})
+      self.assertConfigEqual(img, 'Labels', {'BUILDER': STAMP_DICT['BUILD_USER']})
 
   def test_pause_based(self):
     with TestImage('pause_based') as img:
@@ -830,6 +832,30 @@ class ImageTest(unittest.TestCase):
         'arg1',
       ])
 
+def load_stamp_info():
+  stamp_file = TestData("stamp_info_file.txt")
+  with open(stamp_file) as stamp_fp:
+    for line in stamp_fp:
+      # The first column in each line in the stamp file is the key
+      # and the second column is the corresponding value.
+      split_line = line.strip().split()
+      if len(split_line) == 0:
+        # Skip blank lines.
+        continue
+      key = ""
+      value = ""
+      if len(split_line) == 1:
+        # Value is blank.
+        key = split_line[0]
+      else:
+        key = split_line[0]
+        value = " ".join(split_line[1:])
+      STAMP_DICT[key] = value
+      print("Stamp variable '{key}'='{value}'".format(
+        key=key,
+        value=value
+      ))
 
 if __name__ == '__main__':
-  unittest.main()
+    load_stamp_info()
+    unittest.main()

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -22,6 +22,7 @@ load(
     "container_layer",
 )
 load("//testdata:utils.bzl", "generate_deb")
+load(":stamp_info.bzl", "stamp_info")
 
 exports_files(["pause.tar"])
 
@@ -1042,3 +1043,6 @@ generate_deb(
     name = "pkg_control_xz",
     metadata_compression_type = "xz",
 )
+
+# Make the Bazel stamp file available in tests.
+stamp_info(name = "stamp_info_file")

--- a/testdata/stamp_info.bzl
+++ b/testdata/stamp_info.bzl
@@ -1,0 +1,35 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides the stamp info file containing the Bazel non-volatile keys
+"""
+
+def _impl(ctx):
+    output = ctx.outputs.out
+    ctx.actions.run_shell(
+        outputs = [output],
+        inputs = [ctx.info_file],
+        command = "cp {src} {dst}".format(
+            src = ctx.info_file.path,
+            dst = output.path,
+        ),
+    )
+
+stamp_info = rule(
+    implementation = _impl,
+    outputs = {
+        # The stamp file.
+        "out": "%{name}.txt",
+    },
+)


### PR DESCRIPTION
image_test.py currently uses the environment variable USER to obtain the
build user. While this matches the BUILD_USER when bazel is invoked
localy, it can be different when the test action is executed in a remote
machine. This commit makes the Bazel stamp variables available to
image_test.py so that it can obtain the BUILD_USER as set by Bazel.