### PR TITLE
Use internally downloaded @six and disable legacy_create_init

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -50,7 +50,7 @@ py_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":utils",
-        "@six",
+        "@six//:six",
         "@containerregistry",
     ],
     legacy_create_init = False,
@@ -62,12 +62,13 @@ py_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":utils",
-        "@six",
+        "@six//:six",
         "@containerregistry",
     ],
     legacy_create_init = False,
 )
 
+# TODO(xingao): Flip legacy_create_init once dependency on @bazel_source removed
 py_binary(
     name = "build_tar",
     srcs = ["build_tar.py"],

--- a/container/BUILD
+++ b/container/BUILD
@@ -33,6 +33,7 @@ py_binary(
     deps = [
         "@containerregistry",
     ],
+    legacy_create_init = False,
 )
 
 py_library(
@@ -52,6 +53,7 @@ py_binary(
         "@six",
         "@containerregistry",
     ],
+    legacy_create_init = False,
 )
 
 py_binary(
@@ -63,6 +65,7 @@ py_binary(
         "@six",
         "@containerregistry",
     ],
+    legacy_create_init = False,
 )
 
 py_binary(
@@ -71,6 +74,7 @@ py_binary(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [":build_tar_lib"],
+    legacy_create_init = True,
 )
 
 py_library(

--- a/container/BUILD
+++ b/container/BUILD
@@ -49,7 +49,7 @@ py_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":utils",
-        "@bazel_tools//third_party/py/six",
+        "@six",
         "@containerregistry",
     ],
 )
@@ -60,7 +60,7 @@ py_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":utils",
-        "@bazel_tools//third_party/py/six",
+        "@six",
         "@containerregistry",
     ],
 )

--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -29,6 +29,7 @@ py_binary(
     name = "extract_image_id",
     srcs = [":extract_image_id.py"],
     deps = [":extract_image_id_lib"],
+    legacy_create_init = False,
 )
 
 py_library(
@@ -40,6 +41,7 @@ py_binary(
     name = "compare_ids_test",
     srcs = [":compare_ids_test.py"],
     deps = [":extract_image_id_lib"],
+    legacy_create_init = False
 )
 
 alias(
@@ -54,4 +56,5 @@ alias(
 py_binary(
     name = "idd",
     srcs = ["idd.py"],
+    legacy_create_init = False
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -19,4 +19,5 @@ py_binary(
     deps = [
         "@containerregistry",
     ],
+    legacy_create_init = False,
 )


### PR DESCRIPTION
This moves the `py_binary` rules to use the internally downloaded `@six` dependency, rather than the one from `@bazel_tools`. Previously, both versions of six were in the runfiles, causing odd issues when the incorrect one was resolved first when six was imported.

Additionally, to fix the `__init__.py` issue, this also toggles `legacy_create_init`, which has been done for all targets that support it. The `//container:build_tar` target is the only one that still needs this enabled, due to the dependency on `@bazel_source` that appears temporary.

Alternatively, the internally downloaded six could be removed and you could depend on the `@bazel_tools` one.