### PR TITLE
Do not add --all_incompatible_changes to presubmit

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -18,7 +18,6 @@ platforms:
     # tests/contrib/test_compare_ids_test_* expect 'bazel' on path
     test_flags:
     - "--action_env=PATH"
-    - "--all_incompatible_changes"
     # TODO(xingao): Remove after https://github.com/bazelbuild/rules_scala/issues/644 is addressed.
     - "--incompatible_disallow_legacy_javainfo=false"
   ubuntu1604:
@@ -39,7 +38,6 @@ platforms:
     # tests/contrib/test_compare_ids_test_* expect 'bazel' on path
     test_flags:
     - "--action_env=PATH"
-    - "--all_incompatible_changes"
     # TODO(xingao): Remove after https://github.com/bazelbuild/rules_scala/issues/644 is addressed.
     - "--incompatible_disallow_legacy_javainfo=false"
   macos:
@@ -47,14 +45,12 @@ platforms:
     - "//tests/docker:test_digest_output1"
     build_flags:
     - "--action_env=PATH"
-    - "--all_incompatible_changes"
     # TODO(xingao): Remove after https://github.com/bazelbuild/rules_scala/issues/644 is addressed.
     - "--incompatible_disallow_legacy_javainfo=false"
     test_targets:
     - "//tests/docker:test_digest_output1"
     test_flags:
     - "--action_env=PATH"
-    - "--all_incompatible_changes"
     # TODO(xingao): Remove after https://github.com/bazelbuild/rules_scala/issues/644 is addressed.
     - "--incompatible_disallow_legacy_javainfo=false"
   rbe_ubuntu1604:
@@ -65,7 +61,6 @@ platforms:
     - "--extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:nosla_xenial_docker"
     - "--host_platform=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:nosla_xenial_docker"
     - "--platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:nosla_xenial_docker"
-    - "--all_incompatible_changes"
     # TODO(xingao): Remove after https://github.com/bazelbuild/rules_scala/issues/644 is addressed.
     - "--incompatible_disallow_legacy_javainfo=false"
     test_targets:
@@ -81,6 +76,5 @@ platforms:
     - "--extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:nosla_xenial_docker"
     - "--host_platform=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:nosla_xenial_docker"
     - "--platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:nosla_xenial_docker"
-    - "--all_incompatible_changes"
     # TODO(xingao): Remove after https://github.com/bazelbuild/rules_scala/issues/644 is addressed.
     - "--incompatible_disallow_legacy_javainfo=false"


### PR DESCRIPTION
The incompatible change process is a little bit more involved than using `--all_incompatible_changes`. We allow creating new incompatible flags which we don't expect users to migrate for right away. The principled place to look for incompatible changes is to go to https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+label%3Aincompatible-change+label%3Amigration-ready, ideally also filtered with the bazel version (e.g. for flags that should be migrated in bazel 0.22.0, add the label 'migration-0.22'.

On the buildkite, this is the pipeline that tells rule owners which incompatible flags they have to migrate for in the current bazel release: https://buildkite.com/bazel/bazel-at-release-plus-incompatible-flags

This PR fixed the failure on the Bazel downstream pipeline: https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/745#477cd902-ce69-4aa3-9f07-137bbc40649b