### PR TITLE
Fail when pulled image with unexpected sha256

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,14 +83,6 @@ container_pull(
 )
 
 container_pull(
-    name = "k8s_pause_amd64",
-    # this is a manifest list, so the resolved digest should not match this digest
-    digest = "sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea",
-    registry = "k8s.gcr.io",
-    repository = "pause",
-)
-
-container_pull(
     name = "k8s_pause_arm64",
     architecture = "arm64",
     registry = "k8s.gcr.io",

--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -191,6 +191,14 @@ exports_files(["image.digest", "digest"])
         fail("Failed to read digest: %s" % digest_result.stderr)
     updated_attrs["digest"] = digest_result.stdout
 
+    if repository_ctx.attr.digest and repository_ctx.attr.digest != updated_attrs["digest"]:
+        fail(("SHA256 of the image specified does not match SHA256 of the pulled image. " +
+              "Expected {}, but pulled image with {}. " +
+              "It is possible that you pin to a manifest list which points to another image").format(
+            repository_ctx.attr.digest,
+            updated_attrs["digest"],
+        ))
+
     # Add image.digest for compatibility with container_digest, which generates
     # foo.digest for an image named foo.
     repository_ctx.symlink(repository_ctx.path("image/digest"), repository_ctx.path("image/image.digest"))

--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -194,7 +194,9 @@ exports_files(["image.digest", "digest"])
     if repository_ctx.attr.digest and repository_ctx.attr.digest != updated_attrs["digest"]:
         fail(("SHA256 of the image specified does not match SHA256 of the pulled image. " +
               "Expected {}, but pulled image with {}. " +
-              "It is possible that you pin to a manifest list which points to another image").format(
+              "It is possible that you have a pin to a manifest list " +
+              "which points to another image, if so, " +
+              "change the pin to point at the actual Docker image").format(
             repository_ctx.attr.digest,
             updated_attrs["digest"],
         ))

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -316,12 +316,6 @@ file_test(
 )
 
 file_test(
-    name = "k8s_pause_amd64_digest_test",
-    content = "sha256:59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610",
-    file = "@k8s_pause_amd64//image:digest",
-)
-
-file_test(
     name = "k8s_pause_arm64_digest_test",
     content = "sha256:f365626a556e58189fc21d099fc64603db0f440bff07f77c740989515c544a39",
     file = "@k8s_pause_arm64//image:digest",


### PR DESCRIPTION
To address confusion in #714 when pinning to a manifest list image type.
This forces the user to only pin to a manifest type when using digest.
