### PR TITLE
Use containerregistery cache directory 

### DIFF
--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -106,8 +106,6 @@ exports_files(["digest"])
         if cache_dir.startswith('~/') and "HOME" in repository_ctx.os.environ:
             cache_dir = cache_dir.replace('~', repository_ctx.os.environ["HOME"], 1)
 
-        repository_ctx.execute(["mkdir", "-p", cache_dir])
-
         args += [
             "--cache",
             cache_dir

--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -101,6 +101,18 @@ exports_files(["digest"])
     if repository_ctx.attr.docker_client_config != "":
         args += ["--client-config-dir", "{}".format(repository_ctx.attr.docker_client_config)]
 
+    cache_dir = repository_ctx.os.environ.get("docker_repository_cache")
+    if cache_dir:
+        if cache_dir.startswith('~/') and "HOME" in repository_ctx.os.environ:
+            cache_dir = cache_dir.replace('~', repository_ctx.os.environ["HOME"], 1)
+
+        repository_ctx.execute(["mkdir", "-p", cache_dir])
+
+        args += [
+            "--cache",
+            cache_dir
+        ]
+
     # If a digest is specified, then pull by digest.  Otherwise, pull by tag.
     if repository_ctx.attr.digest:
         args += [

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -24,7 +24,7 @@ load(
 )
 
 # The release of the github.com/google/containerregistry to consume.
-CONTAINERREGISTRY_RELEASE = "v0.0.34"
+CONTAINERREGISTRY_RELEASE = "v0.0.35"
 
 _local_tool_build_template = """
 sh_binary(
@@ -60,7 +60,7 @@ def repositories():
         http_file(
             name = "puller",
             executable = True,
-            sha256 = "2a3ccb6ef8f99ec0053b56380824a7c100ba00eb0e147d1bda748884113542f1",
+            sha256 = "480baba71500f837672093799de9c5492990a04d327a0b9bb3e1f75eecbbdfde",
             urls = [("https://storage.googleapis.com/containerregistry-releases/" +
                      CONTAINERREGISTRY_RELEASE + "/puller.par")],
         )
@@ -69,7 +69,7 @@ def repositories():
         http_file(
             name = "importer",
             executable = True,
-            sha256 = "0eec1a4ffb26623dbb4075e5459fa0ede36548edf872d2691ebbcb3c4ccb8cf3",
+            sha256 = "dad924671e4fee84b7ddfb1cd06b988d7f4e18836b81f0c6ae8e144ae046a18f",
             urls = [("https://storage.googleapis.com/containerregistry-releases/" +
                      CONTAINERREGISTRY_RELEASE + "/importer.par")],
         )
@@ -77,7 +77,7 @@ def repositories():
     if "containerregistry" not in excludes:
         http_archive(
             name = "containerregistry",
-            sha256 = "8182728578f7d7178e7efcef8ce9074988a1a2667f20ecff5cf6234fba284dd3",
+            sha256 = "98a7d40b7b45dc76f031c9e17728dddb963f8ec28a1ee4d18693e57155d198f8",
             strip_prefix = "containerregistry-" + CONTAINERREGISTRY_RELEASE[1:],
             urls = [("https://github.com/google/containerregistry/archive/" +
                      CONTAINERREGISTRY_RELEASE + ".tar.gz")],


### PR DESCRIPTION
This PR is to enable caching in `rules_docker` using the cache feature added to `containerregistery`

**Current open items:**
1. Does `docker_rules` need to create the cache directory if it doesn't exist? (`containerregistery` doesn't create it)
2. How to test this feature in `rules_docker`?