### PR TITLE
Set default_mtime=0 on TarFileWriter so that elements default to the epoch

### DIFF
--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -126,7 +126,8 @@ class TarFile(object):
     self.tarfile = archive.TarFileWriter(
         self.output,
         self.compression,
-        self.root_directory
+        self.root_directory,
+        default_mtime=0
     )
     return self
 


### PR DESCRIPTION
Context: https://github.com/bazelbuild/bazel/pull/7276