### PR TITLE
Add puller function in go

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -314,8 +314,10 @@ rbe_autoconfig(
     name = "buildkite_config",
 )
 
+# gazelle:repo bazel_gazelle
+
 go_repository(
     name = "com_github_google_go_containerregistry",
-    commit = "1c6c7f61e8a5402b606c3c6db169fdcd1b0712b7",
+    commit = "6991786f93129be24f857070fe94754a9ea02a0a",
     importpath = "github.com/google/go-containerregistry",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -300,11 +300,11 @@ register_toolchains("//toolchains/python:container_py_toolchain")
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "36e5cb9f15543faa195daa9ee9c8a7f0306f6b4f3e407ffcdb9410884d9ac4de",
-    strip_prefix = "bazel-toolchains-0.25.0",
+    sha256 = "c6159396a571280c71d072a38147d43dcb44f78fc15976d0d47e6d0bf015458d",
+    strip_prefix = "bazel-toolchains-0.26.1",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.25.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/0.25.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.26.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/0.26.1.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -178,9 +178,9 @@ jvm_maven_import_external(
 # For our scala_image test.
 http_archive(
     name = "io_bazel_rules_scala",
-    sha256 = "5986f9a7852b4dc7e30d6e201990bcf277fe91608d1ac7ec0834909facb71b85",
-    strip_prefix = "rules_scala-300b4369a0a56d9e590d9fea8a73c3913d758e12",
-    urls = ["https://github.com/bazelbuild/rules_scala/archive/300b4369a0a56d9e590d9fea8a73c3913d758e12.tar.gz"],
+    sha256 = "d50b071d6be3ba9860a9c70dcabdcce5d9024efb18548799ba1191188ba844dd",
+    strip_prefix = "rules_scala-7ffc700e32cc72d13be91dab366dd960c17a4c48",
+    urls = ["https://github.com/bazelbuild/rules_scala/archive/7ffc700e32cc72d13be91dab366dd960c17a4c48.tar.gz"],
 )
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")

--- a/container/go/cmd/puller/BUILD
+++ b/container/go/cmd/puller/BUILD
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "new_container_puller",
     srcs = ["puller.go"],
     importpath = "github.com/bazelbuild/rules_docker/container/go/cmd/puller",
     visibility = ["//visibility:private"],
-)
-
-go_binary(
-    name = "puller",
-    embed = [":new_container_puller"],
-    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_google_go_containerregistry//pkg/authn:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/name:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/cache:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/remote:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/tarball:go_default_library",
+    ],
 )

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -1,0 +1,57 @@
+package puller
+
+import (
+	"fmt"
+	"log"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/cache"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+)
+
+const iWasADigestTag = "i-was-a-digest"
+
+// Pull the image with given <imgName> to destination <dstPath> with optional
+// cache files and required platform specifications.
+func pull(imgName, dstPath, cachePath string, platform v1.Platform) {
+	// Get a digest/tag based on the name
+	ref, err := name.ParseReference(imgName)
+	if err != nil {
+		log.Fatalf("parsing tag %q: %v", imgName, err)
+	}
+	log.Printf("Pulling %v", ref)
+
+	// Fetch the image with desired cache files and platform specs
+	i, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(platform))
+	if err != nil {
+		log.Fatalf("reading image %q: %v", ref, err)
+	}
+	if cachePath != "" {
+		i = cache.Image(i, cache.NewFilesystemCache(cachePath))
+	}
+
+	// WriteToFile wants a tag to write to the tarball, but we might have
+	// been given a digest.
+	// If the original ref was a tag, use that. Otherwise, if it was a
+	// digest, tag the image with :i-was-a-digest instead.
+	tag, ok := ref.(name.Tag)
+	if !ok {
+		d, ok := ref.(name.Digest)
+		if !ok {
+			log.Fatal("ref wasn't a tag or digest")
+		}
+		s := fmt.Sprintf("%s:%s", d.Repository.Name(), iWasADigestTag)
+		tag, err = name.NewTag(s)
+		if err != nil {
+			log.Fatalf("parsing digest as tag (%s): %v", s, err)
+		}
+	}
+
+	if err := tarball.WriteToFile(dstPath, tag, i); err != nil {
+		log.Fatalf("writing image %q: %v", dstPath, err)
+	}
+}


### PR DESCRIPTION
Added function `pull` that pulls an image in go.

The function reuses the implementation of `crane pull` [here](https://github.com/google/go-containerregistry/blob/15879f261e2082fe64b9f92d6738f4d959615dfc/pkg/crane/pull.go#L51) with additional platform specification feature.