### PR TITLE
Repo rule to build an image from Dockerfile and save as tar

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -83,6 +83,7 @@ platforms:
     - "-//testdata:pkg_control_xz.deb"
     - "-//testdata:pkg_control_xz"
     # Disabled as docker is not available
+    # TODO(alex1545): enable once docker is supported on buildkite
     - "-//tests/docker:basic_dockerfile_image"
     build_flags:
     - "--extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/latest:toolchain_docker"
@@ -115,6 +116,7 @@ platforms:
     - "-//testdata:pkg_control_xz.deb"
     - "-//testdata:pkg_control_xz"
     # Disabled as docker is not available
+    # TODO(alex1545): enable once docker is supported on buildkite
     - "-//tests/docker:basic_dockerfile_image"
     test_flags:
     - "--extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/latest:toolchain_docker"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -82,6 +82,8 @@ platforms:
     - "-//tests/docker:deb_image_with_dpkgs"
     - "-//testdata:pkg_control_xz.deb"
     - "-//testdata:pkg_control_xz"
+    # Disabled as docker is not available
+    - "-//tests/docker:basic_dockerfile_image"
     build_flags:
     - "--extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/latest:toolchain_docker"
     - "--extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"
@@ -112,6 +114,8 @@ platforms:
     - "-//tests/docker:deb_image_with_dpkgs"
     - "-//testdata:pkg_control_xz.deb"
     - "-//testdata:pkg_control_xz"
+    # Disabled as docker is not available
+    - "-//tests/docker:basic_dockerfile_image"
     test_flags:
     - "--extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/latest:toolchain_docker"
     - "--extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -285,6 +285,14 @@ load(
 
 _nodejs_image_repos()
 
