### PR TITLE
Remove symlinks from lang image runfiles

### DIFF
--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -87,7 +87,6 @@ def cc_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
     base = base or DEFAULT_BASE
     for index, dep in enumerate(layers):
         base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary)
 
     visibility = kwargs.get("visibility", None)
     tags = kwargs.get("tags", None)

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -464,44 +464,28 @@ class ImageTest(unittest.TestCase):
       # Check the application layer, which is on top.
       self.assertTopLayerContains(img, [
         '.',
-        './app',
-        './app/testdata',
-        './app/testdata/py_image.binary.runfiles',
-        './app/testdata/py_image.binary.runfiles/io_bazel_rules_docker',
-        './app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata',
-        './app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata/py_image.py',
-        './app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata/py_image.binary',
-        './app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata/BUILD',
-        './app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata/__init__.py',
-        './app/io_bazel_rules_docker',
+        './app.runfiles',
+        './app.runfiles/io_bazel_rules_docker',
+        './app.runfiles/io_bazel_rules_docker/testdata',
+        './app.runfiles/io_bazel_rules_docker/testdata/py_image.py',
+        './app.runfiles/io_bazel_rules_docker/testdata/py_image.binary',
+        './app.runfiles/io_bazel_rules_docker/testdata/BUILD',
+        './app.runfiles/io_bazel_rules_docker/testdata/__init__.py',
         # TODO(mattmoor): The path normalization for symlinks should match
         # files to avoid this redundancy.
         '/app',
-        '/app/testdata',
-        '/app/testdata/py_image.binary',
-        '/app/testdata/py_image.binary.runfiles',
-        '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker',
-        '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/external',
+        '/app.runfiles',
+        '/app.runfiles/io_bazel_rules_docker',
+        '/app.runfiles/io_bazel_rules_docker/external',
       ])
 
-      # Below that, we have a layer that generates symlinks for the library layer.
+      # Check the library layer, which is below our application layer.
       self.assertLayerNContains(img, 1, [
         '.',
-        '/app',
-        '/app/testdata',
-        '/app/testdata/py_image.binary.runfiles',
-        '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker',
-        '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata',
-        '/app/testdata/py_image.binary.runfiles/io_bazel_rules_docker/testdata/py_image_library.py',
-      ])
-
-      # Check the library layer, which is two below our application layer.
-      self.assertLayerNContains(img, 2, [
-        '.',
-        './app',
-        './app/io_bazel_rules_docker',
-        './app/io_bazel_rules_docker/testdata',
-        './app/io_bazel_rules_docker/testdata/py_image_library.py',
+        './app.runfiles',
+        './app.runfiles/io_bazel_rules_docker',
+        './app.runfiles/io_bazel_rules_docker/testdata',
+        './app.runfiles/io_bazel_rules_docker/testdata/py_image_library.py',
       ])
 
   def test_py_image_with_symlinks_in_data(self):
@@ -509,45 +493,29 @@ class ImageTest(unittest.TestCase):
       # Check the application layer, which is on top.
       self.assertTopLayerContains(img, [
         '.',
-        './app',
-        './app/testdata',
-        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles',
-        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker',
-        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata',
-        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata/py_image.py',
-        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata/py_image_with_symlinks_in_data.binary',
-        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata/foo.txt',
-        './app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata/__init__.py',
-        './app/io_bazel_rules_docker',
+        './app.runfiles',
+        './app.runfiles/io_bazel_rules_docker',
+        './app.runfiles/io_bazel_rules_docker/testdata',
+        './app.runfiles/io_bazel_rules_docker/testdata/py_image.py',
+        './app.runfiles/io_bazel_rules_docker/testdata/py_image_with_symlinks_in_data.binary',
+        './app.runfiles/io_bazel_rules_docker/testdata/foo.txt',
+        './app.runfiles/io_bazel_rules_docker/testdata/__init__.py',
         # TODO(mattmoor): The path normalization for symlinks should match
         # files to avoid this redundancy.
+        '/app.runfiles',
+        '/app.runfiles/io_bazel_rules_docker',
+        '/app.runfiles/io_bazel_rules_docker/foo-symlink.txt',
         '/app',
-        '/app/testdata',
-        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles',
-        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker',
-        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/foo-symlink.txt',
-        '/app/testdata/py_image_with_symlinks_in_data.binary',
-        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/external',
+        '/app.runfiles/io_bazel_rules_docker/external',
       ])
 
