### PR TITLE
Fix --norun option when args are specified for _image rules

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -234,8 +234,8 @@ function read_variables() {
 %{tag_statements}
 
 # An optional "docker run" statement for invoking a loaded container.
-# This is not executed if the single argument --norun is passed.
-if [ "a$*" != "a--norun" ]; then
+# This is not executed if the argument --norun is passed.
+if [[ ! "$*" =~ "--norun" ]]; then
   # This generated and injected by docker_*.
   exec %{run_statements}
 fi

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -291,6 +291,12 @@ function test_java_image() {
   EXPECT_CONTAINS "$(bazel run "$@" testdata:java_image)" "Hello World"
 }
 
+function test_java_image_norun() {
+  cd "${ROOT}"
+  clear_docker
+  EXPECT_NOT_CONTAINS "$(bazel run "$@" testdata:java_image -- --norun)" "Hello World"
+}
+
 function test_java_partial_entrypoint_image() {
   cd "${ROOT}"
   clear_docker
@@ -519,6 +525,7 @@ test_go_image_busybox
 test_go_image_with_tags
 test_java_image -c opt
 test_java_image -c dbg
+test_java_image_norun
 test_java_image_with_custom_run_flags -c opt
 test_java_image_with_custom_run_flags -c dbg
 test_java_sandwich_image -c opt


### PR DESCRIPTION
When an _image rule has args specified these are automatically passed through when running via `bazel run`, which breaks the "single argument" test to skip running the container. In our case this broke CI.