### PR TITLE
use python_version = PY2 for par_binary and py_binary targets

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,23 @@
-build --python_top=//python:default_py_runtime
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Flags to explicitly use python toolchains to select appropriate py_runtime
+# Also, force host binaries to use py2.
+# Note these flags will only work with Bazel 0.25.0 or above.
+build --incompatible_use_python_toolchains
 build --host_force_python=PY2
-test --python_top=//python:default_py_runtime
+test --incompatible_use_python_toolchains
 test --host_force_python=PY2
-run --python_top=//python:default_py_runtime
+run --incompatible_use_python_toolchains
 run --host_force_python=PY2

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,6 @@
+build --python_top=//python:default_py_runtime
+build --host_force_python=PY2
+test --python_top=//python:default_py_runtime
+test --host_force_python=PY2
+run --python_top=//python:default_py_runtime
+run --host_force_python=PY2

--- a/container/BUILD
+++ b/container/BUILD
@@ -30,6 +30,7 @@ py_binary(
     name = "extract_config",
     srcs = ["extract_config.py"],
     legacy_create_init = False,
+    python_version = "PY2",
     visibility = ["//visibility:public"],
     deps = [
         "@containerregistry",
@@ -48,6 +49,7 @@ py_binary(
     name = "join_layers",
     srcs = ["join_layers.py"],
     legacy_create_init = False,
+    python_version = "PY2",
     visibility = ["//visibility:public"],
     deps = [
         ":utils",
@@ -60,6 +62,7 @@ py_binary(
     name = "create_image_config",
     srcs = ["create_image_config.py"],
     legacy_create_init = False,
+    python_version = "PY2",
     visibility = ["//visibility:public"],
     deps = [
         ":utils",

--- a/container/BUILD
+++ b/container/BUILD
@@ -170,6 +170,7 @@ py_test(
     size = "medium",
     srcs = ["image_test.py"],
     data = TEST_DATA,
+    python_version = "PY2",
     deps = ["@containerregistry"],
 )
 

--- a/python/BUILD
+++ b/python/BUILD
@@ -32,10 +32,10 @@ py_runtime(
 # to valid python2 and python3 tools.
 py_runtime(
     name = "default_py_runtime",
+    files = [],
     interpreter_path = select({
         # Update paths as appropriate for your system.
         "@bazel_tools//tools/python:PY2": "/usr/bin/python2",
         "@bazel_tools//tools/python:PY3": "/usr/bin/python3",
     }),
-    files = [],
 )

--- a/python/BUILD
+++ b/python/BUILD
@@ -28,14 +28,3 @@ py_runtime(
     interpreter_path = "/usr/bin/python2",
 )
 
-# Starting with Bazel 0.25.0 we must pass a py_runtime that points
-# to valid python2 and python3 tools.
-py_runtime(
-    name = "default_py_runtime",
-    files = [],
-    interpreter_path = select({
-        # Update paths as appropriate for your system.
-        "@bazel_tools//tools/python:PY2": "/usr/bin/python2",
-        "@bazel_tools//tools/python:PY3": "/usr/bin/python3",
-    }),
-)

--- a/python/BUILD
+++ b/python/BUILD
@@ -27,3 +27,15 @@ py_runtime(
     files = [],
     interpreter_path = "/usr/bin/python2",
 )
+
+# Starting with Bazel 0.25.0 we must pass a py_runtime that points
+# to valid python2 and python3 tools.
+py_runtime(
+    name = "default_py_runtime",
+    interpreter_path = select({
+        # Update paths as appropriate for your system.
+        "@bazel_tools//tools/python:PY2": "/usr/bin/python2",
+        "@bazel_tools//tools/python:PY3": "/usr/bin/python3",
+    }),
+    files = [],
+)

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -3,5 +3,6 @@ package(default_visibility = ["//visibility:public"])
 py_test(
     name = "build_tar_test",
     srcs = ["build_tar_test.py"],
+    python_version = "PY2",
     deps = ["//container:build_tar_lib"],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -17,6 +17,7 @@ py_binary(
     name = "update_deps",
     srcs = ["update_deps.py"],
     legacy_create_init = False,
+    python_version = "PY2",
     deps = [
         "@containerregistry",
     ],


### PR DESCRIPTION
Addresses https://github.com/bazelbuild/rules_k8s/issues/305
Sending PR to kick off presubmits and also check if rules_k8s will be fixed by changing pin to this commit + adding some more  `python_version = PY2` there. 