### PR TITLE
Set default_mtime=0 on TarFileWriter so that elements default to the epoch

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -79,8 +79,8 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        "@bazel_source//tools/build_defs/pkg:archive",
         "@bazel_tools//third_party/py/gflags",
-        "@bazel_tools//tools/build_defs/pkg:archive",
     ],
 )
 

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -25,7 +25,7 @@ import re
 import tarfile
 import tempfile
 
-from tools.build_defs.pkg import archive
+from bazel_source.tools.build_defs.pkg import archive
 from third_party.py import gflags
 
 gflags.DEFINE_string('output', None, 'The output file, mandatory')
@@ -126,7 +126,8 @@ class TarFile(object):
     self.tarfile = archive.TarFileWriter(
         self.output,
         self.compression,
-        self.root_directory
+        self.root_directory,
+        default_mtime=0
     )
     return self
 

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -96,7 +96,7 @@ gflags.DEFINE_string('xz_path', None,
                      'lzma module is unavailable.')
 
 FLAGS = gflags.FLAGS
-
+DEFAULT_MTIME = 0
 
 class TarFile(object):
   """A class to generates a Docker layer."""
@@ -127,7 +127,6 @@ class TarFile(object):
         self.output,
         self.compression,
         self.root_directory,
-        default_mtime=0
     )
     return self
 
@@ -164,7 +163,8 @@ class TarFile(object):
         uid=ids[0],
         gid=ids[1],
         uname=names[0],
-        gname=names[1])
+        gname=names[1],
+        mtime=DEFAULT_MTIME)
 
   def add_empty_file(self, destfile, mode=None, ids=None, names=None,
                      kind=tarfile.REGTYPE):
@@ -196,7 +196,8 @@ class TarFile(object):
         uid=ids[0],
         gid=ids[1],
         uname=names[0],
-        gname=names[1])
+        gname=names[1],
+        mtime=DEFAULT_MTIME)
 
   def add_empty_dir(self, destpath, mode=None, ids=None, names=None):
     """Add a directory to the tar file.
@@ -252,7 +253,7 @@ class TarFile(object):
       destination: where the symbolic link point to.
     """
     symlink = os.path.normpath(symlink)
-    self.tarfile.add_file(symlink, tarfile.SYMTYPE, link=destination)
+    self.tarfile.add_file(symlink, tarfile.SYMTYPE, link=destination, mtime=DEFAULT_MTIME)
 
   @contextmanager
   def write_temp_file(self, data, suffix='tar', mode='wb'):

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -96,7 +96,7 @@ gflags.DEFINE_string('xz_path', None,
                      'lzma module is unavailable.')
 
 FLAGS = gflags.FLAGS
-DEFAULT_MTIME = 0
+
 
 class TarFile(object):
   """A class to generates a Docker layer."""
@@ -127,6 +127,7 @@ class TarFile(object):
         self.output,
         self.compression,
         self.root_directory,
+        default_mtime=0
     )
     return self
 
@@ -163,8 +164,7 @@ class TarFile(object):
         uid=ids[0],
         gid=ids[1],
         uname=names[0],
-        gname=names[1],
-        mtime=DEFAULT_MTIME)
+        gname=names[1])
 
   def add_empty_file(self, destfile, mode=None, ids=None, names=None,
                      kind=tarfile.REGTYPE):
@@ -196,8 +196,7 @@ class TarFile(object):
         uid=ids[0],
         gid=ids[1],
         uname=names[0],
-        gname=names[1],
-        mtime=DEFAULT_MTIME)
+        gname=names[1])
 
   def add_empty_dir(self, destpath, mode=None, ids=None, names=None):
     """Add a directory to the tar file.
@@ -253,7 +252,7 @@ class TarFile(object):
       destination: where the symbolic link point to.
     """
     symlink = os.path.normpath(symlink)
