### PR TITLE
Add cleanup before docker run in incremental loader

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -241,6 +241,10 @@ function read_variables() {
 # An optional "docker run" statement for invoking a loaded container.
 # This is not executed if the single argument --norun is passed.
 if [ "a$*" != "a--norun" ]; then
+  # Once we've loaded the images for all layers, we no longer need the temporary files on disk.
+  # We can clean up before we exec docker, since the exit handler will no longer run.
+  cleanup
+
   # This generated and injected by docker_*.
   exec %{run_statements}
 fi


### PR DESCRIPTION
When #667 was merged, the assumption was that the cleanup handler does not do anything -- but we've since seen a lot of files left around in /tmp on our CI machines from this change.

Since we've already loaded the layers into the docker daemon before `docker run`ing, we can run the cleanup before we `exec docker`.

As an aside...
I'm slightly hesitant that the cleanup step could take a while, which means we're making the race condition from `docker tag` and a much-delayed `docker run` worse.

Maybe the `tag_reference` in the built `run_statements` should use `tag@sha256:digest` format, since we _do_ have the digest available?