### PR TITLE
test use of incompatible_use_python_toolchains flag with Bazel 0.25.0

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,9 +24,6 @@ platforms:
     - "-//tests/contrib:test_compare_ids_test_one_tar_no_id_fails"
     - "-//tests/contrib:test_compare_ids_test_wrong_id_fails"
     # tests/contrib/test_compare_ids_test_* expect 'bazel' on path
-    # Disable targets that are part of an embedded bazel project as buildkite
-    # only recognizes a single top level WORKSPACE file.
-    - "-//testing/examples/..."
     test_flags:
     - "--action_env=PATH"
     # TODO(xingao): Remove after https://github.com/bazelbuild/rules_scala/issues/644 is addressed.
@@ -47,14 +44,13 @@ platforms:
     - "-//tests/contrib:test_compare_ids_test_one_tar_no_id_fails"
     - "-//tests/contrib:test_compare_ids_test_wrong_id_fails"
     # tests/contrib/test_compare_ids_test_* expect 'bazel' on path
-    # Disable targets that are part of an embedded bazel project as buildkite
-    # only recognizes a single top level WORKSPACE file.
-    - "-//testing/examples/..."
     test_flags:
     - "--action_env=PATH"
     # TODO(xingao): Remove after https://github.com/bazelbuild/rules_scala/issues/644 is addressed.
     - "--incompatible_disallow_legacy_javainfo=false"
   macos:
+    shell_commands:
+    - echo $PATH && echo $(which which) && echo $(which python) && echo $(which python2) && echo $(which python3)
     build_targets:
     - "//tests/docker:test_digest_output1"
     build_flags:
@@ -74,9 +70,6 @@ platforms:
     # Disabled as docker is not available
     # TODO(alex1545): enable once docker is supported on buildkite
     - "-//tests/docker:basic_dockerfile_image"
-    # Disable targets that are part of an embedded bazel project as buildkite
-    # only recognizes a single top level WORKSPACE file.
-    - "-//testing/examples/..."
     build_flags:
     - "--extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/latest:toolchain_docker"
     - "--extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"
@@ -101,9 +94,6 @@ platforms:
     # Disabled as docker is not available
     # TODO(alex1545): enable once docker is supported on buildkite
     - "-//tests/docker:basic_dockerfile_image"
-    # Disable targets that are part of an embedded bazel project as buildkite
-    # only recognizes a single top level WORKSPACE file.
-    - "-//testing/examples/..."
     test_flags:
     - "--extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/latest:toolchain_docker"
     - "--extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -49,8 +49,6 @@ platforms:
     # TODO(xingao): Remove after https://github.com/bazelbuild/rules_scala/issues/644 is addressed.
     - "--incompatible_disallow_legacy_javainfo=false"
   macos:
-    shell_commands:
-    - echo $PATH && echo $(which which) && echo $(which python) && echo $(which python2) && echo $(which python3)
     build_targets:
     - "//tests/docker:test_digest_output1"
     build_flags:

--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,3 @@
+# Disable targets that are part of an embedded bazel project as buildkite
+# only recognizes a single top level WORKSPACE file.
+testing/examples

--- a/.bazelrc
+++ b/.bazelrc
@@ -14,10 +14,9 @@
 
 # The following flags are set to test use of new features for python toolchains
 # These flags will only work with Bazel 0.25.0 or above.
-
-#build --incompatible_use_python_toolchains
-#build --host_force_python=PY2
-#test --incompatible_use_python_toolchains
-#test --host_force_python=PY2
-#run --incompatible_use_python_toolchains
-#run --host_force_python=PY2
+build --incompatible_use_python_toolchains
+build --host_force_python=PY2
+test --incompatible_use_python_toolchains
+test --host_force_python=PY2
+run --incompatible_use_python_toolchains
+run --host_force_python=PY2

--- a/.bazelrc
+++ b/.bazelrc
@@ -18,4 +18,3 @@ test --incompatible_use_python_toolchains
 test --host_force_python=PY2
 run --incompatible_use_python_toolchains
 run --host_force_python=PY2
-

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build --incompatible_use_python_toolchains
-build --host_force_python=PY2
-test --incompatible_use_python_toolchains
-test --host_force_python=PY2
-run --incompatible_use_python_toolchains
-run --host_force_python=PY2
+# The following flags are set to test use of new features for python toolchains
+# These flags will only work with Bazel 0.25.0 or above.
+
+#build --incompatible_use_python_toolchains
+#build --host_force_python=PY2
+#test --incompatible_use_python_toolchains
+#test --host_force_python=PY2
+#run --incompatible_use_python_toolchains
+#run --host_force_python=PY2

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,21 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build --incompatible_use_python_toolchains
+build --host_force_python=PY2
+test --incompatible_use_python_toolchains
+test --host_force_python=PY2
+run --incompatible_use_python_toolchains
+run --host_force_python=PY2
+