-    self.tarfile.add_file(symlink, tarfile.SYMTYPE, link=destination, mtime=DEFAULT_MTIME)
+    self.tarfile.add_file(symlink, tarfile.SYMTYPE, link=destination)
 
   @contextmanager
   def write_temp_file(self, data, suffix='tar', mode='wb'):

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -88,7 +88,7 @@ class ImageTest(unittest.TestCase):
 
   def test_tar_base(self):
     with TestImage('tar_base') as img:
-      self.assertDigest(img, 'df626b895bc8c7b18e6615ac09ffbd0693268a24a817a94030ff88c37602147e')
+      self.assertDigest(img, '9592405ace7b400b5a01de496ce050dfc309d52a95ad078a5c20845d7ae6f1a7')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, [
         './usr', './usr/bin', './usr/bin/unremarkabledeath'])
@@ -97,7 +97,7 @@ class ImageTest(unittest.TestCase):
 
   def test_tar_with_tar_base(self):
     with TestImage('tar_with_tar_base') as img:
-      self.assertDigest(img, 'fc867d1606f3b54228ef9b2a3dcda56f2d2056bfcd1e0a18da3a0e7b86b95798')
+      self.assertDigest(img, '76d01605ebe270f71a8aab057c221d291d9ced2632c8e59d34b635ebe5233f4c')
       self.assertEqual(2, len(img.fs_layers()))
       self.assertTopLayerContains(img, [
         './asdf', './usr', './usr/bin',
@@ -105,7 +105,7 @@ class ImageTest(unittest.TestCase):
 
   def test_tars_in_layer_with_tar_base(self):
     with TestImage('tars_in_layer_with_tar_base') as img:
-      self.assertDigest(img, '80f850359828f763ae544f9b7725f89755f1a28a80738a514735becae60924af')
+      self.assertDigest(img, 'f6dc468e5bba82c32b44408866ea7edf0b64a3080a6b314db17c762bb5362708')
       self.assertEqual(3, len(img.fs_layers()))
       self.assertTopLayerContains(img, [
         './asdf', './usr', './usr/bin',
@@ -116,7 +116,7 @@ class ImageTest(unittest.TestCase):
 
   def test_directory_with_tar_base(self):
     with TestImage('directory_with_tar_base') as img:
-      self.assertDigest(img, 'ad11d32eb4b2d3abd01ce599a4200b20cf1c545ce870b174d28fd717c558a58c')
+      self.assertDigest(img, '4db1263177fb4ac82773bdbb33f8569da803fa2b88f0a1e0511bf7149b23cbc3')
       self.assertEqual(2, len(img.fs_layers()))
       self.assertTopLayerContains(img, [
         '.', './foo', './foo/asdf', './foo/usr',
@@ -124,13 +124,13 @@ class ImageTest(unittest.TestCase):
 
   def test_files_with_tar_base(self):
     with TestImage('files_with_tar_base') as img:
-      self.assertDigest(img, 'f6f74908187196165c75ccabf1e419255a7217f282f2989020ac6873b6b4a741')
+      self.assertDigest(img, '14fc464f1d508b4b53101e11e803de2427700b8c3e7cb8d1f3827cb890fb1865')
       self.assertEqual(2, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './bar'])
 
   def test_workdir_with_tar_base(self):
     with TestImage('workdir_with_tar_base') as img:
-      self.assertDigest(img, 'fe996f674b45b5d446e8eedd66cf2f6cfaddd9949e56f71d1a4963db40763145')
+      self.assertDigest(img, 'd224b4d4bc981cbd43b7219ce36df1410183d059a08b92c7aeb387332fd8f6f0')
       self.assertEqual(2, len(img.fs_layers()))
       self.assertTopLayerContains(img, [])
       # Check that the working directory property has been properly configured.
@@ -138,7 +138,7 @@ class ImageTest(unittest.TestCase):
 
   def test_tar_with_files_base(self):
     with TestImage('tar_with_files_base') as img:
-      self.assertDigest(img, 'b791c09580efa5b2e961897a98facb46432e964558cfdbdbf153f0f2662a2465')
+      self.assertDigest(img, '7287c537904c80559cda442a6de13063882c8b645b3875716c970006dc721925')
       self.assertEqual(2, len(img.fs_layers()))
       self.assertTopLayerContains(img, [
         './asdf', './usr', './usr/bin',
@@ -152,7 +152,7 @@ class ImageTest(unittest.TestCase):
 
   def test_layers_with_docker_tarball_base(self):
     with TestImage('layers_with_docker_tarball_base') as img:
-      self.assertDigest(img, '927b3b98286e16727e2144152efb90f7394b0ad37d16668d40ce22b9e49debf9')
+      self.assertDigest(img, '37c30a70a2be44014f69e6acc38d2e99b7eb34cd77fe0f16655637e056b292ad')
       self.assertEqual(5, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './foo'])
       self.assertLayerNContains(img, 1, ['.', './three', './three/three'])
@@ -160,7 +160,7 @@ class ImageTest(unittest.TestCase):
 
   def test_base_with_entrypoint(self):
     with TestImage('base_with_entrypoint') as img:
-      self.assertDigest(img, '813cb4af1c3f73cc2b5f837a61dca6a62335b87e5cd762e780286ca99f71ac83')
+      self.assertDigest(img, '5a260a3910e39c09ed929a15169657a7b5bed0c9c2a394d88c9cb59c27077f58')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertConfigEqual(img, 'Entrypoint', ['/bar'])
       self.assertConfigEqual(img, 'ExposedPorts', {'8080/tcp': {}})
@@ -173,7 +173,7 @@ class ImageTest(unittest.TestCase):
 
   def test_derivative_with_cmd(self):
     with TestImage('derivative_with_cmd') as img:
-      self.assertDigest(img, 'd9756678b73e8ed342866f3694618f85a45430a01f89694580c76659445a7ccb')
+      self.assertDigest(img, '9cb523fa98457bb3fb2125e031b4fb11f466b7ccef6f5f008f37c4bacfbc62da')
       self.assertEqual(3, len(img.fs_layers()))
 
       self.assertConfigEqual(img, 'Entrypoint', ['/bar'])
@@ -354,7 +354,7 @@ class ImageTest(unittest.TestCase):
     )) as img:
         self.assertDigest(img, '31d7d27f5e63516de98a3f67c382b7f86cfa1000d75c04a9e04c136162daa98b')
     with TestBundleImage('bundle_test', 'docker.io/ubuntu:latest') as img:
-      self.assertDigest(img, '813cb4af1c3f73cc2b5f837a61dca6a62335b87e5cd762e780286ca99f71ac83')
+      self.assertDigest(img, '5a260a3910e39c09ed929a15169657a7b5bed0c9c2a394d88c9cb59c27077f58')
       self.assertEqual(1, len(img.fs_layers()))
     with TestBundleImage(
         'bundle_test', 'us.gcr.io/google-appengine/base:fresh') as img:
@@ -391,7 +391,7 @@ class ImageTest(unittest.TestCase):
 
   def test_with_passwd(self):
     with TestImage('with_passwd') as img:
-      self.assertDigest(img, '27149ceaab154631346209b42c9494708210901fbb6e9f88cb9370fb51f30999')
+      self.assertDigest(img, '13d751d146a188d44d81e8fc54cfb030fd7b3ba8fe5d590be953b2fdf2521126')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './etc', './etc/passwd'])
 
@@ -405,7 +405,7 @@ class ImageTest(unittest.TestCase):
 
   def test_with_passwd_tar(self):
     with TestImage('with_passwd_tar') as img:
-      self.assertDigest(img, 'b8f091c370d6a8a6f74e11327f52e579f73dd93d9cf82e39e83b3096bb0c2256')
+      self.assertDigest(img, '0125015b694e09b5ddbda7dd25576bfc914391436c494e1697fdf6a31fa1cdf1')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './etc', './etc/password', './root', './myhomedir'])
 
