### PR TITLE
`legacy_run_behavior` value shouldn't be taken from base.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1881,6 +1881,24 @@ container_image(name, base, data_path, directory, files, legacy_repository_namin
         Only valid when <code>launcher</code> is specified.</p>
       </td>
     </tr>
+    <tr>
+      <td><code>legacy_run_behavior</code></td>
+      <td>
+        <p><code>Bool; optional, default to True</code></p>
+        <p>If set to False, <code>bazel run</code> on the
+        <code>container_image</code> target will directly invoke
+        <code>docker run</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>docker_run_flags</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>Optional flags to use with <code>docker run</code> command.</p>
+        <p>Only used when <code>legacy_run_behavior</code> is set to
+        <code>False</code>.</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -898,6 +898,7 @@ container_image(
     base = "//tests/docker/go:go_image",
     launcher = ":launcher",
     launcher_args = ["-env=CUSTOM_MESSAGE=Launched via launcher!"],
+    legacy_run_behavior = False,
 )
 
 # Re-enable once https://github.com/bazelbuild/rules_d/issues/14 is fixed.

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -750,12 +750,10 @@ py3_image(
 
 # The following `container_image` and `py3_image` combination shows how to set
 # custom `docker_run_flags` in `py3_image`.
-# Note that `docker_run_flags` is only used when `legacy_run_behavior` is False.
 container_image(
     name = "py3_image_base_with_custom_run_flags",
     base = "@py3_image_base//image",
     docker_run_flags = "-i --rm --network=host -e ABC=ABC",
-    legacy_run_behavior = False,
 )
 
 py3_image(
@@ -825,12 +823,10 @@ java_image(
 
 # The following `container_image` and `java_image` combination shows how to set
 # custom `docker_run_flags` in `java_image`.
-# Note that `docker_run_flags` is only used when `legacy_run_behavior` is False.
 container_image(
     name = "java_image_base_with_custom_run_flags",
     base = "@java_image_base//image",
     docker_run_flags = "-i --rm --network=host -e ABC=ABC",
-    legacy_run_behavior = False,
 )
 
 java_image(
@@ -858,12 +854,10 @@ war_image(
 
 # The following `container_image` and `war_image` combination shows how to set
 # custom `docker_run_flags` in `war_image`.
-# Note that `docker_run_flags` is only used when `legacy_run_behavior` is False.
 container_image(
     name = "war_image_base_with_custom_run_flags",
     base = "@jetty_image_base//image",
     docker_run_flags = "-i --rm --network=host -e ABC=ABC",
-    legacy_run_behavior = False,
 )
 
 war_image(


### PR DESCRIPTION
Fixes #728, #739 
Closes #584
Related to #505, #482 