--- a/README.md
+++ b/README.md
@@ -1119,13 +1119,13 @@ This can then be referenced in `BUILD` files as `@gitlab//image`.
 
 ## Python tools
 
-Starting with Bazel 0.25.0 its possible to configure python toolchains
+Starting with Bazel 0.25.0 it's possible to configure python toolchains
 for `rules_docker`.
 
 To use these features you need to enable the flags in the `.bazelrc`
 file at the root of this project.
 
-Use of these features requires a python toolchain to be registered.
+Use of these features require a python toolchain to be registered.
 `//py_images/image.bzl:deps` and `//py3_images/image.bzl:deps` register a
 default python toolchain (`//toolchains/python:container_py_toolchain`)
 that defines the path to python tools inside the default container used

--- a/README.md
+++ b/README.md
@@ -397,6 +397,10 @@ If you need to modify somehow the container produced by
 <a href=#overview-1>Language Rules Overview</a> about how to do this
 and see <a href=#go_image-custom-base>go_image (custom base)</a> example below.
 
+If you are using `py_image` with a custom base that has python tools installed
+in a location different to the default base, please see
+<a href=#python-tools>Python tools</a>.
+
 ### py_image (fine layering)
 
 For Python and Java's `lang_image` rules, you can factor
@@ -473,6 +477,10 @@ If you need to modify somehow the container produced by
 `py3_image` (e.g., `env`, `symlink`), see note above in
 <a href=#overview-1>Language Rules Overview</a> about how to do this
 and see <a href=#go_image-custom-base>go_image (custom base)</a> example below.
+
+If you are using `py3_image` with a custom base that has python tools installed
+in a location different to the default base, please see
+<a href=#python-tools>Python tools</a>.
 
 ### nodejs_image
 
