### PR TITLE
Publish an image.digest file for container_pull.

### DIFF
--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -116,7 +116,7 @@ container_import(
   layers = glob(["*.tar.gz"]),
 )
 
-exports_files(["digest"])
+exports_files(["image.digest", "digest"])
 """)
 
     args = [
@@ -190,6 +190,8 @@ exports_files(["digest"])
     if digest_result.return_code:
         fail("Failed to read digest: %s" % digest_result.stderr)
     updated_attrs["digest"] = digest_result.stdout
+
+    repository_ctx.symlink(repository_ctx.path("image/digest"), repository_ctx.path("image/image.digest"))
     return updated_attrs
 
 pull = struct(

--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -191,7 +191,10 @@ exports_files(["image.digest", "digest"])
         fail("Failed to read digest: %s" % digest_result.stderr)
     updated_attrs["digest"] = digest_result.stdout
 
+    # Add image.digest for compatibility with container_digest, which generates
+    # foo.digest for an image named foo.
     repository_ctx.symlink(repository_ctx.path("image/digest"), repository_ctx.path("image/image.digest"))
+
     return updated_attrs
 
 pull = struct(

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -310,6 +310,12 @@ file_test(
 )
 
 file_test(
+    name = "distroless_fixed_id_image_digest_test",
+    content = "sha256:a26dde6863dd8b0417d7060c990abe85c1d2481541568445e82b46de9452cf0c",
+    file = "@distroless_fixed_id//image:image.digest",
+)
+
+file_test(
     name = "k8s_pause_amd64_digest_test",
     content = "sha256:59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610",
     file = "@k8s_pause_amd64//image:digest",


### PR DESCRIPTION
The container_build rules publish "foo.digest" for a container "foo".
container_pull names the container "image" and only publishes "digest",
not "image.digest", so far.