### PR TITLE
Fix incremental loader cleanup when no run statements are defined

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -239,8 +239,9 @@ function read_variables() {
 %{tag_statements}
 
 # An optional "docker run" statement for invoking a loaded container.
-# This is not executed if the single argument --norun is passed.
-if [ "a$*" != "a--norun" ]; then
+# This is not executed if the single argument --norun is passed or
+# no run_statements are generated (in which case, 'run' is 'False').
+if [[ "a$*" != "a--norun" && "%{run}" == "True" ]]; then
   # Once we've loaded the images for all layers, we no longer need the temporary files on disk.
   # We can clean up before we exec docker, since the exit handler will no longer run.
   cleanup

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -219,6 +219,7 @@ def incremental_load(
             "%{docker_tool_path}": toolchain_info.tool_path,
             "%{load_statements}": "\n".join(load_statements),
             "%{run_statements}": "\n".join(run_statements),
+            "%{run}": str(run),
             # If this rule involves stamp variables than load them as bash
             # variables, and turn references to them into bash variable
             # references.


### PR DESCRIPTION
This fixes the bug mentioned in #793. When we don't generate any run statements (that is, `run` in `incremental_load()` is false), we don't `exec docker`, and the cleanup runs twice.