### PR TITLE
Return providers instead of struct from rule impl functions

### DIFF
--- a/container/bundle.bzl
+++ b/container/bundle.bzl
@@ -14,6 +14,7 @@
 """Rule for bundling Container images into a tarball."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@io_bazel_rules_docker//container:providers.bzl", "BundleInfo")
 load(
     "//container:layer_tools.bzl",
     _assemble_image = "assemble",
@@ -21,7 +22,6 @@ load(
     _incr_load = "incremental_load",
     _layer_tools = "tools",
 )
-load("//container:providers.bzl", "BundleInfo")
 load(
     "//skylib:label.bzl",
     _string_to_label = "string_to_label",
@@ -71,21 +71,17 @@ def _container_bundle_impl(ctx):
 
     stamp_files = [ctx.info_file, ctx.version_file] if stamp else []
 
-    return struct(
-        container_images = images,
-        stamp = stamp,
-        providers = [
-            BundleInfo(
-                container_images = images,
-                stamp = stamp,
-            ),
-            DefaultInfo(
-                files = depset(),
-                executable = ctx.outputs.executable,
-                runfiles = ctx.runfiles(files = (stamp_files + runfiles)),
-            ),
-        ],
-    )
+    return [
+        BundleInfo(
+            container_images = images,
+            stamp = stamp,
+        ),
+        DefaultInfo(
+            executable = ctx.outputs.executable,
+            files = depset(),
+            runfiles = ctx.runfiles(files = (stamp_files + runfiles)),
+        ),
+    ]
 
 container_bundle_ = rule(
     attrs = dicts.add({

--- a/container/flatten.bzl
+++ b/container/flatten.bzl
@@ -14,12 +14,12 @@
 """A rule to flatten container images."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@io_bazel_rules_docker//container:providers.bzl", "FlattenInfo")
 load(
     "//container:layer_tools.bzl",
     _get_layers = "get_from_target",
     _layer_tools = "tools",
 )
-load("//container:providers.bzl", "FlattenInfo")
 
 def _impl(ctx):
     """Core implementation of container_flatten."""

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -46,6 +46,11 @@ load(
     _sha256 = "sha256",
 )
 load(
+    "@io_bazel_rules_docker//container:providers.bzl",
+    "ImageInfo",
+    "LayerInfo",
+)
+load(
     "//container:layer.bzl",
     _layer = "layer",
 )