-      # Below that, we have a layer that generates symlinks for the library layer.
+      # Check the library layer, which is below our application layer.
       self.assertLayerNContains(img, 1, [
         '.',
-        '/app',
-        '/app/testdata',
-        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles',
-        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker',
-        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata',
-        '/app/testdata/py_image_with_symlinks_in_data.binary.runfiles/io_bazel_rules_docker/testdata/py_image_library.py',
-      ])
-
-      # Check the library layer, which is two below our application layer.
-      self.assertLayerNContains(img, 2, [
-        '.',
-        './app',
-        './app/io_bazel_rules_docker',
-        './app/io_bazel_rules_docker/testdata',
-        './app/io_bazel_rules_docker/testdata/py_image_library.py',
+        './app.runfiles',
+        './app.runfiles/io_bazel_rules_docker',
+        './app.runfiles/io_bazel_rules_docker/testdata',
+        './app.runfiles/io_bazel_rules_docker/testdata/py_image_library.py',
       ])
 
   def test_py_image_complex(self):
@@ -555,141 +523,75 @@ class ImageTest(unittest.TestCase):
       # bazel-bin/testdata/py_image_complex-layer.tar
       self.assertTopLayerContains(img, [
         '.',
-        './app',
-        './app/testdata',
-        './app/testdata/py_image_complex.binary.runfiles',
-        './app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker',
-        './app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata',
-        './app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata/py_image_complex.py',
-        './app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata/py_image_complex.binary',
-        './app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata/test',
-        './app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata/test/__init__.py',
-        './app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0',
-        './app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0/__init__.py',
-        './app/testdata/py_image_complex.binary.runfiles/__init__.py',
-        './app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2',
-        './app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2/__init__.py',
-        './app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata/__init__.py',
-        './app/io_bazel_rules_docker',
+        './app.runfiles',
+        './app.runfiles/io_bazel_rules_docker',
+        './app.runfiles/io_bazel_rules_docker/testdata',
+        './app.runfiles/io_bazel_rules_docker/testdata/py_image_complex.py',
+        './app.runfiles/io_bazel_rules_docker/testdata/py_image_complex.binary',
+        './app.runfiles/io_bazel_rules_docker/testdata/test',
+        './app.runfiles/io_bazel_rules_docker/testdata/test/__init__.py',
+        './app.runfiles/pypi__six_1_11_0',
+        './app.runfiles/pypi__six_1_11_0/__init__.py',
+        './app.runfiles/__init__.py',
+        './app.runfiles/pypi__addict_2_1_2',
+        './app.runfiles/pypi__addict_2_1_2/__init__.py',
+        './app.runfiles/io_bazel_rules_docker/testdata/__init__.py',
         '/app',
-        '/app/testdata',
-        '/app/testdata/py_image_complex.binary',
-        '/app/testdata/py_image_complex.binary.runfiles',
-        '/app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker',
-        '/app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/external',
-      ])
-
-      # bazel-bin/testdata/py_image_complex.3-symlinks-layer.tar
-      self.assertLayerNContains(img, 1, [
-        '.',
-        '/app',
-        '/app/testdata',
-        '/app/testdata/py_image_complex.binary.runfiles',
-        '/app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker',
-        '/app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata',
-        '/app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata/py_image_complex_library.py',
-        '/app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata/py_image_library_using_six.py',
+        '/app.runfiles',
+        '/app.runfiles/io_bazel_rules_docker',
+        '/app.runfiles/io_bazel_rules_docker/external',
       ])
 
       # bazel-bin/testdata/py_image_complex.3-layer.tar
