### PR TITLE
Allow passwd entry with non-existing home path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ bazel-bin
 bazel-genfiles
 bazel-out
 bazel-testlogs
+
+# Eclipse and PyDev
+.project
+.pydevproject

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -393,7 +393,7 @@ class ImageTest(unittest.TestCase):
 
   def test_with_passwd(self):
     with TestImage('with_passwd') as img:
-      self.assertDigest(img, '27149ceaab154631346209b42c9494708210901fbb6e9f88cb9370fb51f30999')
+      self.assertDigest(img, 'b5ddebd09ebfc17bee33929d65a925416739acaeefefe82d87197f112cabbb7f')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './etc', './etc/passwd'])
 
@@ -407,7 +407,7 @@ class ImageTest(unittest.TestCase):
 
   def test_with_passwd_tar(self):
     with TestImage('with_passwd_tar') as img:
-      self.assertDigest(img, 'b8f091c370d6a8a6f74e11327f52e579f73dd93d9cf82e39e83b3096bb0c2256')
+      self.assertDigest(img, 'ceaff61cd81661d85eac1078134baec9c9b34ed4337c84103f8a147a912e8cf2')
       self.assertEqual(1, len(img.fs_layers()))
       self.assertTopLayerContains(img, ['.', './etc', './etc/password', './root', './myhomedir'])
 

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -401,7 +401,7 @@ class ImageTest(unittest.TestCase):
       with tarfile.open(fileobj=buf, mode='r') as layer:
         content = layer.extractfile('./etc/passwd').read()
         self.assertEqual(
-          'root:x:0:0:Root:/root:/rootshell\nfoobar:x:1234:2345:myusernameinfo:/myhomedir:/myshell\n',
+          'root:x:0:0:Root:/root:/rootshell\nfoobar:x:1234:2345:myusernameinfo:/myhomedir:/myshell\nnobody:x:65534:65534:nobody with no home:/nonexistent:/sbin/nologin\n',
           content)
         self.assertEqual(layer.getmember("./etc/passwd").mode, PASSWD_FILE_MODE)
 
@@ -415,7 +415,7 @@ class ImageTest(unittest.TestCase):
       with tarfile.open(fileobj=buf, mode='r') as layer:
         content = layer.extractfile('./etc/password').read()
         self.assertEqual(
-          'root:x:0:0:Root:/root:/rootshell\nfoobar:x:1234:2345:myusernameinfo:/myhomedir:/myshell\n',
+          'root:x:0:0:Root:/root:/rootshell\nfoobar:x:1234:2345:myusernameinfo:/myhomedir:/myshell\nnobody:x:65534:65534:nobody with no home:/nonexistent:/sbin/nologin\n',
           content)
         self.assertEqual(layer.getmember("./etc/password").mode, PASSWD_FILE_MODE)
         self.assertTarInfo(layer.getmember("./root"), 0, 0, DIR_PERMISSION, True)

--- a/contrib/passwd.bzl
+++ b/contrib/passwd.bzl
@@ -25,6 +25,7 @@ PasswdFileContentProviderInfo = provider(
         "gid",
         "info",
         "home",
+        "create_home",
         "shell",
         "name",
     ],
@@ -38,6 +39,7 @@ def _passwd_entry_impl(ctx):
         gid = ctx.attr.gid,
         info = ctx.attr.info,
         home = ctx.attr.home,
+        create_home = ctx.attr.create_home,
         shell = ctx.attr.shell,
         name = ctx.attr.name,
     )]
@@ -60,12 +62,13 @@ def _build_homedirs_tar(ctx, passwd_file):
     homedirs = []
     owners_map = {}
     for entry in ctx.attr.entries:
-        homedir = entry[PasswdFileContentProviderInfo].home
-        owners_map[homedir] = "{uid}.{gid}".format(
-            uid = entry[PasswdFileContentProviderInfo].uid,
-            gid = entry[PasswdFileContentProviderInfo].gid,
-        )
-        homedirs.append(homedir)
+        if entry[PasswdFileContentProviderInfo].create_home:
+            homedir = entry[PasswdFileContentProviderInfo].home
+            owners_map[homedir] = "{uid}.{gid}".format(
+                uid = entry[PasswdFileContentProviderInfo].uid,
+                gid = entry[PasswdFileContentProviderInfo].gid,
+            )
+            homedirs.append(homedir)
     dest_file = _join_path(
         ctx.attr.passwd_file_pkg_dir,
         ctx.label.name,
@@ -108,6 +111,7 @@ passwd_entry = rule(
     attrs = {
         "gid": attr.int(default = 1000),
         "home": attr.string(default = "/home"),
+        "create_home": attr.bool(default = True),
         "info": attr.string(default = "user"),
         "shell": attr.string(default = "/bin/bash"),
         "uid": attr.int(default = 1000),

--- a/contrib/passwd.bzl
+++ b/contrib/passwd.bzl
@@ -109,9 +109,9 @@ def _passwd_tar_impl(ctx):
 
 passwd_entry = rule(
     attrs = {
+        "create_home": attr.bool(default = True),
         "gid": attr.int(default = 1000),
         "home": attr.string(default = "/home"),
-        "create_home": attr.bool(default = True),
         "info": attr.string(default = "user"),
         "shell": attr.string(default = "/bin/bash"),
         "uid": attr.int(default = 1000),

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -534,11 +534,23 @@ passwd_entry(
     username = "foobar",
 )
 
+passwd_entry(
+    name = "nobody_user",
+    create_home = False,
+    gid = 65534,
+    home = "/nonexistent",
+    info = "nobody with no home",
+    shell = "/sbin/nologin",
+    uid = 65534,
+    username = "nobody",
+)
+
 passwd_file(
     name = "passwd",
     entries = [
         ":root_user",
         ":foobar_user",
+        ":nobody_user",
     ],
 )
 

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -566,6 +566,7 @@ passwd_tar(
     entries = [
         ":root_user",
         ":foobar_user",
+        ":nobody_user",
     ],
     passwd_file_pkg_dir = "etc",
 )


### PR DESCRIPTION
This will be useful to create an entry like `nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin`.

I'm new to Starlark, so I need some help actually.