### PR TITLE
Create new starlark rules for new OCI format puller binary

### DIFF
--- a/container/go/cmd/puller/BUILD
+++ b/container/go/cmd/puller/BUILD
@@ -11,25 +11,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ###
+# Build file for new puller binary based on go-containerregistry backend.
 
+load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-go_library(
-    name = "go_default_library",
-    srcs = ["puller.go"],
-    importpath = "github.com/bazelbuild/rules_docker/container/go/cmd/puller",
-    visibility = ["//visibility:private"],
-    deps = [
-        "@com_github_google_go_containerregistry//pkg/authn:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/name:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/v1/remote:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/v1/tarball:go_default_library",
-    ],
-)
+# gazelle:prefix github.com/bazelbuild/rules_docker
+gazelle(name = "gazelle")
 
 go_binary(
     name = "puller",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["puller.go"],
+    importpath = "github.com/bazelbuild/rules_docker",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//container/go/pkg/oci:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/authn:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/name:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/cache:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/remote:go_default_library",
+    ],
 )

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Bazel Authors. All rights reserved.
+/// Copyright 2015 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //////////////////////////////////////////////////////////////////////
-// This binary pulls images from a Docker Registry.
+// This binary pulls images from a Docker Registry using the go-containerregistry as backend.
+// Unlike regular docker pull, the format this package uses is proprietary.
+
 package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	ospkg "os"
 
+	"github.com/bazelbuild/rules_docker/container/go/pkg/oci"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/cache"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
 var (
 	imgName         = flag.String("name", "", "The name location including repo and digest/tag of the docker image to pull and save. Supports fully-qualified tag or digest references.")
 	directory       = flag.String("directory", "", "Where to save the images files.")
 	clientConfigDir = flag.String("client-config-dir", "", "The path to the directory where the client configuration files are located. Overiddes the value from DOCKER_CONFIG.")
+	cachePath       = flag.String("cache", "", "Image's files cache directory.")
 	arch            = flag.String("architecture", "", "Image platform's CPU architecture.")
 	os              = flag.String("os", "", "Image's operating system, if referring to a multi-platform manifest list. Default linux.")
 	osVersion       = flag.String("os-version", "", "Image's operating system version, if referring to a multi-platform manifest list.")
@@ -40,6 +43,39 @@ var (
 	variant         = flag.String("variant", "", "Image's CPU variant, if referring to a multi-platform manifest list.")
 	features        = flag.String("features", "", "Image's CPU features, if referring to a multi-platform manifest list.")
 )
+
+// Tag applied to images that were pulled by digest. This denotes that the
+// image was (probably) never tagged with this, but lets us avoid applying the
+// ":latest" tag which might be misleading.
+const iWasADigestTag = "i-was-a-digest"
+
+// NOTE: This function is adapted from https://github.com/google/go-containerregistry/blob/master/pkg/crane/pull.go
+// with slight modification to take in a platform argument.
+// Pull the image with given <imgName> to destination <dstPath> with optional
+// cache files and required platform specifications.
+func pull(imgName, dstPath, cachePath string, platform v1.Platform) {
+	// Get a digest/tag based on the name.
+	ref, err := name.ParseReference(imgName)
+	if err != nil {
+		log.Fatalf("parsing tag %q: %v", imgName, err)
+	}
+	log.Printf("Pulling %v", ref)
+
+	// Fetch the image with desired cache files and platform specs.
+	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(platform))
+	if err != nil {
+		log.Fatalf("reading image %q: %v", ref, err)
+	}
+	if cachePath != "" {
+		img = cache.Image(img, cache.NewFilesystemCache(cachePath))
+	}
+
+	// // Image file to write to disk.
+	if err := oci.Write(img, dstPath); err != nil {
+		// if err := oci.Write(img, path); err != nil {
+		log.Fatalf("failed to write image to %q: %v", dstPath, err)
+	}
+}
 
 func main() {
 	flag.Parse()
@@ -58,50 +94,17 @@ func main() {
 		ospkg.Setenv("DOCKER_CONFIG", *clientConfigDir)
 	}
 
+	// Create a Platform struct with arguments
+	platform := v1.Platform{
+		Architecture: *arch,
+		OS:           *os,
+		OSVersion:    *osVersion,
+		OSFeatures:   []string{*osFeatures},
+		Variant:      *variant,
+		Features:     []string{*features},
+	}
+
+	pull(*imgName, *directory, *cachePath, platform)
+
 	log.Printf("Successfully pulled image %q into %q", *imgName, *directory)
-}
-
-// Tag applied to images that were pulled by digest. This denotes that the
-// image was (probably) never tagged with this, but lets us avoid applying the
-// ":latest" tag which might be misleading.
-const iWasADigestTag = "i-was-a-digest"
-
-// NOTE: This function is mostly copied from https://github.com/google/go-containerregistry/blob/master/pkg/crane/pull.go
-// with slight modification to take in a platform argument.
-// Pull the image with given <imgName> to destination <dstPath> with optional
-// cache files and required platform specifications.
-func pull(imgName, dstPath, cachePath string, platform v1.Platform) {
-	// Get a digest/tag based on the name
-	ref, err := name.ParseReference(imgName)
-	if err != nil {
-		log.Fatalf("parsing tag %q: %v", imgName, err)
-	}
-	log.Printf("Pulling %v", ref)
-
-	// Fetch the image with desired cache files and platform specs
-	i, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(platform))
-	if err != nil {
-		log.Fatalf("reading image %q: %v", ref, err)
-	}
-
-	// WriteToFile wants a tag to write to the tarball, but we might have
-	// been given a digest.
-	// If the original ref was a tag, use that. Otherwise, if it was a
-	// digest, tag the image with :i-was-a-digest instead.
-	tag, ok := ref.(name.Tag)
-	if !ok {
-		d, ok := ref.(name.Digest)
-		if !ok {
-			log.Fatal("ref wasn't a tag or digest")
-		}
-		s := fmt.Sprintf("%s:%s", d.Repository.Name(), iWasADigestTag)
-		tag, err = name.NewTag(s)
-		if err != nil {
-			log.Fatalf("parsing digest as tag (%s): %v", s, err)
-		}
-	}
-
-	if err := tarball.WriteToFile(dstPath, tag, i); err != nil {
-		log.Fatalf("writing image %q: %v", dstPath, err)
-	}
 }