@@ -422,7 +422,7 @@ class ImageTest(unittest.TestCase):
 
   def test_with_group(self):
     with TestImage('with_group') as img:
-      self.assertDigest(img, 'd6384ee5db847e2c8a9e941d78c10bec987aa9cbd4b5b84847e20336ec09d49c')
+      self.assertDigest(img, '343f85ea24618b3a7edee0dd55a351897ee33075501af90f21929a308fa0d132')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './etc', './etc/group'])
 

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -213,9 +213,8 @@ class ImageTest(unittest.TestCase):
       cfg = json.loads(img.config_file())
       self.assertEqual('1989-05-03T12:58:12.345Z', cfg.get('created', ''))
 
-  # TODO(ngiraldo): re-enable this test once I fix issue related to
-  # https://github.com/bazelbuild/bazel/commit/1cf75b9dab3e0bb2ffa3014d6e657aa486b1c7bf
-  def no_test_with_stamped_creation_time(self):
+  # This test is flaky. If it fails, do a bazel clean --expunge_async and try again
+  def test_with_stamped_creation_time(self):
     with TestImage('with_stamped_creation_time') as img:
       self.assertEqual(2, len(img.fs_layers()))
       cfg = json.loads(img.config_file())
@@ -234,9 +233,8 @@ class ImageTest(unittest.TestCase):
       # Assume that any value for 'created' within a reasonable bound is fine.
       self.assertLessEqual(now - created, datetime.timedelta(minutes=15))
 
