### PR TITLE
Allow dockerfile build to be cached.

### DIFF
--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -59,13 +59,18 @@ def _impl(repository_ctx):
         for pair in repository_ctx.attr.build_args.items():
             build_args.extend(["--build-arg", "%s=%s" % (pair[0], pair[1])])
 
+    cache_args = []
+    if not repository_ctx.attr.cache:
+        cache_args.append("--no-cache")
+
+
     # The docker bulid command needs to run using the supplied Dockerfile
     # because it may refer to relative paths in its ADD, COPY and WORKDIR
     # instructions.
     command = [docker_path, "build"]
     command.extend(build_args)
+    command.extend(cache_args)
     command.extend([
-        "--no-cache",
         "-f",
         dockerfile_path,
         "-t",
@@ -115,6 +120,10 @@ dockerfile_image = repository_rule(
             allow_single_file = True,
             mandatory = True,
             doc = "The label for the Dockerfile to build the image from.",
+        ),
+        "cache": attr.bool(
+            default = False,
+            doc = "Turn on docker caching for the build.",
         ),
     },
     implementation = _impl,

--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -63,7 +63,6 @@ def _impl(repository_ctx):
     if not repository_ctx.attr.cache:
         cache_args.append("--no-cache")
 
-
     # The docker bulid command needs to run using the supplied Dockerfile
     # because it may refer to relative paths in its ADD, COPY and WORKDIR
     # instructions.

--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -110,6 +110,10 @@ dockerfile_image = repository_rule(
             doc = "A map of args to pass to the --build-arg option in the " +
                   "`docker build` command.",
         ),
+        "cache": attr.bool(
+            default = False,
+            doc = "Turn on docker caching for the build.",
+        ),
         "docker_path": attr.string(
             doc = "The full path to the docker binary. If not specified, it " +
                   "will be searched for in the path. If not available, " +
@@ -119,10 +123,6 @@ dockerfile_image = repository_rule(
             allow_single_file = True,
             mandatory = True,
             doc = "The label for the Dockerfile to build the image from.",
-        ),
-        "cache": attr.bool(
-            default = False,
-            doc = "Turn on docker caching for the build.",
         ),
     },
     implementation = _impl,

--- a/testing/examples/WORKSPACE
+++ b/testing/examples/WORKSPACE
@@ -63,8 +63,8 @@ container_pull(
 
 dockerfile_image(
     name = "basic_alpine_dockerfile",
-    dockerfile = "//basic:Dockerfile",
     cache = True,
+    dockerfile = "//basic:Dockerfile",
 )
 
 dockerfile_image(

--- a/testing/examples/WORKSPACE
+++ b/testing/examples/WORKSPACE
@@ -64,6 +64,7 @@ container_pull(
 dockerfile_image(
     name = "basic_alpine_dockerfile",
     dockerfile = "//basic:Dockerfile",
+    cache = True,
 )
 
 dockerfile_image(


### PR DESCRIPTION
Some teams prefer to trade build speed over hermeticity, so allow docker caching to be turned on for the build.