### PR TITLE
Update container_bundle doc to remark deprecation of "stamp" attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,7 @@ An executable rule that pushes a Docker image to a Docker registry on `bazel run
       <td><code>stamp</code></td>
       <td>
         <p><code>Bool; optional</code></p>
+        <p>Deprecated: it is now automatically inferred.</p>
         <p>If true, enable use of workspace status variables
         (e.g. <code>BUILD_USER</code>, <code>BUILD_EMBED_LABEL</code>,
         and custom values set using <code>--workspace_status_command</code>)

--- a/README.md
+++ b/README.md
@@ -1882,6 +1882,7 @@ A rule that aliases and saves N images into a single `docker save` tarball.
       <td><code>stamp</code></td>
       <td>
         <p><code>Bool; optional</code></p>
+        <p>Deprecated: it is now automatically inferred.</p>
         <p>If true, enable use of workspace status variables
         (e.g. <code>BUILD_USER</code>, <code>BUILD_EMBED_LABEL</code>,
         and custom values set using <code>--workspace_status_command</code>)


### PR DESCRIPTION
When I tried using it, `bazel` says it is depreated.

`DEBUG: /.../home/chanseok/.cache/bazel/_bazel_chanseok/2fa25e6c02293c6f4b6133cec26037eb/external/io_bazel_rules_docker/container/bundle.bzl:42:9: Attr 'stamp' is deprecated; it is now automatically inferred. Please remove it from //:all`