--- a/container/go/pkg/oci/BUILD
+++ b/container/go/pkg/oci/BUILD
@@ -1,0 +1,29 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ###
+# Build for the new writer function to write OCI Format Images to disk.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["write.go"],
+    importpath = "github.com/bazelbuild/rules_docker/container/go/pkg/oci",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/empty:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/layout:go_default_library",
+    ],
+)

--- a/container/go/pkg/oci/write.go
+++ b/container/go/pkg/oci/write.go
@@ -1,0 +1,49 @@
+/// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////
+// This binary writes images into the OCI Image Layout format.
+// Uses the go-containerregistry API as backend.
+
+package oci
+
+import (
+	"fmt"
+	"log"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+)
+
+// Write writes a v1.Image to the Path and updates the index.json to reference it.
+// This is just syntactic sugar wrapping Path.AppendImage from the go-container registry.
+func Write(img v1.Image, dstPath string) error {
+	// Path represents an OCI image layout ooted in a file system path
+	var path layout.Path
+	var err error
+
+	// Open the layout, if it already exists.
+	if path, err = layout.FromPath(dstPath); err != nil {
+		// Does not already exist, so initialize it with an empty index.
+		if path, err = layout.Write(dstPath, empty.Index); err != nil {
+			log.Fatalf("cannot initialize layout: %v", err)
+		}
+
+	}
+
+	if err := path.AppendImage(img); err != nil {
+		return fmt.Errorf("unable to write image to path")
+	}
+	return nil
+}

--- a/container/new_pull.bzl
+++ b/container/new_pull.bzl
@@ -70,9 +70,7 @@ _container_pull_attrs = {
     ),
     "_puller": attr.label(
         executable = True,
-        default = Label("@io_bazel_rules_docker//container/go/cmd/puller:puller"),
-        # Below for use with local repository.
-        # default = Label("@puller//:puller"),
+        default = Label("@go_puller//file:downloaded"),
         cfg = "host",
     ),
 }

