### PR TITLE
Switch bash runfile resolution to @bazel_tools

### DIFF
--- a/container/bundle.bzl
+++ b/container/bundle.bzl
@@ -21,6 +21,8 @@ load(
     _get_layers = "get_from_target",
     _incr_load = "incremental_load",
     _layer_tools = "tools",
+    _get_layer_deps_runfiles = "get_deps_runfiles",
+    _layer_deps = "deps",
 )
 load(
     "//skylib:label.bzl",
@@ -79,7 +81,7 @@ def _container_bundle_impl(ctx):
         DefaultInfo(
             executable = ctx.outputs.executable,
             files = depset(),
-            runfiles = ctx.runfiles(files = (stamp_files + runfiles)),
+            runfiles = ctx.runfiles(files = (stamp_files + runfiles + _get_layer_deps_runfiles(ctx))),
         ),
     ]
 
@@ -93,7 +95,7 @@ container_bundle_ = rule(
             default = False,
             mandatory = False,
         ),
-    }, _layer_tools),
+    }, _layer_tools, _layer_deps),
     executable = True,
     outputs = {
         "out": "%{name}.tar",

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -60,6 +60,8 @@ load(
     _get_layers = "get_from_target",
     _incr_load = "incremental_load",
     _layer_tools = "tools",
+    _get_layer_deps_runfiles = "get_deps_runfiles",
+    _layer_deps = "deps",
 )
 load(
     "//skylib:filetype.bzl",
@@ -426,7 +428,7 @@ def _impl(
     _assemble_image_digest(ctx, name, container_parts, output_tarball, output_digest)
 
     runfiles = ctx.runfiles(
-        files = unzipped_layers + diff_ids + [config_file, config_digest] +
+        files = unzipped_layers + diff_ids + [config_file, config_digest] + _get_layer_deps_runfiles(ctx) +
                 ([container_parts["legacy"]] if container_parts["legacy"] else []),
     )
 
@@ -495,7 +497,7 @@ _attrs = dicts.add(_layer.attrs, {
         cfg = "host",
         executable = True,
     ),
-}, _hash_tools, _layer_tools, _zip_tools)
+}, _hash_tools, _layer_tools, _layer_deps, _zip_tools)
 
 _outputs = dict(_layer.outputs)
 

--- a/container/push-tag.sh.tpl
+++ b/container/push-tag.sh.tpl
@@ -13,19 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
-
-function guess_runfiles() {
-    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
-        # Runfiles are adjacent to the current script.
-        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
-    else
-        # The current script is within some other script's runfiles.
-        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
-    fi
-}
-
-RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+set -euo pipefail
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
 
 %{container_pusher} %{args} "$@"

--- a/skylib/path.bzl
+++ b/skylib/path.bzl
@@ -87,7 +87,13 @@ def strip_prefix(path, prefix):
 
 def runfile(ctx, f):
     """Return the runfiles relative path of f."""
-    if ctx.workspace_name:
-        return ctx.workspace_name + "/" + f.short_path
-    else:
+    if f.short_path.startswith("../"):
+        return f.short_path[len("../"):]
+    if not ctx.workspace_name:
         return f.short_path
+    if f.short_path.startswith(ctx.workspace_name):
+        return f.short_path
+    return ctx.workspace_name + "/" + f.short_path
+
+def rlocation(ctx, f):
+    return "$(rlocation {})".format(runfile(ctx, f))


### PR DESCRIPTION
Use https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash to find runfile locations in scripts throughout rules_docker. This fixes the case where the user runs with `--noenable_runfiles` and thus does not have a runfiles directory, only a runfiles manifest. I would guess this PR will also fix any issues related to the runfiles directory for windows users as well, but I don't have a windows computer to test it out.

Maybe fixes #513 🤷‍♂ 