+# For dockerfile_image rule tests
+load("//contrib:dockerfile_build.bzl", "dockerfile_image")
+
+dockerfile_image(
+    name = "basic_dockerfile",
+    dockerfile = "//contrib:Dockerfile",
+)
+
 http_archive(
     name = "bazel_toolchains",
     sha256 = "4b1468b254a572dbe134cc1fd7c6eab1618a72acd339749ea343bd8f55c3b7eb",

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.8
+ENTRYPOINT ["echo"]
+CMD ["Hello World!"]

--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -53,7 +53,7 @@ def _impl(repository_ctx):
 
     # TODO(alex1545): once the read() function is available, enable copying
     # file with repository_ctx.read() and repository_ctx.file() instead of
-    # executing the `cp` command
+    # executing the `cat` command
     # dockerfile_content = repository_ctx.read(repository_ctx.attr.dockerfile)
 
     # Copy the provided Dockerfile into the root of this workspace since using

--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -19,10 +19,12 @@ This rule uses the docker tool installed in the system to build the image and
 then save it as a tar file. The saved tar file is available for other rules to
 use (e.g. container_image, container_load, container_test)
 
+The built docker image is always called after the dockerfile_image target used
+to build the image and tagged with `dockerfile_image` (i.e. <target_name>:dockerfile_image).
 The produced tar file is available at @<repo_name>//image:dockerfile_image.tar
 """
 
-def docker(repository_ctx):
+def _docker(repository_ctx):
     """Resolves the docker path.
 
     Args:
@@ -42,7 +44,13 @@ def docker(repository_ctx):
 def _impl(repository_ctx):
     """Core implementation of dockerfile_image."""
 
-    docker_path = docker(repository_ctx)
+    docker_path = _docker(repository_ctx)
+
+    # TODO(alex1545): once the read() function is available, enable copying
+    # file with repository_ctx.read() and repository_ctx.file() instead of
+    # executing the `cp` command
+    # dockerfile_content = repository_ctx.read(repository_ctx.attr.dockerfile)
+    # repository_ctx.file("Dockerfile", dockerfile_content)
 
     dockerfile_src = repository_ctx.path(repository_ctx.attr.dockerfile)
     dockerfile_dest = repository_ctx.path("Dockerfile")
@@ -65,6 +73,7 @@ def _impl(repository_ctx):
     build_args = [
         docker_path,
         "build",
+        "--no-cache",
         "-t",
         img_name,
         repository_ctx.path(""),

--- a/docker/dockerfile_build.bzl
+++ b/docker/dockerfile_build.bzl
@@ -98,15 +98,15 @@ exports_files(["{}"])
 
 dockerfile_image = repository_rule(
     attrs = {
-        "dockerfile": attr.label(
-            allow_single_file = True,
-            mandatory = True,
-            doc = "The label for the Dockerfile to build the image from.",
-        ),
         "docker_path": attr.string(
             doc = "The full path to the docker binary. If not specified, it " +
                   "will be searched for in the path. If not available, " +
                   "the rule build will fail.",
+        ),
+        "dockerfile": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "The label for the Dockerfile to build the image from.",
         ),
     },
     implementation = _impl,

--- a/docker/dockerfile_build.bzl
+++ b/docker/dockerfile_build.bzl
@@ -1,0 +1,113 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Repository rule for building a Docker image from a Dockerfile and saving it
+   into a tar file.
+
+This rule uses the docker tool installed in the system to build the image and
+then save it as a tar file. The saved tar file is available for other rules to
+use (e.g. container_image, container_load, container_test)
+
+The produced tar file is available at @<repo_name>//image:dockerfile_image.tar
+"""
+
+def docker(repository_ctx):
+    """Resolves the docker path.
+
+    Args:
+      repository_ctx: The repository context
+
+    Returns:
+      Tha path to the docker tool
+    """
+
+    if repository_ctx.attr.docker_path:
+        return repository_ctx.attr.docker_path
+    if repository_ctx.which("docker"):
+        return repository_ctx.which("docker")
+
+    fail("Path to the docker tool was not provided and it could not be resolved automatically.")
+
+def _impl(repository_ctx):
+    """Core implementation of dockerfile_image."""
+
+    docker_path = docker(repository_ctx)
+
+    dockerfile_src = repository_ctx.path(repository_ctx.attr.dockerfile)
+    dockerfile_dest = repository_ctx.path("Dockerfile")
+
+    # Copy the provided Dockerfile into the root of this workspace since using
+    # the -f flag with the docker build command is problematic.
+    cp_result = repository_ctx.execute([
+        "cp",
+        dockerfile_src,
+        dockerfile_dest,
+    ])
+    if cp_result.return_code:
+        fail("Failed to copy Dockerfile from {} to {}: {}".format(
+            dockerfile_src,
+            dockerfile_dest,
+            cp_result.stderr,
+        ))
+
+    img_name = repository_ctx.name + ":dockerfile_image"
+    build_args = [
+        docker_path,
+        "build",
+        "-t",
+        img_name,
+        repository_ctx.path(""),
+    ]
+    build_result = repository_ctx.execute(build_args)
+    if build_result.return_code:
+        fail("docker build command failed: {} ({})".format(
+            build_result.stderr,
+            " ".join(build_args),
+        ))
+
+    image_tar = "dockerfile_image.tar"
+    repository_ctx.file("image/BUILD", """
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["{}"])
+""".format(image_tar))
+
+    save_result = repository_ctx.execute([
+        docker_path,
+        "save",
+        "-o",
+        "image/" + image_tar,
+        img_name,
+    ])
+    if save_result.return_code:
+        fail("docker save command failed for image {}: {}".format(
+            img_name,
+            save_result.stderr,
+        ))
+
+dockerfile_image = repository_rule(
+    attrs = {
+        "dockerfile": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "The label for the Dockerfile to build the image from.",
+        ),
+        "docker_path": attr.string(
+            doc = "The full path to the docker binary. If not specified, it " +
+                  "will be searched for in the path. If not available, " +
+                  "the rule build will fail.",
+        ),
+    },
+    implementation = _impl,
+)

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -522,6 +522,8 @@ function test_container_pull_cache() {
   rm -rf $scratch_dir
 }
 
+# TODO(alex1545): remove this test from here and enable running on buildkite
+# once docker is supported.
 function test_dockerfile_image_basic() {
   cd "${ROOT}"
   clear_docker

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -522,6 +522,12 @@ function test_container_pull_cache() {
   rm -rf $scratch_dir
 }
 
+function test_dockerfile_image_basic() {
+  cd "${ROOT}"
+  clear_docker
+  bazel test tests/docker:basic_dockerfile_image
+}
+
 test_container_push_with_stamp
 test_container_push_all
 test_container_push_with_auth
@@ -578,3 +584,4 @@ test_container_push
 test_container_push_tag_file
 test_launcher_image
 test_container_pull_cache
+test_dockerfile_image_basic

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -356,3 +356,10 @@ docker_push_all(
     name = "test_docker_push_three_images_bundle",
     bundle = ":three_images_bundle",
 )
+
+container_test(
+    name = "basic_dockerfile_image",
+    configs = ["//tests/docker/configs:basic_dockerfile.yaml"],
+    image = "@basic_dockerfile//image:dockerfile_image",
+    driver = "tar",
+)

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -360,6 +360,6 @@ docker_push_all(
 container_test(
     name = "basic_dockerfile_image",
     configs = ["//tests/docker/configs:basic_dockerfile.yaml"],
-    image = "@basic_dockerfile//image:dockerfile_image",
     driver = "tar",
+    image = "@basic_dockerfile//image:dockerfile_image",
 )

--- a/tests/docker/configs/basic_dockerfile.yaml
+++ b/tests/docker/configs/basic_dockerfile.yaml
@@ -1,0 +1,5 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  entrypoint: ['echo']
+  cmd: ['Hello World!']


### PR DESCRIPTION
Repo rule that uses the docker binary installed in the system to build a docker image from a given Dockerfile. It then saves that image as a tar file.