### PR TITLE
container_pull: don't drop name in returned arguments

### DIFF
--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -131,6 +131,8 @@ exports_files(["digest"])
         k: getattr(repository_ctx.attr, k)
         for k in _container_pull_attrs.keys()
     }
+    updated_attrs["name"] = repository_ctx.name
+
     digest_result = repository_ctx.execute(["cat", repository_ctx.path("image/digest")])
     if digest_result.return_code:
         fail("Failed to read digest: %s" % digest_result.stderr)


### PR DESCRIPTION
I may have introduced a small bug in #544:
```
INFO: Rule 'debian-base-arm' modified arguments {"digest": "sha256:27c1633c98e29cc9ae40b7b50f84a247ff1e50c1804389fec9d570bda359cbbb"} and dropped ["name"]
INFO: Rule 'go_image_base' dropped arguments ["name"]
INFO: Rule 'alpine-base' dropped arguments ["name"]
INFO: Rule 'git-base' dropped arguments ["name"]
```

I'm explicitly setting the name here to make that info message go away. (Note that it seems like everything is still working, so this probably isn't a critical urgent fix.)