### PR TITLE
container_push: added attribute 'tag_file'

### DIFF
--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -397,6 +397,16 @@ function test_container_push() {
   docker stop -t 0 $cid
 }
 
+function test_container_push_tag_file() {
+  cd "${ROOT}"
+  clear_docker
+  cid=$(docker run --rm -d -p 5000:5000 --name registry registry:2)
+  bazel build tests/docker:push_tag_file_test
+  EXPECT_CONTAINS "$(cat bazel-bin/tests/docker/push_tag_file_test)" '--name=localhost:5000/docker/test:$(cat ${RUNFILES}/io_bazel_rules_docker/tests/docker/test.tag)'
+
+  docker stop -t 0 $cid
+}
+
 # Launch a private docker registry at localhost:5000 that requires a basic
 # htpasswd authentication with credentials at docker-config/htpasswd and needs
 # the docker client to be using the authentication from
@@ -543,4 +553,5 @@ test_rust_image -c dbg
 test_nodejs_image -c opt
 test_nodejs_image -c dbg
 test_container_push
+test_container_push_tag_file
 test_launcher_image

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -269,6 +269,24 @@ container_push(
     tags = ["manual"],
 )
 
+genrule(
+    name = "push_tag_file",
+    output_to_bindir = 1,
+    srcs = [],
+    outs = ["test.tag"],
+    cmd = """echo test > $@""",
+)
+
+container_push(
+    name = "push_tag_file_test",
+    format = "Docker",
+    image = ":set_cmd",
+    registry = "localhost:5000",
+    repository = "docker/test",
+    tag_file = ":test.tag",
+    tags = ["manual"],
+)
+
 container_push(
     name = "push_stamped_test",
     format = "Docker",


### PR DESCRIPTION
I need ability to specify tag of image for push as content of file.
I added `tag_file` attribute to `container_push` rule.