-      self.assertLayerNContains(img, 2, [
+      self.assertLayerNContains(img, 1, [
         '.',
-        './app',
-        './app/io_bazel_rules_docker',
-        './app/io_bazel_rules_docker/testdata',
-        './app/io_bazel_rules_docker/testdata/py_image_complex_library.py',
-        './app/io_bazel_rules_docker/testdata/py_image_library_using_six.py',
-      ])
-
-      # bazel-bin/testdata/py_image_complex.2-symlinks-layer.tar
-      self.assertLayerNContains(img, 3, [
-        '.',
-        '/app',
-        '/app/testdata',
-        '/app/testdata/py_image_complex.binary.runfiles',
-        '/app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker',
-        '/app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata',
-        '/app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata/test',
-        '/app/testdata/py_image_complex.binary.runfiles/io_bazel_rules_docker/testdata/test/py_image_library_using_addict.py',
+        './app.runfiles',
+        './app.runfiles/io_bazel_rules_docker',
+        './app.runfiles/io_bazel_rules_docker/testdata',
+        './app.runfiles/io_bazel_rules_docker/testdata/py_image_complex_library.py',
+        './app.runfiles/io_bazel_rules_docker/testdata/py_image_library_using_six.py',
       ])
 
       # bazel-bin/testdata/py_image_complex.2-layer.tar
-      self.assertLayerNContains(img, 4, [
+      self.assertLayerNContains(img, 2, [
         '.',
-        './app',
-        './app/io_bazel_rules_docker',
-        './app/io_bazel_rules_docker/testdata',
-        './app/io_bazel_rules_docker/testdata/test',
-        './app/io_bazel_rules_docker/testdata/test/py_image_library_using_addict.py',
-      ])
-
-      # bazel-bin/testdata/py_image_complex.1-symlinks-layer.tar
-      self.assertLayerNContains(img, 5, [
-        '.',
-        '/app',
-        '/app/testdata',
-        '/app/testdata/py_image_complex.binary.runfiles',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0/six.py',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/DESCRIPTION.rst',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/METADATA',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/RECORD',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/WHEEL',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/metadata.json',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/top_level.txt',
+        './app.runfiles',
+        './app.runfiles/io_bazel_rules_docker',
+        './app.runfiles/io_bazel_rules_docker/testdata',
+        './app.runfiles/io_bazel_rules_docker/testdata/test',
+        './app.runfiles/io_bazel_rules_docker/testdata/test/py_image_library_using_addict.py',
       ])
 
       # bazel-bin/testdata/py_image_complex.1-layer.tar
-      self.assertLayerNContains(img, 6, [
+      self.assertLayerNContains(img, 3, [
         '.',
-        './app',
-        './app/pypi__six_1_11_0',
-        './app/pypi__six_1_11_0/six.py',
-        './app/pypi__six_1_11_0/six-1.11.0.dist-info',
-        './app/pypi__six_1_11_0/six-1.11.0.dist-info/DESCRIPTION.rst',
-        './app/pypi__six_1_11_0/six-1.11.0.dist-info/METADATA',
-        './app/pypi__six_1_11_0/six-1.11.0.dist-info/RECORD',
-        './app/pypi__six_1_11_0/six-1.11.0.dist-info/WHEEL',
-        './app/pypi__six_1_11_0/six-1.11.0.dist-info/metadata.json',
-        './app/pypi__six_1_11_0/six-1.11.0.dist-info/top_level.txt',
-      ])
-
-
-      # bazel-bin/testdata/py_image_complex.0-symlinks-layer.tar
-      self.assertLayerNContains(img, 7, [
-        '.',
-        '/app',
-        '/app/testdata',
-        '/app/testdata/py_image_complex.binary.runfiles',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2/addict',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2/addict/__init__.py',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2/addict/addict.py',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/DESCRIPTION.rst',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/METADATA',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/RECORD',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/WHEEL',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/metadata.json',
-        '/app/testdata/py_image_complex.binary.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/top_level.txt',
+        './app.runfiles',
+        './app.runfiles/pypi__six_1_11_0',
+        './app.runfiles/pypi__six_1_11_0/six.py',
+        './app.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info',
+        './app.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/DESCRIPTION.rst',
+        './app.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/METADATA',
+        './app.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/RECORD',
+        './app.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/WHEEL',
+        './app.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/metadata.json',
+        './app.runfiles/pypi__six_1_11_0/six-1.11.0.dist-info/top_level.txt',
       ])
 
       # bazel-bin/testdata/py_image_complex.0-layer.tar
-      self.assertLayerNContains(img, 8, [
+      self.assertLayerNContains(img, 4, [
         '.',
-        './app',
-        './app/pypi__addict_2_1_2',
-        './app/pypi__addict_2_1_2/addict',
-        './app/pypi__addict_2_1_2/addict/__init__.py',
-        './app/pypi__addict_2_1_2/addict/addict.py',
-        './app/pypi__addict_2_1_2/addict-2.1.2.dist-info',
-        './app/pypi__addict_2_1_2/addict-2.1.2.dist-info/DESCRIPTION.rst',
-        './app/pypi__addict_2_1_2/addict-2.1.2.dist-info/METADATA',
-        './app/pypi__addict_2_1_2/addict-2.1.2.dist-info/RECORD',
-        './app/pypi__addict_2_1_2/addict-2.1.2.dist-info/WHEEL',
-        './app/pypi__addict_2_1_2/addict-2.1.2.dist-info/metadata.json',
-        './app/pypi__addict_2_1_2/addict-2.1.2.dist-info/top_level.txt',
+        './app.runfiles',
+        './app.runfiles/pypi__addict_2_1_2',
+        './app.runfiles/pypi__addict_2_1_2/addict',
+        './app.runfiles/pypi__addict_2_1_2/addict/__init__.py',
+        './app.runfiles/pypi__addict_2_1_2/addict/addict.py',
+        './app.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info',
+        './app.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/DESCRIPTION.rst',
+        './app.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/METADATA',
+        './app.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/RECORD',
+        './app.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/WHEEL',
+        './app.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/metadata.json',
+        './app.runfiles/pypi__addict_2_1_2/addict-2.1.2.dist-info/top_level.txt',
       ])
 
   def test_java_image(self):

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -56,7 +56,6 @@ def d_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
     base = base or DEFAULT_BASE
     for index, dep in enumerate(layers):
         base = app_layer(name = "%s_%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s_%d-symlinks" % (name, index), base = base, dep = dep, binary = binary)
 
     visibility = kwargs.get("visibility", None)
     tags = kwargs.get("tags", None)

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -90,7 +90,6 @@ def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
     base = base or DEFAULT_BASE
     for index, dep in enumerate(layers):
         base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary)
 
     visibility = kwargs.get("visibility", None)
     tags = kwargs.get("tags", None)

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -100,7 +100,6 @@ def py_image(name, base = None, deps = [], layers = [], **kwargs):
     base = base or DEFAULT_BASE
     for index, dep in enumerate(layers):
         base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary_name)
     visibility = kwargs.get("visibility", None)
     tags = kwargs.get("tags", None)
     app_layer(

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -94,7 +94,6 @@ def py3_image(name, base = None, deps = [], layers = [], **kwargs):
     base = base or DEFAULT_BASE
     for index, dep in enumerate(layers):
         base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary_name)
 
     visibility = kwargs.get("visibility", None)
     tags = kwargs.get("tags", None)

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -56,7 +56,6 @@ def rust_image(name, base = None, deps = [], layers = [], binary = None, **kwarg
     base = base or DEFAULT_BASE
     for index, dep in enumerate(layers):
         base = app_layer(name = "%s_%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s_%d-symlinks" % (name, index), base = base, dep = dep, binary = binary)
 
     visibility = kwargs.get("visibility", None)
     tags = kwargs.get("tags", None)

--- a/testdata/py_image.py
+++ b/testdata/py_image.py
@@ -25,8 +25,9 @@ def main():
   print('Third: %d' % py_image_library.fn(3))
   print('Fourth: %d' % py_image_library.fn(4))
   print(sys.argv)
+  print(os.getcwd())
   if len(sys.argv) > 1:
-    print(os.stat(sys.argv[2]))
+    print(os.stat(sys.argv[3]))
 
 
 if __name__ == '__main__':

--- a/tests/docker/cc/configs/cc_image.yaml
+++ b/tests/docker/cc/configs/cc_image.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.0.0
 
 metadataTest:
-  entrypoint: ['/app/tests/docker/cc/cc_image.binary']
+  entrypoint: ['/app']
   cmd: [
     'arg0',
     'arg1',
@@ -10,16 +10,16 @@ metadataTest:
 
 fileExistenceTests:
 - name: 'cc_image.binary'
-  path: './app/tests/docker/cc/cc_image.binary.runfiles/io_bazel_rules_docker/tests/docker/cc/cc_image.binary'
+  path: './app.runfiles/io_bazel_rules_docker/tests/docker/cc/cc_image.binary'
   shouldExist: true
   permissions: '-r-xr-xr-x'
 
 - name: 'BUILD'
-  path: './app/tests/docker/cc/cc_image.binary.runfiles/io_bazel_rules_docker/tests/docker/cc/BUILD'
+  path: './app.runfiles/io_bazel_rules_docker/tests/docker/cc/BUILD'
   shouldExist: true
   permissions: '-r-xr-xr-x'
 
 - name: 'external'
-  path: '/app/tests/docker/cc/cc_image.binary.runfiles/io_bazel_rules_docker/external'
+  path: '/app.runfiles/io_bazel_rules_docker/external'
   shouldExist: true
   permissions: 'Lrwxrwxrwx'

--- a/tests/docker/go/configs/go_image.yaml
+++ b/tests/docker/go/configs/go_image.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.0.0
 
 metadataTest:
-  entrypoint: ['/app/tests/docker/go/go_image.binary']
+  entrypoint: ['/app']
   cmd: [
     'arg0',
     'arg1',

--- a/tests/docker/nodejs/configs/nodejs_image.yaml
+++ b/tests/docker/nodejs/configs/nodejs_image.yaml
@@ -9,5 +9,5 @@ metadataTest:
       value: "noninteractive"
     - key: PATH
       value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-  entrypoint: ['/app/tests/docker/nodejs/nodejs_image.binary']
-  workdir: "/app/tests/docker/nodejs/nodejs_image.binary.runfiles/io_bazel_rules_docker"
+  entrypoint: ['/app']
+  workdir: "/app.runfiles/io_bazel_rules_docker"

--- a/tests/docker/nodejs/configs/nodejs_image_custom_binary.yaml
+++ b/tests/docker/nodejs/configs/nodejs_image_custom_binary.yaml
@@ -9,5 +9,5 @@ metadataTest:
       value: "noninteractive"
     - key: PATH
       value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-  entrypoint: ['/app/tests/docker/nodejs/my_custom_binary']
-  workdir: "/app/tests/docker/nodejs/my_custom_binary.runfiles/io_bazel_rules_docker"
+  entrypoint: ['/app']
+  workdir: "/app.runfiles/io_bazel_rules_docker"

--- a/tests/docker/nodejs/configs/nodejs_image_custom_binary_with_args.yaml
+++ b/tests/docker/nodejs/configs/nodejs_image_custom_binary_with_args.yaml
@@ -9,5 +9,5 @@ metadataTest:
       value: "noninteractive"
     - key: PATH
       value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-  entrypoint: ['/app/tests/docker/nodejs/my_custom_binary']
-  workdir: "/app/tests/docker/nodejs/my_custom_binary.runfiles/io_bazel_rules_docker"
+  entrypoint: ['/app']
+  workdir: "/app.runfiles/io_bazel_rules_docker"

--- a/tests/docker/nodejs/configs/nodejs_image_empty_list_args.yaml
+++ b/tests/docker/nodejs/configs/nodejs_image_empty_list_args.yaml
@@ -9,5 +9,5 @@ metadataTest:
       value: "noninteractive"
     - key: PATH
       value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-  entrypoint: ['/app/tests/docker/nodejs/nodejs_image_empty_list_args.binary']
-  workdir: "/app/tests/docker/nodejs/nodejs_image_empty_list_args.binary.runfiles/io_bazel_rules_docker"
+  entrypoint: ['/app']
+  workdir: "/app.runfiles/io_bazel_rules_docker"

--- a/tests/docker/nodejs/configs/nodejs_image_list_with_empty_string_args.yaml
+++ b/tests/docker/nodejs/configs/nodejs_image_list_with_empty_string_args.yaml
@@ -9,5 +9,5 @@ metadataTest:
       value: "noninteractive"
     - key: PATH
       value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-  entrypoint: ['/app/tests/docker/nodejs/nodejs_image_list_with_empty_string_args.binary']
-  workdir: "/app/tests/docker/nodejs/nodejs_image_list_with_empty_string_args.binary.runfiles/io_bazel_rules_docker"
+  entrypoint: ['/app']
+  workdir: "/app.runfiles/io_bazel_rules_docker"

--- a/tests/docker/nodejs/configs/nodejs_image_no_args.yaml
+++ b/tests/docker/nodejs/configs/nodejs_image_no_args.yaml
@@ -9,5 +9,5 @@ metadataTest:
       value: "noninteractive"
     - key: PATH
       value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-  entrypoint: ['/app/tests/docker/nodejs/nodejs_image_no_args.binary']
-  workdir: "/app/tests/docker/nodejs/nodejs_image_no_args.binary.runfiles/io_bazel_rules_docker"
+  entrypoint: ['/app']
+  workdir: "/app.runfiles/io_bazel_rules_docker"

--- a/tests/docker/nodejs/configs/nodejs_image_none_args.yaml
+++ b/tests/docker/nodejs/configs/nodejs_image_none_args.yaml
@@ -9,5 +9,5 @@ metadataTest:
       value: "noninteractive"
     - key: PATH
       value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-  entrypoint: ['/app/tests/docker/nodejs/nodejs_image_none_args.binary']
-  workdir: "/app/tests/docker/nodejs/nodejs_image_none_args.binary.runfiles/io_bazel_rules_docker"
+  entrypoint: ['/app']
+  workdir: "/app.runfiles/io_bazel_rules_docker"

--- a/tests/docker/python/configs/py_image.yaml
+++ b/tests/docker/python/configs/py_image.yaml
@@ -3,7 +3,7 @@ schemaVersion: 2.0.0
 metadataTest:
   entrypoint: [
     '/usr/bin/python',
-    '/app/tests/docker/python/py_image.binary',
+    '/app',
   ]
   cmd: [
     'arg0',

--- a/tests/docker/python3/configs/py3_image.yaml
+++ b/tests/docker/python3/configs/py3_image.yaml
@@ -3,7 +3,7 @@ schemaVersion: 2.0.0
 metadataTest:
   entrypoint: [
     '/usr/bin/python',
-    '/app/tests/docker/python3/py3_image.binary',
+    '/app',
   ]
   cmd: [
     'arg0',

--- a/tests/docker/rust/configs/rust_image.yaml
+++ b/tests/docker/rust/configs/rust_image.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.0.0
 
 metadataTest:
-  entrypoint: ['/app/tests/docker/rust/rust_image_binary']
+  entrypoint: ['/app']
   cmd: [
     'arg0',
     'arg1',


### PR DESCRIPTION
Previously, we would place runfiles in an image-agnostic path, such as:
  ```
  /app/pypi__six_1_11_0/six.py
  ```
and then (in a different layer), symlink it to a suitable path under runfiles:
  ```
  /app/testdata/py_image_complex.binary.runfiles/pypi__six_1_11_0/six.py -> /app/pypi__six_1_11_0/six.py
  ```
Change the image structure such that the runfiles tree is constructed in an
image-agnostic path at `/app.runfiles`, which makes it unnecessary to create
symlinks, while still keeping the file paths image-agnostic to support sharing
layers between images.  In the new layout, the runfiles are placed at:
  ```
  /app.runfiles/pypi__six_1_11_0/six.py
  ```
Runfiles are discovered (unless `RUNFILES_DIR` is already set) by looking at
`$0.runfiles`, so we also create a symlink from /app to the py_binary launcher
script, and set image `ENTRYPOINT` to `["python", "/app"]`.