@@ -55,11 +60,6 @@ load(
     _get_layers = "get_from_target",
     _incr_load = "incremental_load",
     _layer_tools = "tools",
-)
-load(
-    "//container:providers.bzl",
-    "ImageInfo",
-    "LayerInfo",
 )
 load(
     "//skylib:filetype.bzl",
@@ -433,21 +433,18 @@ def _impl(
                 ([container_parts["legacy"]] if container_parts["legacy"] else []),
     )
 
-    return struct(
-        container_parts = container_parts,
-        providers = [
-            ImageInfo(
-                container_parts = container_parts,
-                legacy_run_behavior = legacy_run_behavior,
-                docker_run_flags = docker_run_flags,
-            ),
-            DefaultInfo(
-                executable = output_executable,
-                files = depset([output_layer]),
-                runfiles = runfiles,
-            ),
-        ],
-    )
+    return [
+        ImageInfo(
+            container_parts = container_parts,
+            legacy_run_behavior = legacy_run_behavior,
+            docker_run_flags = docker_run_flags,
+        ),
+        DefaultInfo(
+            executable = output_executable,
+            files = depset([output_layer]),
+            runfiles = runfiles,
+        ),
+    ]
 
 _attrs = dicts.add(_layer.attrs, {
     "base": attr.label(allow_files = container_filetype),

--- a/container/import.bzl
+++ b/container/import.bzl
@@ -19,13 +19,13 @@ load(
     _hash_tools = "tools",
     _sha256 = "sha256",
 )
+load("@io_bazel_rules_docker//container:providers.bzl", "ImportInfo")
 load(
     "//container:layer_tools.bzl",
     _assemble_image = "assemble",
     _incr_load = "incremental_load",
     _layer_tools = "tools",
 )
-load("//container:providers.bzl", "ImportInfo")
 load(
     "//skylib:filetype.bzl",
     tar_filetype = "tar",
@@ -141,19 +141,16 @@ def _container_import_impl(ctx):
             ),
         )
 
-    return struct(
-        container_parts = container_parts,
-        providers = [
-            ImportInfo(
-                container_parts = container_parts,
-            ),
-            DefaultInfo(
-                executable = ctx.outputs.executable,
-                files = depset([ctx.outputs.out]),
-                runfiles = runfiles,
-            ),
-        ],
-    )
+    return [
+        ImportInfo(
+            container_parts = container_parts,
+        ),
+        DefaultInfo(
+            executable = ctx.outputs.executable,
+            files = depset([ctx.outputs.out]),
+            runfiles = runfiles,
+        ),
+    ]
 
 container_import = rule(
     attrs = dicts.add({

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -19,11 +19,11 @@ load(
     _hash_tools = "tools",
     _sha256 = "sha256",
 )
+load("@io_bazel_rules_docker//container:providers.bzl", "LayerInfo")
 load(
     "//container:layer_tools.bzl",
     _layer_tools = "tools",
 )
-load("//container:providers.bzl", "LayerInfo")
 load(
     "//skylib:filetype.bzl",
     deb_filetype = "deb",

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -14,6 +14,11 @@
 """Tools for dealing with Docker Image layers."""
 
 load(
+    "@io_bazel_rules_docker//container:providers.bzl",
+    "ImageInfo",
+    "ImportInfo",
+)
+load(
     "//skylib:path.bzl",
     _get_runfile_path = "runfile",
 )
@@ -58,8 +63,10 @@ def get_from_target(ctx, name, attr_target, file_target = None):
     """
     if file_target:
         return _extract_layers(ctx, name, file_target)
-    elif hasattr(attr_target, "container_parts"):
-        return attr_target.container_parts
+    elif attr_target and ImageInfo in attr_target:
+        return attr_target[ImageInfo].container_parts
+    elif attr_target and ImportInfo in attr_target:
+        return attr_target[ImportInfo].container_parts
     else:
         if not hasattr(attr_target, "files"):
             return {}

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -18,12 +18,12 @@ Bazel rule for publishing images.
 """
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@io_bazel_rules_docker//container:providers.bzl", "PushInfo")
 load(
     "//container:layer_tools.bzl",
     _get_layers = "get_from_target",
     _layer_tools = "tools",
 )
-load("//container:providers.bzl", "PushInfo")
 load(
     "//skylib:path.bzl",
     "runfile",
@@ -128,7 +128,10 @@ def _impl(ctx):
     runfiles = runfiles.merge(ctx.attr._pusher[DefaultInfo].default_runfiles)
 
     return [
-        DefaultInfo(executable = ctx.outputs.executable, runfiles = runfiles),
+        DefaultInfo(
+            executable = ctx.outputs.executable,
+            runfiles = runfiles,
+        ),
         PushInfo(
             registry = registry,
             repository = repository,

--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -17,6 +17,7 @@ This variant of container_push accepts a container_bundle target and publishes
 the embedded image references.
 """
 
+load("@io_bazel_rules_docker//container:providers.bzl", "BundleInfo")
 load(
     "//skylib:path.bzl",
     "runfile",
@@ -27,8 +28,8 @@ def _get_runfile_path(ctx, f):
 
 def _impl(ctx):
     """Core implementation of container_push."""
-    stamp = ctx.attr.bundle.stamp
-    images = ctx.attr.bundle.container_images
+    stamp = ctx.attr.bundle[BundleInfo].stamp
+    images = ctx.attr.bundle[BundleInfo].container_images
 
     stamp_inputs = []
     if stamp:


### PR DESCRIPTION
This addresses the incompatible change via the ----incompatible_disallow_struct_provider_syntax flag described [here](https://github.com/bazelbuild/bazel/issues/7347).