### PR TITLE
go_image() now respects restricted_to and compatible_with

### DIFF
--- a/go/image.bzl
+++ b/go/image.bzl
@@ -89,6 +89,8 @@ def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
 
     visibility = kwargs.get("visibility", None)
     tags = kwargs.get("tags", None)
+    restricted_to = kwargs.get("restricted_to", None)
+    compatible_with = kwargs.get("compatible_with", None)
     app_layer(
         name = name,
         base = base,
@@ -98,4 +100,6 @@ def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
         args = kwargs.get("args"),
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
+        restricted_to = restricted_to,
+        compatible_with = compatible_with,
     )


### PR DESCRIPTION
I'm trying to build a go_image with a go_binary marked as restricted_to=[... some environment...] and it fails, apparently because app_layer() doesn't see the restricted_to values passed to go_image. This also passes through compatible_with for good measure.
