### PR TITLE
Implement OCI Image Format Puller

### DIFF
--- a/container/go/cmd/puller/BUILD
+++ b/container/go/cmd/puller/BUILD
@@ -11,25 +11,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ###
+# Build file for new puller binary based on go-containerregistry backend.
 
+load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-go_library(
-    name = "go_default_library",
-    srcs = ["puller.go"],
-    importpath = "github.com/bazelbuild/rules_docker/container/go/cmd/puller",
-    visibility = ["//visibility:private"],
-    deps = [
-        "@com_github_google_go_containerregistry//pkg/authn:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/name:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/v1/remote:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/v1/tarball:go_default_library",
-    ],
-)
+# gazelle:prefix github.com/bazelbuild/rules_docker
+gazelle(name = "gazelle")
 
 go_binary(
     name = "puller",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["puller.go"],
+    importpath = "github.com/bazelbuild/rules_docker",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//container/go/pkg/oci:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/authn:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/name:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/cache:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/remote:go_default_library",
+    ],
 )

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -37,7 +37,6 @@ var (
 	imgName         = flag.String("name", "", "The name location including repo and digest/tag of the docker image to pull and save. Supports fully-qualified tag or digest references.")
 	directory       = flag.String("directory", "", "Where to save the images files.")
 	clientConfigDir = flag.String("client-config-dir", "", "The path to the directory where the client configuration files are located. Overiddes the value from DOCKER_CONFIG.")
-	cachePath       = flag.String("cache", "", "Image's files cache directory.")
 	arch            = flag.String("architecture", "", "Image platform's CPU architecture.")
 	os              = flag.String("os", "", "Image's operating system, if referring to a multi-platform manifest list. Default linux.")
 	osVersion       = flag.String("os-version", "", "Image's operating system version, if referring to a multi-platform manifest list.")
@@ -67,9 +66,6 @@ func pull(imgName, dstPath, cachePath string, platform v1.Platform) {
 	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(platform))
 	if err != nil {
 		log.Fatalf("reading image %q: %v", ref, err)
-	}
-	if cachePath != "" {
-		img = cache.Image(img, cache.NewFilesystemCache(cachePath))
 	}
 
 	// // Image file to write to disk.

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Bazel Authors. All rights reserved.
+/// Copyright 2015 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //////////////////////////////////////////////////////////////////////
-// This binary pulls images from a Docker Registry.
+// This binary pulls images from a Docker Registry using the go-containerregistry as backend.
+// This binary is able to accomodate the new Manifest List image format.
+// Unlike regular docker pull, the format this package uses is proprietary.
+
 package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	ospkg "os"
+	"strings"
 
+	"github.com/bazelbuild/rules_docker/container/go/pkg/oci"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/cache"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
 var (
 	imgName         = flag.String("name", "", "The name location including repo and digest/tag of the docker image to pull and save. Supports fully-qualified tag or digest references.")
 	directory       = flag.String("directory", "", "Where to save the images files.")
 	clientConfigDir = flag.String("client-config-dir", "", "The path to the directory where the client configuration files are located. Overiddes the value from DOCKER_CONFIG.")
+	cachePath       = flag.String("cache", "", "Image's files cache directory.")
 	arch            = flag.String("architecture", "", "Image platform's CPU architecture.")
 	os              = flag.String("os", "", "Image's operating system, if referring to a multi-platform manifest list. Default linux.")
 	osVersion       = flag.String("os-version", "", "Image's operating system version, if referring to a multi-platform manifest list.")
@@ -40,6 +45,39 @@ var (
 	variant         = flag.String("variant", "", "Image's CPU variant, if referring to a multi-platform manifest list.")
 	features        = flag.String("features", "", "Image's CPU features, if referring to a multi-platform manifest list.")
 )
+
+// Tag applied to images that were pulled by digest. This denotes that the
+// image was (probably) never tagged with this, but lets us avoid applying the
+// ":latest" tag which might be misleading.
+const iWasADigestTag = "i-was-a-digest"
+
+// NOTE: This function is adapted from https://github.com/google/go-containerregistry/blob/master/pkg/crane/pull.go
+// with slight modification to take in a platform argument.
+// Pull the image with given <imgName> to destination <dstPath> with optional
+// cache files and required platform specifications.
+func pull(imgName, dstPath, cachePath string, platform v1.Platform) {
+	// Get a digest/tag based on the name.
+	ref, err := name.ParseReference(imgName)
+	if err != nil {
+		log.Fatalf("parsing tag %q: %v", imgName, err)
+	}
+	log.Printf("Pulling %v", ref)
+
+	// Fetch the image with desired cache files and platform specs.
+	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(platform))
+	if err != nil {
+		log.Fatalf("reading image %q: %v", ref, err)
+	}
+	if cachePath != "" {
+		img = cache.Image(img, cache.NewFilesystemCache(cachePath))
+	}
+
+	// // Image file to write to disk.
+	if err := oci.Write(img, dstPath); err != nil {
+		// if err := oci.Write(img, path); err != nil {
+		log.Fatalf("failed to write image to %q: %v", dstPath, err)
+	}
+}
 
 func main() {
 	flag.Parse()
@@ -58,50 +96,17 @@ func main() {
 		ospkg.Setenv("DOCKER_CONFIG", *clientConfigDir)
 	}
 
+	// Create a Platform struct with arguments
+	platform := v1.Platform{
+		Architecture: *arch,
+		OS:           *os,
+		OSVersion:    *osVersion,
+		OSFeatures:   strings.Fields(*osFeatures),
+		Variant:      *variant,
+		Features:     strings.Fields(*features),
+	}
+
+	pull(*imgName, *directory, *cachePath, platform)
+
 	log.Printf("Successfully pulled image %q into %q", *imgName, *directory)
-}
-
-// Tag applied to images that were pulled by digest. This denotes that the
-// image was (probably) never tagged with this, but lets us avoid applying the
-// ":latest" tag which might be misleading.
-const iWasADigestTag = "i-was-a-digest"
-
-// NOTE: This function is mostly copied from https://github.com/google/go-containerregistry/blob/master/pkg/crane/pull.go
-// with slight modification to take in a platform argument.
-// Pull the image with given <imgName> to destination <dstPath> with optional
-// cache files and required platform specifications.
-func pull(imgName, dstPath, cachePath string, platform v1.Platform) {
-	// Get a digest/tag based on the name
-	ref, err := name.ParseReference(imgName)
-	if err != nil {
-		log.Fatalf("parsing tag %q: %v", imgName, err)
-	}
-	log.Printf("Pulling %v", ref)
-
-	// Fetch the image with desired cache files and platform specs
-	i, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(platform))
-	if err != nil {
-		log.Fatalf("reading image %q: %v", ref, err)
-	}
-
-	// WriteToFile wants a tag to write to the tarball, but we might have
-	// been given a digest.
-	// If the original ref was a tag, use that. Otherwise, if it was a
-	// digest, tag the image with :i-was-a-digest instead.
-	tag, ok := ref.(name.Tag)
-	if !ok {
-		d, ok := ref.(name.Digest)
-		if !ok {
-			log.Fatal("ref wasn't a tag or digest")
-		}
-		s := fmt.Sprintf("%s:%s", d.Repository.Name(), iWasADigestTag)
-		tag, err = name.NewTag(s)
-		if err != nil {
-			log.Fatalf("parsing digest as tag (%s): %v", s, err)
-		}
-	}
-
-	if err := tarball.WriteToFile(dstPath, tag, i); err != nil {
-		log.Fatalf("writing image %q: %v", dstPath, err)
-	}
 }

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -54,7 +54,7 @@ const iWasADigestTag = "i-was-a-digest"
 // with slight modification to take in a platform argument.
 // Pull the image with given <imgName> to destination <dstPath> with optional
 // cache files and required platform specifications.