-  # TODO(ngiraldo): re-enable this test once I fix issue related to
-  # https://github.com/bazelbuild/bazel/commit/1cf75b9dab3e0bb2ffa3014d6e657aa486b1c7bf
-  def no_test_with_default_stamped_creation_time(self):
+  # This test is flaky. If it fails, do a bazel clean --expunge_async and try again 
+  def test_with_default_stamped_creation_time(self):
     # {BUILD_TIMESTAMP} should be the default when `stamp = True` and
     # `creation_time` isn't explicitly defined.
     with TestImage('with_default_stamped_creation_time') as img:

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -88,7 +88,7 @@ class ImageTest(unittest.TestCase):
 
   def test_tar_base(self):
     with TestImage('tar_base') as img:
-      self.assertDigest(img, '9592405ace7b400b5a01de496ce050dfc309d52a95ad078a5c20845d7ae6f1a7')
+      self.assertDigest(img, 'df626b895bc8c7b18e6615ac09ffbd0693268a24a817a94030ff88c37602147e')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, [
         './usr', './usr/bin', './usr/bin/unremarkabledeath'])
@@ -97,7 +97,7 @@ class ImageTest(unittest.TestCase):
 
   def test_tar_with_tar_base(self):
     with TestImage('tar_with_tar_base') as img:
