### PR TITLE
Match the full package name.

### DIFF
--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -104,7 +104,7 @@ class TarFile(object):
   class DebError(Exception):
     pass
 
-  PKG_NAME_RE = re.compile(r'Package:\s*(?P<pkg_name>\w+).*')
+  PKG_NAME_RE = re.compile(r'Package:\s*(?P<pkg_name>[^\s]+).*')
   DPKG_STATUS_DIR = '/var/lib/dpkg/status.d'
   PKG_METADATA_FILE = 'control'
 


### PR DESCRIPTION
\w does not include hyphen, so packages with - in their name generate
the same filenames. A random one is included into the final image.

Testing suggests that the files put into the image based on these are how https://cloud.google.com/container-registry/docs/container-analysis determines what is installed. Having non-overlapping filenames means that all the metadata is present for the analysis.