### PR TITLE
exec docker run statement.

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -237,7 +237,5 @@ function read_variables() {
 # This is not executed if the single argument --norun is passed.
 if [ "a$*" != "a--norun" ]; then
   # This generated and injected by docker_*.
-  %{run_statements}
-  # Empty if blocks can be problematic.
-  echo > /dev/null
+  exec %{run_statements}
 fi


### PR DESCRIPTION
We are running into some smaller issues, where we want to run the binary output of the x_image rules in another script, but then when this script wants to gracefully terminate all its child processes it only kills the bash process but not the docker run it executed. As far as I can tell (and from testing) the `cleanup` function does not do anything in this case so it should also be no problem that it is not getting called anymore.

And in general I think it is nicer in a case like this, where we have a wrapper script that just sets up a few things before executing a single binary that this binary then becomes the main process.