-      self.assertDigest(img, '76d01605ebe270f71a8aab057c221d291d9ced2632c8e59d34b635ebe5233f4c')
+      self.assertDigest(img, 'fc867d1606f3b54228ef9b2a3dcda56f2d2056bfcd1e0a18da3a0e7b86b95798')
       self.assertEqual(2, len(img.fs_layers()))
       self.assertTopLayerContains(img, [
         './asdf', './usr', './usr/bin',
@@ -105,7 +105,7 @@ class ImageTest(unittest.TestCase):
 
   def test_tars_in_layer_with_tar_base(self):
     with TestImage('tars_in_layer_with_tar_base') as img:
-      self.assertDigest(img, 'f6dc468e5bba82c32b44408866ea7edf0b64a3080a6b314db17c762bb5362708')
+      self.assertDigest(img, '80f850359828f763ae544f9b7725f89755f1a28a80738a514735becae60924af')
       self.assertEqual(3, len(img.fs_layers()))
       self.assertTopLayerContains(img, [
         './asdf', './usr', './usr/bin',
@@ -116,7 +116,7 @@ class ImageTest(unittest.TestCase):
 
   def test_directory_with_tar_base(self):
     with TestImage('directory_with_tar_base') as img:
-      self.assertDigest(img, '4db1263177fb4ac82773bdbb33f8569da803fa2b88f0a1e0511bf7149b23cbc3')
+      self.assertDigest(img, 'ad11d32eb4b2d3abd01ce599a4200b20cf1c545ce870b174d28fd717c558a58c')
       self.assertEqual(2, len(img.fs_layers()))
       self.assertTopLayerContains(img, [
         '.', './foo', './foo/asdf', './foo/usr',
@@ -124,13 +124,13 @@ class ImageTest(unittest.TestCase):
 
   def test_files_with_tar_base(self):
     with TestImage('files_with_tar_base') as img:
-      self.assertDigest(img, '14fc464f1d508b4b53101e11e803de2427700b8c3e7cb8d1f3827cb890fb1865')
+      self.assertDigest(img, 'f6f74908187196165c75ccabf1e419255a7217f282f2989020ac6873b6b4a741')
       self.assertEqual(2, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './bar'])
 
   def test_workdir_with_tar_base(self):
     with TestImage('workdir_with_tar_base') as img:
-      self.assertDigest(img, 'd224b4d4bc981cbd43b7219ce36df1410183d059a08b92c7aeb387332fd8f6f0')
+      self.assertDigest(img, 'fe996f674b45b5d446e8eedd66cf2f6cfaddd9949e56f71d1a4963db40763145')
       self.assertEqual(2, len(img.fs_layers()))
       self.assertTopLayerContains(img, [])
       # Check that the working directory property has been properly configured.
@@ -138,7 +138,7 @@ class ImageTest(unittest.TestCase):
 
   def test_tar_with_files_base(self):
     with TestImage('tar_with_files_base') as img:
-      self.assertDigest(img, '7287c537904c80559cda442a6de13063882c8b645b3875716c970006dc721925')
+      self.assertDigest(img, 'b791c09580efa5b2e961897a98facb46432e964558cfdbdbf153f0f2662a2465')
       self.assertEqual(2, len(img.fs_layers()))
       self.assertTopLayerContains(img, [
         './asdf', './usr', './usr/bin',
@@ -152,7 +152,7 @@ class ImageTest(unittest.TestCase):
 
   def test_layers_with_docker_tarball_base(self):
     with TestImage('layers_with_docker_tarball_base') as img:
-      self.assertDigest(img, '37c30a70a2be44014f69e6acc38d2e99b7eb34cd77fe0f16655637e056b292ad')
+      self.assertDigest(img, '927b3b98286e16727e2144152efb90f7394b0ad37d16668d40ce22b9e49debf9')
       self.assertEqual(5, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './foo'])
       self.assertLayerNContains(img, 1, ['.', './three', './three/three'])
@@ -160,7 +160,7 @@ class ImageTest(unittest.TestCase):
 
   def test_base_with_entrypoint(self):
     with TestImage('base_with_entrypoint') as img:
-      self.assertDigest(img, '5a260a3910e39c09ed929a15169657a7b5bed0c9c2a394d88c9cb59c27077f58')
+      self.assertDigest(img, '813cb4af1c3f73cc2b5f837a61dca6a62335b87e5cd762e780286ca99f71ac83')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertConfigEqual(img, 'Entrypoint', ['/bar'])
       self.assertConfigEqual(img, 'ExposedPorts', {'8080/tcp': {}})
@@ -173,7 +173,7 @@ class ImageTest(unittest.TestCase):
 
   def test_derivative_with_cmd(self):
     with TestImage('derivative_with_cmd') as img:
-      self.assertDigest(img, '9cb523fa98457bb3fb2125e031b4fb11f466b7ccef6f5f008f37c4bacfbc62da')
+      self.assertDigest(img, 'd9756678b73e8ed342866f3694618f85a45430a01f89694580c76659445a7ccb')
       self.assertEqual(3, len(img.fs_layers()))
 
       self.assertConfigEqual(img, 'Entrypoint', ['/bar'])
@@ -213,7 +213,9 @@ class ImageTest(unittest.TestCase):
       cfg = json.loads(img.config_file())
       self.assertEqual('1989-05-03T12:58:12.345Z', cfg.get('created', ''))
 
-  def test_with_stamped_creation_time(self):
+  # TODO(ngiraldo): re-enable this test once I fix issue related to
+  # https://github.com/bazelbuild/bazel/commit/1cf75b9dab3e0bb2ffa3014d6e657aa486b1c7bf
+  def no_test_with_stamped_creation_time(self):
     with TestImage('with_stamped_creation_time') as img:
       self.assertEqual(2, len(img.fs_layers()))
       cfg = json.loads(img.config_file())
@@ -232,7 +234,9 @@ class ImageTest(unittest.TestCase):
       # Assume that any value for 'created' within a reasonable bound is fine.
       self.assertLessEqual(now - created, datetime.timedelta(minutes=15))
 
-  def test_with_default_stamped_creation_time(self):
+  # TODO(ngiraldo): re-enable this test once I fix issue related to
+  # https://github.com/bazelbuild/bazel/commit/1cf75b9dab3e0bb2ffa3014d6e657aa486b1c7bf
+  def no_test_with_default_stamped_creation_time(self):
     # {BUILD_TIMESTAMP} should be the default when `stamp = True` and
     # `creation_time` isn't explicitly defined.
     with TestImage('with_default_stamped_creation_time') as img:
@@ -354,7 +358,7 @@ class ImageTest(unittest.TestCase):
     )) as img:
         self.assertDigest(img, '31d7d27f5e63516de98a3f67c382b7f86cfa1000d75c04a9e04c136162daa98b')
     with TestBundleImage('bundle_test', 'docker.io/ubuntu:latest') as img:
-      self.assertDigest(img, '5a260a3910e39c09ed929a15169657a7b5bed0c9c2a394d88c9cb59c27077f58')
+      self.assertDigest(img, '813cb4af1c3f73cc2b5f837a61dca6a62335b87e5cd762e780286ca99f71ac83')
       self.assertEqual(1, len(img.fs_layers()))
     with TestBundleImage(
         'bundle_test', 'us.gcr.io/google-appengine/base:fresh') as img:
@@ -391,7 +395,7 @@ class ImageTest(unittest.TestCase):
 
   def test_with_passwd(self):
     with TestImage('with_passwd') as img:
-      self.assertDigest(img, '13d751d146a188d44d81e8fc54cfb030fd7b3ba8fe5d590be953b2fdf2521126')
+      self.assertDigest(img, '27149ceaab154631346209b42c9494708210901fbb6e9f88cb9370fb51f30999')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './etc', './etc/passwd'])
 
@@ -405,7 +409,7 @@ class ImageTest(unittest.TestCase):
 
   def test_with_passwd_tar(self):
     with TestImage('with_passwd_tar') as img:
-      self.assertDigest(img, '0125015b694e09b5ddbda7dd25576bfc914391436c494e1697fdf6a31fa1cdf1')
+      self.assertDigest(img, 'b8f091c370d6a8a6f74e11327f52e579f73dd93d9cf82e39e83b3096bb0c2256')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './etc', './etc/password', './root', './myhomedir'])
 