-func pull(imgName, dstPath, cachePath string, platform v1.Platform) {
+func pull(imgName, dstPath, platform v1.Platform) {
 	// Get a digest/tag based on the name.
 	ref, err := name.ParseReference(imgName)
 	if err != nil {
@@ -102,7 +102,7 @@ func main() {
 		Features:     strings.Fields(*features),
 	}
 
-	pull(*imgName, *directory, *cachePath, platform)
+	pull(*imgName, *directory, platform)
 
 	log.Printf("Successfully pulled image %q into %q", *imgName, *directory)
 }

--- a/container/go/pkg/oci/BUILD
+++ b/container/go/pkg/oci/BUILD
@@ -1,12 +1,31 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ###
+# Build for the new writer function to write OCI Format Images to disk.
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["reader.go"],
+    srcs = [
+        "reader.go",
+        "write.go",
+    ],
     importpath = "github.com/bazelbuild/rules_docker/container/go/pkg/oci",
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/empty:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1/layout:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
     ],

--- a/container/go/pkg/oci/write.go
+++ b/container/go/pkg/oci/write.go
@@ -1,0 +1,49 @@
+/// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////
+// This binary writes images into the OCI Image Layout format.
+// Uses the go-containerregistry API as backend.
+
+package oci
+
+import (
+	"fmt"
+	"log"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+)
+
+// Write writes a v1.Image to the Path and updates the index.json to reference it.
+// This is just syntactic sugar wrapping Path.AppendImage from the go-container registry.
+func Write(img v1.Image, dstPath string) error {
+	// Path represents an OCI image layout ooted in a file system path
+	var path layout.Path
+	var err error
+
+	// Open the layout, if it already exists.
+	if path, err = layout.FromPath(dstPath); err != nil {
+		// Does not already exist, so initialize it with an empty index.
+		if path, err = layout.Write(dstPath, empty.Index); err != nil {
+			log.Fatalf("cannot initialize layout: %v", err)
+		}
+
+	}
+
+	if err := path.AppendImage(img); err != nil {
+		return fmt.Errorf("unable to write image to path")
+	}
+	return nil
+}


### PR DESCRIPTION
Extended rules_docker API to now contain the `Write` function which outputs the images from the puller in OCI standard format. BUILD files updated in the process.