### PR TITLE
Update subpar dependency

### DIFF
--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -180,6 +180,7 @@ py_library(
         http_archive(
             name = "subpar",
             sha256 = "7ab6ab37ede82255e00c0456846a1428b20e8813f77d83bcf54ddd59ba34377a",
+            # Commit from 2019-03-07.
             strip_prefix = "subpar-0356bef3fbbabec5f0e196ecfacdeb6db62d48c0",
             urls = ["https://github.com/google/subpar/archive/0356bef3fbbabec5f0e196ecfacdeb6db62d48c0.tar.gz"],
         )

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -179,9 +179,9 @@ py_library(
     if "subpar" not in excludes:
         http_archive(
             name = "subpar",
-            sha256 = "cf3762b10426a1887d37f127b4c1390785ecb969254096eb714cc1db371f78d6",
-            strip_prefix = "subpar-a4f9b23bf01bcc7a52d458910af65a90ee991aff",
-            urls = ["https://github.com/google/subpar/archive/a4f9b23bf01bcc7a52d458910af65a90ee991aff.tar.gz"],
+            sha256 = "7ab6ab37ede82255e00c0456846a1428b20e8813f77d83bcf54ddd59ba34377a",
+            strip_prefix = "subpar-0356bef3fbbabec5f0e196ecfacdeb6db62d48c0",
+            urls = ["https://github.com/google/subpar/archive/0356bef3fbbabec5f0e196ecfacdeb6db62d48c0.tar.gz"],
         )
 
     if "structure_test_linux" not in excludes:


### PR DESCRIPTION
This updates the declared version of the subpar dependency to 0356bef3fbbabec5f0e196ecfacdeb6db62d48c0, which includes changes to work with --incompatible_remove_old_python_version_api in Bazel 0.23.

I also sent google/containerregistry#146 to update containerregistry for the same issue. Once that's merged you may wish to update your dependency on them, but I believe the definition I updated in this PR takes precedence anyway.