### PR TITLE
Split py_binary into py_binary and py_library …

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -69,6 +69,14 @@ py_binary(
     srcs = ["build_tar.py"],
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
+    deps = [":build_tar_lib"],
+)
+
+py_library(
+    name = "build_tar_lib",
+    srcs = ["build_tar.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         "@bazel_tools//third_party/py/gflags",
         "@bazel_tools//tools/build_defs/pkg:archive",

--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -28,12 +28,18 @@ exports_files(["extract_image_id.py"])
 py_binary(
     name = "extract_image_id",
     srcs = [":extract_image_id.py"],
+    deps = [":extract_image_id_lib"],
+)
+
+py_library(
+    name = "extract_image_id_lib",
+    srcs = [":extract_image_id.py"],
 )
 
 py_binary(
     name = "compare_ids_test",
     srcs = [":compare_ids_test.py"],
-    deps = ["extract_image_id"],
+    deps = [":extract_image_id_lib"],
 )
 
 alias(

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -3,5 +3,5 @@ package(default_visibility = ["//visibility:public"])
 py_test(
     name = "build_tar_test",
     srcs = ["build_tar_test.py"],
-    deps = ["//container:build_tar"],
+    deps = ["//container:build_tar_lib"],
 )


### PR DESCRIPTION
to avoid having py_binary in deps.

* Having py_binary in deps is deprecated and will break in 19Q1.