### PR TITLE
Fix buildifier 0.22.0 warnings in files matching *image.bzl

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,8 @@
 ---
-buildifier: true
+# TODO (smukherj): Renable this once all lint warnings have been fixed.
+# See https://buildkite.com/bazel/rules-docker-docker/builds/1085#322f83d5-7cca-425a-b838-ff32ba055808
+# for the list of issues.
+# buildifier: true
 platforms:
   ubuntu1404:
     test_targets:

--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -33,8 +33,11 @@ load(
 load(":cc.bzl", "DIGESTS")
 
 def repositories():
-    # Call the core "repositories" function to reduce boilerplate.
-    # This is idempotent if folks call it themselves.
+    """Import the dependencies for the cc_image rule.
+
+    Call the core "repositories" function to reduce boilerplate. This is
+    idempotent if folks call it themselves.
+    """
     _repositories()
 
     excludes = native.existing_rules().keys()
@@ -64,6 +67,9 @@ def cc_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
     """Constructs a container image wrapping a cc_binary target.
 
   Args:
+    name: Name of the cc_image target.
+    base: Base image to use for the cc_image.
+    deps: Dependencies of the cc_image.
     binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.

--- a/container/BUILD
+++ b/container/BUILD
@@ -29,11 +29,11 @@ filegroup(
 py_binary(
     name = "extract_config",
     srcs = ["extract_config.py"],
+    legacy_create_init = False,
     visibility = ["//visibility:public"],
     deps = [
         "@containerregistry",
     ],
-    legacy_create_init = False,
 )
 
 py_library(
@@ -47,35 +47,35 @@ py_library(
 py_binary(
     name = "join_layers",
     srcs = ["join_layers.py"],
+    legacy_create_init = False,
     visibility = ["//visibility:public"],
     deps = [
         ":utils",
-        "@six//:six",
         "@containerregistry",
+        "@six",
     ],
-    legacy_create_init = False,
 )
 
 py_binary(
     name = "create_image_config",
     srcs = ["create_image_config.py"],
+    legacy_create_init = False,
     visibility = ["//visibility:public"],
     deps = [
         ":utils",
-        "@six//:six",
         "@containerregistry",
+        "@six",
     ],
-    legacy_create_init = False,
 )
 
 # TODO(xingao): Flip legacy_create_init once dependency on @bazel_source removed
 py_binary(
     name = "build_tar",
     srcs = ["build_tar.py"],
+    legacy_create_init = True,
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [":build_tar_lib"],
-    legacy_create_init = True,
 )
 
 py_library(

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -433,18 +433,21 @@ def _impl(
                 ([container_parts["legacy"]] if container_parts["legacy"] else []),
     )
 
-    return [
-        ImageInfo(
-            container_parts = container_parts,
-            legacy_run_behavior = legacy_run_behavior,
-            docker_run_flags = docker_run_flags,
-        ),
-        DefaultInfo(
-            executable = output_executable,
-            files = depset([output_layer]),
-            runfiles = runfiles,
-        ),
-    ]
+    return struct(
+        container_parts = container_parts,
+        providers = [
+            ImageInfo(
+                container_parts = container_parts,
+                legacy_run_behavior = legacy_run_behavior,
+                docker_run_flags = docker_run_flags,
+            ),
+            DefaultInfo(
+                executable = output_executable,
+                files = depset([output_layer]),
+                runfiles = runfiles,
+            ),
+        ],
+    )
 
 _attrs = dicts.add(_layer.attrs, {
     "base": attr.label(allow_files = container_filetype),

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -17,6 +17,10 @@ load(
     "//skylib:path.bzl",
     _get_runfile_path = "runfile",
 )
+load(
+    "//container:providers.bzl",
+    "ImageInfo",
+)
 
 def _extract_layers(ctx, name, artifact):
     config_file = ctx.actions.declare_file(name + "." + artifact.basename + ".config")
@@ -47,8 +51,8 @@ def _extract_layers(ctx, name, artifact):
 def get_from_target(ctx, name, attr_target, file_target = None):
     if file_target:
         return _extract_layers(ctx, name, file_target)
-    elif hasattr(attr_target, "container_parts"):
-        return attr_target.container_parts
+    elif attr_target and ImageInfo in attr_target:
+        return attr_target[ImageInfo].container_parts
     else:
         if not hasattr(attr_target, "files"):
             return {}

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -17,10 +17,6 @@ load(
     "//skylib:path.bzl",
     _get_runfile_path = "runfile",
 )
-load(
-    "//container:providers.bzl",
-    "ImageInfo",
-)
 
 def _extract_layers(ctx, name, artifact):
     config_file = ctx.actions.declare_file(name + "." + artifact.basename + ".config")

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -51,8 +51,8 @@ def _extract_layers(ctx, name, artifact):
 def get_from_target(ctx, name, attr_target, file_target = None):
     if file_target:
         return _extract_layers(ctx, name, file_target)
-    elif attr_target and ImageInfo in attr_target:
-        return attr_target[ImageInfo].container_parts
+    elif hasattr(attr_target, "container_parts"):
+        return attr_target.container_parts
     else:
         if not hasattr(attr_target, "files"):
             return {}

--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -28,8 +28,8 @@ exports_files(["extract_image_id.py"])
 py_binary(
     name = "extract_image_id",
     srcs = [":extract_image_id.py"],
-    deps = [":extract_image_id_lib"],
     legacy_create_init = False,
+    deps = [":extract_image_id_lib"],
 )
 
 py_library(
@@ -40,8 +40,8 @@ py_library(
 py_binary(
     name = "compare_ids_test",
     srcs = [":compare_ids_test.py"],
+    legacy_create_init = False,
     deps = [":extract_image_id_lib"],
-    legacy_create_init = False
 )
 
 alias(
@@ -56,5 +56,5 @@ alias(
 py_binary(
     name = "idd",
     srcs = ["idd.py"],
-    legacy_create_init = False
+    legacy_create_init = False,
 )

--- a/contrib/rename_image.bzl
+++ b/contrib/rename_image.bzl
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # Migrated from https://github.com/GoogleContainerTools/base-images-docker/blob/4f2fc8da248a61c3f8e13bbb43e9db6c0ed44ba3/util/run.bzl#L264
+"""A rule to rename the image from a <lang>_image or container_image target.
+"""
 
 load("//container:bundle.bzl", "container_bundle")
 

--- a/contrib/rename_image.bzl
+++ b/contrib/rename_image.bzl
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Migrated from https://github.com/GoogleContainerTools/base-images-docker/blob/4f2fc8da248a61c3f8e13bbb43e9db6c0ed44ba3/util/run.bzl#L264
 """A rule to rename the image from a <lang>_image or container_image target.
+
+Migrated from https://github.com/GoogleContainerTools/base-images-docker/blob/4f2fc8da248a61c3f8e13bbb43e9db6c0ed44ba3/util/run.bzl#L264
 """
 
 load("//container:bundle.bzl", "container_bundle")

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -28,12 +28,17 @@ load(
 )
 
 def repositories():
+    """Import the dependencies of the d_image rule.
+    """
     _repositories()
 
 def d_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
     """Constructs a container image wrapping a d_binary target.
 
   Args:
+    name: Name of the d_image target.
+    base: Base image to use for the d_image.
+    deps: Dependencies of the d_image target.
     binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -37,8 +37,11 @@ load(
 load(":go.bzl", "DIGESTS")
 
 def repositories():
-    # Call the core "repositories" function to reduce boilerplate.
-    # This is idempotent if folks call it themselves.
+    """Import the dependencies of the go_image rule.
+
+    Call the core "repositories" function to reduce boilerplate. This is
+    idempotent if folks call it themselves.
+    """
     _repositories()
 
     excludes = native.existing_rules().keys()
@@ -68,6 +71,9 @@ def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
     """Constructs a container image wrapping a go_binary target.
 
   Args:
+    name: Name of the go_image target.
+    base: Base image to use to build the go_image.
+    deps: Dependencies of the go image target.
     binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into their own layers.
     **kwargs: See go_binary.

--- a/groovy/image.bzl
+++ b/groovy/image.bzl
@@ -37,6 +37,13 @@ def groovy_image(
     """Builds a container image overlaying the groovy_binary.
 
   Args:
+    name: Name of the groovy_image target.
+    base: Base image to use for the groovy_image.
+    main_class: The main entrypoint class in the groovy image.
+    srcs: List of groovy source files that will be used to build the binary
+          to be included in the groovy_image.
+    deps: The dependencies of the groovy_image target.
+    jvm_flags: The flags to pass to the JVM when running the groovy image.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     **kwargs: See groovy_binary.

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -46,8 +46,11 @@ load(
 )
 
 def repositories():
-    # Call the core "repositories" function to reduce boilerplate.
-    # This is idempotent if folks call it themselves.
+    """Import the dependencies of the java_image rule.
+
+    Call the core "repositories" function to reduce boilerplate. This is
+    idempotent if folks call it themselves.
+    """
     _repositories()
 
     excludes = native.existing_rules().keys()
@@ -103,6 +106,14 @@ DEFAULT_JETTY_BASE = select({
 })
 
 def java_files(f):
+    """Filter out the list of java source files from the given list of runfiles.
+
+    Args:
+        f: Runfiles for a java_image rule.
+
+    Returns:
+        Depset of java source files.
+    """
     files = depset()
     if java_common.provider in f:
         java_provider = f[java_common.provider]
@@ -259,6 +270,11 @@ def java_image(
     """Builds a container image overlaying the java_binary.
 
   Args:
+    name: Name of the image target.
+    base: Base image to use for the java image.
+    deps: Dependencies of the java image rule.
+    runtime_deps: Runtime dependencies of the java image.
+    jvm_flags: Flags to pass to the JVM when running the java image.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     main_class: This parameter is optional. If provided it will be used in the
@@ -393,6 +409,9 @@ def war_image(name, base = None, deps = [], layers = [], **kwargs):
   https://github.com/bazelbuild/bazel/issues/3519
 
   Args:
+    name: Name of the war_image target.
+    base: Base image to use for the war image.
+    deps: Dependencies of the way image target.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     **kwargs: See java_library.

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -123,7 +123,18 @@ def _default_symlinks(dep):
         return dep.default_runfiles.symlinks
 
 def app_layer_impl(ctx, runfiles = None, emptyfiles = None):
-    """Appends a layer for a single dependency's runfiles."""
+    """Appends a layer for a single dependency's runfiles.
+
+    Args:
+        ctx: The Bazel runtime context object.
+        runfiles: (Optional) depset of runfiles to include in this language
+                  image layer.
+        emptyfiles: (Optional) depset of empty files to include in this
+                    language image layer.
+
+    Returns:
+        A container image provider for the application layer.
+    """
 
     runfiles = runfiles or _default_runfiles
     emptyfiles = emptyfiles or _default_emptyfiles

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -37,8 +37,11 @@ load(
 load(":nodejs.bzl", "DIGESTS")
 
 def repositories():
-    # Call the core "repositories" function to reduce boilerplate.
-    # This is idempotent if folks call it themselves.
+    """Import the dependencies of the nodejs_image rule.
+
+    Call the core "repositories" function to reduce boilerplate. This is
+    idempotent if folks call it themselves.
+    """
     _repositories()
 
     excludes = native.existing_rules().keys()
@@ -108,8 +111,12 @@ def nodejs_image(
     """Constructs a container image wrapping a nodejs_binary target.
 
   Args:
+    name: Name of the nodejs_image target.
+    base: Base image to use for the nodejs_image.
+    data: Runtime dependencies of the nodejs_image.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
+    node_modules: The list of Node modules to include in the nodejs image.
     **kwargs: See nodejs_binary.
   """
     binary_name = name + ".binary"

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -34,8 +34,11 @@ load(
 load(":python.bzl", "DIGESTS")
 
 def repositories():
-    # Call the core "repositories" function to reduce boilerplate.
-    # This is idempotent if folks call it themselves.
+    """Import the dependencies of the py_image rule.
+
+    Call the core "repositories" function to reduce boilerplate. This is
+    idempotent if folks call it themselves.
+    """
     _repositories()
 
     excludes = native.existing_rules().keys()
@@ -70,6 +73,9 @@ def py_image(name, base = None, deps = [], layers = [], **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
     Args:
+        name: Name of the py_image target.
+        base: Base image to use in the py_image.
+        deps: Dependencies of the py_image target.
         layers: Augments "deps" with dependencies that should be put into
             their own layers.
         **kwargs: See py_binary.

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -33,8 +33,11 @@ load(
 load(":python3.bzl", "DIGESTS")
 
 def repositories():
-    # Call the core "repositories" function to reduce boilerplate.
-    # This is idempotent if folks call it themselves.
+    """Import the dependencies of the py3_image rule.
+
+    Call the core "repositories" function to reduce boilerplate. This is
+    idempotent if folks call it themselves.
+    """
     _repositories()
 
     excludes = native.existing_rules().keys()
@@ -64,6 +67,9 @@ def py3_image(name, base = None, deps = [], layers = [], **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
   Args:
+    name: Name of the py3_image rule target.
+    base: Base image to use for the py3_image.
+    deps: Dependencies of the py3_image.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     **kwargs: See py_binary.

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -28,12 +28,17 @@ load(
 )
 
 def repositories():
+    """Import the dependencies for the rule_image rule.
+    """
     _repositories()
 
 def rust_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
     """Constructs a container image wrapping a rust_binary target.
 
   Args:
+    name: Name of the rust_image target.
+    base: Base image to use for the rust_image.
+    deps: Dependencies of the rust_image target.
     binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.

--- a/scala/image.bzl
+++ b/scala/image.bzl
@@ -37,6 +37,13 @@ def scala_image(
     """Builds a container image overlaying the scala_binary.
 
   Args:
+    name: Name of the scala_image target.
+    base: Base image to use for the scala_image.
+    main_class: The main entrypoint class for the scala binary in the scala
+                image.
+    deps: Dependencies of the scala image target.
+    runtime_deps: Runtime dependencies of the scala image.
+    jvm_flags: Flags to pass to the JVM when running the scala image.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     **kwargs: See scala_binary.

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -271,10 +271,10 @@ container_push(
 
 genrule(
     name = "push_tag_file",
-    output_to_bindir = 1,
     srcs = [],
     outs = ["test.tag"],
     cmd = """echo test > $@""",
+    output_to_bindir = 1,
 )
 
 container_push(

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -16,8 +16,8 @@ package(default_visibility = ["//visibility:private"])
 py_binary(
     name = "update_deps",
     srcs = ["update_deps.py"],
+    legacy_create_init = False,
     deps = [
         "@containerregistry",
     ],
-    legacy_create_init = False,
 )


### PR DESCRIPTION
Still get

./container/image.bzl:342: uninitialized: Variable "layer" may not have been initialized. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#uninitialized)

which seems to be a bug in buildifier because the loop variable in a
list comprehension is being reported as potentially uninitialized.

Fixes involve adding function, argument, return statement and module
docs.