--- a/container/new_pull.bzl
+++ b/container/new_pull.bzl
@@ -1,0 +1,211 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""An new implementation of container_pull based on google/containerregistry using google/go-containerregistry.
+
+This wraps the rulesdocker.go.cmd.puller.puller executable in a
+Bazel rule for downloading base images without a Docker client to
+construct new images.
+"""
+
+_container_pull_attrs = {
+    "architecture": attr.string(
+        default = "amd64",
+        doc = "(optional) Which CPU architecture to pull if this image " +
+              "refers to a multi-platform manifest list, default 'amd64'.",
+    ),
+    "cpu_variant": attr.string(
+        doc = "Which CPU variant to pull if this image refers to a " +
+              "multi-platform manifest list.",
+    ),
+    "digest": attr.string(
+        doc = "(optional) The digest of the image to pull.",
+    ),
+    "docker_client_config": attr.string(
+        doc = "A custom directory for the docker client config.json. " +
+              "If DOCKER_CONFIG is not specified, the value of the " +
+              "DOCKER_CONFIG environment variable will be used. DOCKER_CONFIG" +
+              " is not defined, the home directory will be used.",
+        mandatory = False,
+    ),
+    "os": attr.string(
+        default = "linux",
+        doc = "(optional) Which os to pull if this image refers to a " +
+              "multi-platform manifest list, default 'linux'.",
+    ),
+    "os_features": attr.string_list(
+        doc = "(optional) Specifies os features when pulling a multi-platform " +
+              "manifest list.",
+    ),
+    "os_version": attr.string(
+        doc = "(optional) Which os version to pull if this image refers to a " +
+              "multi-platform manifest list.",
+    ),
+    "platform_features": attr.string_list(
+        doc = "(optional) Specifies platform features when pulling a " +
+              "multi-platform manifest list.",
+    ),
+    "registry": attr.string(
+        mandatory = True,
+        doc = "The registry from which we are pulling.",
+    ),
+    "repository": attr.string(
+        mandatory = True,
+        doc = "The name of the image.",
+    ),
+    "tag": attr.string(
+        default = "latest",
+        doc = "(optional) The tag of the image, default to 'latest' " +
+              "if this and 'digest' remain unspecified.",
+    ),
+    "_puller": attr.label(
+        executable = True,
+        default = Label("@io_bazel_rules_docker//container/go/cmd/puller:puller"),
+        # Below for use with local repository.
+        # default = Label("@puller//:puller"),
+        cfg = "host",
+    ),
+}
+
+def _impl(repository_ctx):
+    """Core implementation of container_pull."""
+
+    # Add an empty top-level BUILD file.
+    repository_ctx.file("BUILD", "")
+
+    repository_ctx.file("image/BUILD", """
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_docker//container:import.bzl", "container_import")
+
+container_import(
+  name = "image",
+  config = "config.json",
+  layers = glob(["*.tar.gz"]),
+)
+
+exports_files(["image.digest", "digest"])
+""")
+    # print(repository_ctx.path(repository_ctx.attr._puller))
+
+    args = [
+        repository_ctx.path(repository_ctx.attr._puller),
+        "-directory",
+        repository_ctx.path("image"),
+        "-os",
+        repository_ctx.attr.os,
+        "-os-version",
+        repository_ctx.attr.os_version,
+        "-os-features",
+        " ".join(repository_ctx.attr.os_features),
+        "-architecture",
+        repository_ctx.attr.architecture,
+        "-variant",
+        repository_ctx.attr.cpu_variant,
+        "-features",
+        " ".join(repository_ctx.attr.platform_features),
+    ]
+
+    # print(args)
+
+    # Use the custom docker client config directory if specified.
+    if repository_ctx.attr.docker_client_config != "":
+        args += ["-client-config-dir", "{}".format(repository_ctx.attr.docker_client_config)]
+
+    cache_dir = repository_ctx.os.environ.get("DOCKER_REPO_CACHE")
+    if cache_dir:
+        if cache_dir.startswith("~/") and "HOME" in repository_ctx.os.environ:
+            cache_dir = cache_dir.replace("~", repository_ctx.os.environ["HOME"], 1)
+
+        args += [
+            "-cache",
+            cache_dir,
+        ]
+
+    # If a digest is specified, then pull by digest.  Otherwise, pull by tag.
+    if repository_ctx.attr.digest:
+        args += [
+            "-name",
+            "{registry}/{repository}@{digest}".format(
+                registry = repository_ctx.attr.registry,
+                repository = repository_ctx.attr.repository,
+                digest = repository_ctx.attr.digest,
+            ),
+        ]
+    else:
+        tag_ = repository_ctx.attr.tag
+        if not repository_ctx.attr.tag:
+            tag_ = "latest"
+        args += [
+            "-name",
+            "{registry}/{repository}:{tag}".format(
+                registry = repository_ctx.attr.registry,
+                repository = repository_ctx.attr.repository,
+                tag = tag_,
+            ),
+        ]
+
+    kwargs = {}
+    if "PULLER_TIMEOUT" in repository_ctx.os.environ:
+        kwargs["timeout"] = int(repository_ctx.os.environ.get("PULLER_TIMEOUT"))
+
+    result = repository_ctx.execute(args, **kwargs)
+    if result.return_code:
+        fail("Pull command failed: %s (%s)" % (result.stderr, " ".join(args)))
+
+    updated_attrs = {
+        k: getattr(repository_ctx.attr, k)
+        for k in _container_pull_attrs.keys()
+    }
+    updated_attrs["name"] = repository_ctx.name
+
+    # if repository_ctx.attr.digest:
+    digest_result = repository_ctx.execute(["cat", repository_ctx.path("image/digest")])
+    if digest_result.return_code:
+        fail("Failed to read digest: %s" % digest_result.stderr)
+    updated_attrs["digest"] = digest_result.stdout
+
+    if repository_ctx.attr.digest != updated_attrs["digest"]:
+        fail(("SHA256 of the image specified does not match SHA256 of the pulled image. " +
+              "Expected {}, but pulled image with {}. " +
+              "It is possible that you have a pin to a manifest list " +
+              "which points to another image, if so, " +
+              "change the pin to point at the actual Docker image").format(
+            repository_ctx.attr.digest,
+            updated_attrs["digest"],
+        ))
+
+    # Add image.digest for compatibility with container_digest, which generates
+    # foo.digest for an image named foo.
+    repository_ctx.symlink(repository_ctx.path("image/digest"), repository_ctx.path("image/image.digest"))
+
+    return updated_attrs
+
+pull = struct(
+    attrs = _container_pull_attrs,
+    implementation = _impl,
+)
+
+# Pulls a container image.
+
+# This rule pulls a container image into our intermediate format.  The
+# output of this rule can be used interchangeably with `docker_build`.
+new_container_pull = repository_rule(
+    attrs = _container_pull_attrs,
+    implementation = _impl,
+    environ = [
+        "DOCKER_REPO_CACHE",
+        "HOME",
+        "PULLER_TIMEOUT",
+    ],
+)

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -64,7 +64,7 @@ def repositories():
             sha256 = "59b8faec497bb73069e1cc525f655b5b5f860864371db12a233b64decfc325ff",
             urls = [(" https://storage.googleapis.com/rules_docker/b0f78e9c51dbeb5bc52f89339e7325fa3140424e/puller-linux-amd64")],
         )
-    
+
     if "puller" not in excludes:
         # Old puller binary pin.
         http_file(

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -57,13 +57,28 @@ def repositories():
     excludes = native.existing_rules().keys()
 
     if "puller" not in excludes:
+        # New puller binary pin.
         http_file(
             name = "puller",
             executable = True,
-            sha256 = "75ffb6edfee4bfcfbccd7ebee641dd90b4e2f73c773a9cca04cd0ec849576624",
-            urls = [("https://storage.googleapis.com/containerregistry-releases/" +
-                     CONTAINERREGISTRY_RELEASE + "/puller.par")],
+            sha256 = "59b8faec497bb73069e1cc525f655b5b5f860864371db12a233b64decfc325ff",
+            urls = [(" https://storage.googleapis.com/rules_docker/b0f78e9c51dbeb5bc52f89339e7325fa3140424e/puller-linux-amd64")],
         )
+
+        # Old puller binary pin.
+        # http_file(
+        #     name = "puller",
+        #     executable = True,
+        #     sha256 = "75ffb6edfee4bfcfbccd7ebee641dd90b4e2f73c773a9cca04cd0ec849576624",
+        #     urls = [("https://storage.googleapis.com/containerregistry-releases/" +
+        #              CONTAINERREGISTRY_RELEASE + "/puller.par")],
+        # )
+
+        # Use for local testing if there is a local repository set up.
+        # native.local_repository(
+        #     name = "puller",
+        #     path = "/usr/local/google/home/xwinxu/go_puller",
+        # )
 
     if "importer" not in excludes:
         http_file(

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -56,23 +56,24 @@ def repositories():
     """Download dependencies of container rules."""
     excludes = native.existing_rules().keys()
 
-    if "puller" not in excludes:
+    if "go_puller" not in excludes:
         # New puller binary pin.
         http_file(
-            name = "puller",
+            name = "go_puller",
             executable = True,
             sha256 = "59b8faec497bb73069e1cc525f655b5b5f860864371db12a233b64decfc325ff",
             urls = [(" https://storage.googleapis.com/rules_docker/b0f78e9c51dbeb5bc52f89339e7325fa3140424e/puller-linux-amd64")],
         )
-
+    
+    if "puller" not in excludes:
         # Old puller binary pin.
-        # http_file(
-        #     name = "puller",
-        #     executable = True,
-        #     sha256 = "75ffb6edfee4bfcfbccd7ebee641dd90b4e2f73c773a9cca04cd0ec849576624",
-        #     urls = [("https://storage.googleapis.com/containerregistry-releases/" +
-        #              CONTAINERREGISTRY_RELEASE + "/puller.par")],
-        # )
+        http_file(
+            name = "puller",
+            executable = True,
+            sha256 = "75ffb6edfee4bfcfbccd7ebee641dd90b4e2f73c773a9cca04cd0ec849576624",
+            urls = [("https://storage.googleapis.com/containerregistry-releases/" +
+                     CONTAINERREGISTRY_RELEASE + "/puller.par")],
+        )
 
         # Use for local testing if there is a local repository set up.
         # native.local_repository(


### PR DESCRIPTION
Modified the starlark (`.bzl`) rules to account for the new puller binary being uploaded to the cloud.

Old puller is left intact, invoke `new_container_pull` to use new puller.