@@ -422,7 +426,7 @@ class ImageTest(unittest.TestCase):
 
   def test_with_group(self):
     with TestImage('with_group') as img:
-      self.assertDigest(img, '343f85ea24618b3a7edee0dd55a351897ee33075501af90f21929a308fa0d132')
+      self.assertDigest(img, 'd6384ee5db847e2c8a9e941d78c10bec987aa9cbd4b5b84847e20336ec09d49c')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './etc', './etc/group'])
 

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -56,8 +56,8 @@ def repositories():
     """Download dependencies of container rules."""
     excludes = native.existing_rules().keys()
 
-    # TODO(ngiraldo): Remove after 45e68f2f4344afa32f91b835888123cda3a77dc6 is in a Bazel release
-    # https://github.com/bazelbuild/bazel/commit/45e68f2f4344afa32f91b835888123cda3a77dc6
+    # TODO(ngiraldo): Remove after 1cf75b9dab3e0bb2ffa3014d6e657aa486b1c7bf is in a Bazel release
+    # https://github.com/bazelbuild/bazel/commit/1cf75b9dab3e0bb2ffa3014d6e657aa486b1c7bf
     if "bazel_source" not in excludes:
         http_archive(
             name = "bazel_source",

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -56,6 +56,15 @@ def repositories():
     """Download dependencies of container rules."""
     excludes = native.existing_rules().keys()
 
+    # TODO(ngiraldo): Remove after 45e68f2f4344afa32f91b835888123cda3a77dc6 is in a Bazel release
+    # https://github.com/bazelbuild/bazel/commit/45e68f2f4344afa32f91b835888123cda3a77dc6
+    if "bazel_source" not in excludes:
+        http_archive(
+            name = "bazel_source",
+            urls = [("https://github.com/bazelbuild/bazel/archive/45e68f2f4344afa32f91b835888123cda3a77dc6.tar.gz")],
+            sha256 = "90d93b3ead9841bbdf482e8b9cfc6f235b8159d330ae73c06f8036a667b0b8d4",
+        )
+
     if "puller" not in excludes:
         http_file(
             name = "puller",

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -61,9 +61,9 @@ def repositories():
     if "bazel_source" not in excludes:
         http_archive(
             name = "bazel_source",
-            sha256 = "90d93b3ead9841bbdf482e8b9cfc6f235b8159d330ae73c06f8036a667b0b8d4",
-            strip_prefix = "bazel-45e68f2f4344afa32f91b835888123cda3a77dc6",
-            urls = [("https://github.com/bazelbuild/bazel/archive/45e68f2f4344afa32f91b835888123cda3a77dc6.tar.gz")],
+            sha256 = "3f5441ab5bf403bc44e31bf018ed994d02a1bd2dbf350eface5bf343bc7dff4c",
+            strip_prefix = "bazel-1cf75b9dab3e0bb2ffa3014d6e657aa486b1c7bf",
+            urls = [("https://github.com/bazelbuild/bazel/archive/1cf75b9dab3e0bb2ffa3014d6e657aa486b1c7bf.tar.gz")],
         )
 
     if "puller" not in excludes:

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -61,8 +61,9 @@ def repositories():
     if "bazel_source" not in excludes:
         http_archive(
             name = "bazel_source",
-            urls = [("https://github.com/bazelbuild/bazel/archive/45e68f2f4344afa32f91b835888123cda3a77dc6.tar.gz")],
             sha256 = "90d93b3ead9841bbdf482e8b9cfc6f235b8159d330ae73c06f8036a667b0b8d4",
+            strip_prefix = "bazel-45e68f2f4344afa32f91b835888123cda3a77dc6",
+            urls = [("https://github.com/bazelbuild/bazel/archive/45e68f2f4344afa32f91b835888123cda3a77dc6.tar.gz")],
         )
 
     if "puller" not in excludes:

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -195,7 +195,7 @@ container_test(
 
 file_test(
     name = "test_digest_output1",
-    content = "sha256:683df4781a99de9f52a213dd84133d2b10d769f0077ff99f8128e48c2b361572",
+    content = "sha256:12f16b811707264bb51f96e85a5f08f0d23fe874dd857a4cd39f7a90844a8bdb",
     file = ":deb_image_with_dpkgs.digest",
 )
 

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -195,7 +195,7 @@ container_test(
 
 file_test(
     name = "test_digest_output1",
-    content = "sha256:12f16b811707264bb51f96e85a5f08f0d23fe874dd857a4cd39f7a90844a8bdb",
+    content = "sha256:683df4781a99de9f52a213dd84133d2b10d769f0077ff99f8128e48c2b361572",
     file = ":deb_image_with_dpkgs.digest",
 )
 


### PR DESCRIPTION
Replaces https://github.com/bazelbuild/rules_docker/pull/694 
* adds import of bazel at commit at which mtime was added 