### PR TITLE
Forward new provider for python in filter_layer

### DIFF
--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -287,21 +287,21 @@ def _filter_layer_rule_impl(ctx):
             runfiles = runfiles.merge(dep.target.default_runfiles)
             filtered_depsets.append(dep.target_deps)
 
-    # Forward correct provider, depending on Bazel version, so that the filter_layer() can be
+    # Forward correct provider, depending on availability, so that the filter_layer() can be
     # used as a normal dependency to native targets (e.g. py_library(deps = [<filter_layer>])).
     if hasattr(ctx.attr.dep, "py"):
-        # Forward legacy builtin provider
+        # Forward legacy builtin provider and PyInfo provider
         return struct(
             providers = [
                 FilterLayerInfo(
                     runfiles = runfiles,
                     filtered_depset = depset(transitive = filtered_depsets),
                 ),
-            ],
+            ] + ([ctx.attr.dep[PyInfo]] if PyInfo in ctx.attr.dep else []),
             py = ctx.attr.dep.py if hasattr(ctx.attr.dep, "py") else None,
         )
     else:
-        # Forward the PyInfo provider in Bazel >= 0.23.0
+        # Forward the PyInfo provider only
         return struct(
             providers = [
                 FilterLayerInfo(

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -286,17 +286,30 @@ def _filter_layer_rule_impl(ctx):
         if str(dep.target.label).startswith(ctx.attr.filter) and str(dep.target.label) != str(ctx.attr.dep.label):
             runfiles = runfiles.merge(dep.target.default_runfiles)
             filtered_depsets.append(dep.target_deps)
-    return struct(
-        providers = [
-            FilterLayerInfo(
-                runfiles = runfiles,
-                filtered_depset = depset(transitive = filtered_depsets),
-            ),
-        ],
-        # Also forward builtin providers so that the filter_layer() can be used as a normal
-        # dependency to native targets (e.g. py_library(deps = [<filter_layer>])).
-        py = ctx.attr.dep.py if hasattr(ctx.attr.dep, "py") else None,
-    )
+
+    # Forward correct provider, depending on Bazel version, so that the filter_layer() can be
+    # used as a normal dependency to native targets (e.g. py_library(deps = [<filter_layer>])).
+    if hasattr(ctx.attr.dep, "py"):
+        # Forward legacy builtin provider
+        return struct(
+            providers = [
+                FilterLayerInfo(
+                    runfiles = runfiles,
+                    filtered_depset = depset(transitive = filtered_depsets),
+                ),
+            ],
+            py = ctx.attr.dep.py if hasattr(ctx.attr.dep, "py") else None,
+        )
+    else:
+        # Forward the PyInfo provider in Bazel >= 0.23.0
+        return struct(
+            providers = [
+                FilterLayerInfo(
+                    runfiles = runfiles,
+                    filtered_depset = depset(transitive = filtered_depsets),
+                ),
+            ] + ([ctx.attr.dep[PyInfo]] if PyInfo in ctx.attr.dep else []),
+        )
 
 # A rule that allows selecting a subset of transitive dependencies, and using
 # them as a layer in an image.


### PR DESCRIPTION
In upcoming Bazel 0.23.0, the legacy `py` provider [has been changed to `PyInfo`](https://github.com/bazelbuild/bazel/issues/7298), with both being allowed to work currently. However, in a future release the use of `py` will be not be permitted, which can be simulated with `--incompatible_disallow_legacy_py_provider`.

This change forwards the old `py` provider in `filter_layer` in older Bazel, and `PyInfo` in newer Bazel and has been tested to work correctly when `--incompatible_disallow_legacy_py_provider` is enabled. Prior to this change, `filter_layer` would fail when run in this mode.