@@ -1108,6 +1116,44 @@ authenticated_container_pull(
 This can then be referenced in `BUILD` files as `@gitlab//image`.
 
 **NOTE:** This will only work on systems with Python >2.7.6
+
+## Python tools
+
+Starting with Bazel 0.25.0 its possible to configure python toolchains
+for `rules_docker`.
+
+To use these features you need to enable the flags in the `.bazelrc`
+file at the root of this project.
+
+Use of these features requires a python toolchain to be registered.
+`//py_images/image.bzl:deps` and `//py3_images/image.bzl:deps` register a
+default python toolchain (`//toolchains/python:container_py_toolchain`)
+that defines the path to python tools inside the default container used
+for these rules.
+
+### Known issues
+
+If you are using a custom base for `py_image` or `py3_image` builds that has
+python tools installed in a different location to those defined in
+`//toolchains/python:container_py_toolchain`, you will need to create a
+toolchain that points to these paths and register it _before_ the call to
+`py*_images/image.bzl:deps` in your `WORKSPACE`.
+
+Until Bazel 0.26.0 is relesed, registration of the default python toolchain
+will result in all python targets using that same toolchain, which might
+result in errors if any of those targets need to run locally.
+Once Bazel 0.26.0 is out, this default toolchain will only be compatible with
+python targets that run inside a container and will not interfere with
+other python targets.
+
+Use of python toolchain features, currently, only supports picking one
+version of python for execution of host tools. `rules_docker` heavily depends
+on execution of python host tools that are only compatible with python 2.
+Flags in the recommended `.bazelrc` file force all host tools to use python 2.
+If your project requires using host tools that are only compatible with
+python 3 you will not be able to use these features at the moment. We
+expect this issue to be resolved before use of python toolchain features
+becomes the default.
 
 ## Updating the `distroless` base images.
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -285,6 +285,9 @@ dockerfile_image(
     dockerfile = "//contrib:Dockerfile",
 )
 
+# Register the default py_toolchain for containerized execution
+register_toolchains("//toolchains/python:container_py_toolchain")
+
 http_archive(
     name = "bazel_toolchains",
     sha256 = "816ee04419c49f5abe75fcaf1a192a0eec339f9997f7a3abed976b2c7ef412ad",

--- a/python/BUILD
+++ b/python/BUILD
@@ -22,8 +22,12 @@ licenses(["notice"])  # Apache 2.0
 # --python_top=//python:py_runtime_2
 # Note you need to have a symlink to a valid python2 version in
 # '/usr/bin/python2' for this to work.
+# Note this will stop working with Bazel 0.26.0 or whenever
+# --incompatible_use_python_toolchains is turned on by default.
+# See https://github.com/bazelbuild/bazel/issues/7899
 py_runtime(
     name = "py_runtime_2",
     files = [],
     interpreter_path = "/usr/bin/python2",
+    python_version = "PY2",
 )

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -41,6 +41,9 @@ def repositories():
     """
     _repositories()
 
+    # Register the default py_toolchain for containerized execution
+    native.register_toolchains("@io_bazel_rules_docker//toolchains/python:container_py_toolchain")
+
     excludes = native.existing_rules().keys()
     if "py_image_base" not in excludes:
         container_pull(
@@ -87,7 +90,10 @@ def py_image(name, base = None, deps = [], layers = [], **kwargs):
 
     # TODO(mattmoor): Consider using par_binary instead, so that
     # a single target can be used for all three.
-    native.py_binary(name = binary_name, deps = deps + layers, **kwargs)
+
+    # TODO(ngiraldo): Add exec_compatible_with=["@io_bazel_rules_docker//toolchains/pythin:run_in_container"]
+    # once py_binary targets support it.
+    native.py_binary(name = binary_name, python_version = "PY2", deps = deps + layers, **kwargs)
 
     # TODO(mattmoor): Consider making the directory into which the app
     # is placed configurable.

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -40,6 +40,9 @@ def repositories():
     """
     _repositories()
 
+    # Register the default py_toolchain for containerized execution
+    native.register_toolchains("@io_bazel_rules_docker//toolchains/python:container_py_toolchain")
+
     excludes = native.existing_rules().keys()
     if "py3_image_base" not in excludes:
         container_pull(
@@ -82,7 +85,9 @@ def py3_image(name, base = None, deps = [], layers = [], **kwargs):
     # TODO(mattmoor): Consider using par_binary instead, so that
     # a single target can be used for all three.
 
-    native.py_binary(name = binary_name, deps = deps + layers, **kwargs)
+    # TODO(ngiraldo): Add exec_compatible_with=["@io_bazel_rules_docker//toolchains/pythin:run_in_container"]
+    # once py_binary targets support it.
+    native.py_binary(name = binary_name, python_version = "PY3", deps = deps + layers, **kwargs)
 
     # TODO(mattmoor): Consider making the directory into which the app
     # is placed configurable.

--- a/toolchains/python/BUILD
+++ b/toolchains/python/BUILD
@@ -1,0 +1,63 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+py_runtime(
+    name = "default_container_py2_runtime",
+    interpreter_path = "/usr/bin/python",
+    python_version = "PY2",
+)
+
+py_runtime(
+    name = "default_container_py3_runtime",
+    interpreter_path = "/usr/bin/python3",
+    python_version = "PY3",
+)
+
+py_runtime_pair(
+    name = "default_container_py_runtime_pair",
+    py2_runtime = ":default_container_py2_runtime",
+    py3_runtime = ":default_container_py3_runtime",
+)
+
+# A toolchain to run python outputs inside a container.
+# If you are using --incompatible_use_python_toolchains this toolchain must
+# be used to indicate the location of python tools inside the container as
+# the auto-detected toolchain relies on using "which", which is not present
+# in the default python containers.
+# If you are using a custom base for py_image which has python tools in a
+# different location, you must register that toolchain prior to the
+# registration of this one in @io_bazel_rules_docker//python:image.bzl
+toolchain(
+    name = "container_py_toolchain",
+    # TODO(ngiraldo): Uncomment the line below once py_binary targets
+    # support using 'exec_compatible_with'
+    #target_compatible_with = [":run_in_container"],
+    toolchain = ":default_container_py_runtime_pair",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+# Constraints used to describe docker compatible toolchains.
+
+constraint_setting(name = "docker")
+
+constraint_value(
+    name = "run_in_container",
+    constraint_setting = ":docker",
+)


### PR DESCRIPTION
Changes required for use upcoming python toolchains features:
* create a `py_runtime_pair` and toolchain that is compatible with the base containers used in `py_image` and `py3_image`
* register toolchains in `deps` targets for `py_image` and `py3_image`
* Set explicitly `python_version` in `native.py_binary` calls in image.bzl for py and py3
* Adds flags to `.bazelrc` so all our CI runs with testing these fatures
  Note: flags that will only work with 0.25.0. But I tested that changes are still OK on CI if flags in bazelrc are not turned on.
* Update readme to document use of python toolchains
* extra: Use .bazelignore to avoid building anything under testing/examples/
