### PR TITLE
Implement OCI image puller binary and writer utility

### DIFF
--- a/container/go/cmd/puller/BUILD
+++ b/container/go/cmd/puller/BUILD
@@ -11,25 +11,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ###
+# Build file for new puller binary based on go-containerregistry backend.
 
+load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-go_library(
-    name = "go_default_library",
-    srcs = ["puller.go"],
-    importpath = "github.com/bazelbuild/rules_docker/container/go/cmd/puller",
-    visibility = ["//visibility:private"],
-    deps = [
-        "@com_github_google_go_containerregistry//pkg/authn:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/name:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/v1/remote:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/v1/tarball:go_default_library",
-    ],
-)
+# gazelle:prefix github.com/bazelbuild/rules_docker
+gazelle(name = "gazelle")
 
 go_binary(
     name = "puller",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["puller.go"],
+    importpath = "github.com/bazelbuild/rules_docker",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//container/go/pkg/oci:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/authn:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/name:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/remote:go_default_library",
+    ],
 )

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -44,11 +44,6 @@ var (
 	features        = flag.String("features", "", "Image's CPU features, if referring to a multi-platform manifest list.")
 )
 
-// Tag applied to images that were pulled by digest. This denotes that the
-// image was (probably) never tagged with this, but lets us avoid applying the
-// ":latest" tag which might be misleading.
-const iWasADigestTag = "i-was-a-digest"
-
 // NOTE: This function is adapted from https://github.com/google/go-containerregistry/blob/master/pkg/crane/pull.go
 // with slight modification to take in a platform argument.
 // Pull the image with given <imgName> to destination <dstPath> with optional required platform specifications.

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Bazel Authors. All rights reserved.
+/// Copyright 2015 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //////////////////////////////////////////////////////////////////////
-// This binary pulls images from a Docker Registry.
+// This binary pulls images from a Docker Registry using the go-containerregistry as backend.
+// Unlike regular docker pull, the format this package uses is proprietary.
+
 package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	ospkg "os"
+	"strings"
 
+	"github.com/bazelbuild/rules_docker/container/go/pkg/oci"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
 var (
@@ -40,6 +42,36 @@ var (
 	variant         = flag.String("variant", "", "Image's CPU variant, if referring to a multi-platform manifest list.")
 	features        = flag.String("features", "", "Image's CPU features, if referring to a multi-platform manifest list.")
 )
+
+// Tag applied to images that were pulled by digest. This denotes that the
+// image was (probably) never tagged with this, but lets us avoid applying the
+// ":latest" tag which might be misleading.
+const iWasADigestTag = "i-was-a-digest"
+
+// NOTE: This function is adapted from https://github.com/google/go-containerregistry/blob/master/pkg/crane/pull.go
+// with slight modification to take in a platform argument.
+// Pull the image with given <imgName> to destination <dstPath> with optional
+// cache files and required platform specifications.
+func pull(imgName, dstPath string, platform v1.Platform) {
+	// Get a digest/tag based on the name.
+	ref, err := name.ParseReference(imgName)
+	if err != nil {
+		log.Fatalf("parsing tag %q: %v", imgName, err)
+	}
+	log.Printf("Pulling %v", ref)
+
+	// Fetch the image with desired cache files and platform specs.
+	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(platform))
+	if err != nil {
+		log.Fatalf("reading image %q: %v", ref, err)
+	}
+
+	// // Image file to write to disk.
+	if err := oci.Write(img, dstPath); err != nil {
+		// if err := oci.Write(img, path); err != nil {
+		log.Fatalf("failed to write image to %q: %v", dstPath, err)
+	}
+}
 
 func main() {
 	flag.Parse()
@@ -58,50 +90,17 @@ func main() {
 		ospkg.Setenv("DOCKER_CONFIG", *clientConfigDir)
 	}
 
+	// Create a Platform struct with arguments
+	platform := v1.Platform{
+		Architecture: *arch,
+		OS:           *os,
+		OSVersion:    *osVersion,
+		OSFeatures:   strings.Fields(*osFeatures),
+		Variant:      *variant,
+		Features:     strings.Fields(*features),
+	}
+
+	pull(*imgName, *directory, platform)
+
 	log.Printf("Successfully pulled image %q into %q", *imgName, *directory)
-}
-
-// Tag applied to images that were pulled by digest. This denotes that the
-// image was (probably) never tagged with this, but lets us avoid applying the
-// ":latest" tag which might be misleading.
-const iWasADigestTag = "i-was-a-digest"
-
-// NOTE: This function is mostly copied from https://github.com/google/go-containerregistry/blob/master/pkg/crane/pull.go
-// with slight modification to take in a platform argument.
-// Pull the image with given <imgName> to destination <dstPath> with optional
-// cache files and required platform specifications.
-func pull(imgName, dstPath, cachePath string, platform v1.Platform) {
-	// Get a digest/tag based on the name
-	ref, err := name.ParseReference(imgName)
-	if err != nil {
-		log.Fatalf("parsing tag %q: %v", imgName, err)
-	}
-	log.Printf("Pulling %v", ref)
-
-	// Fetch the image with desired cache files and platform specs
-	i, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(platform))
-	if err != nil {
-		log.Fatalf("reading image %q: %v", ref, err)
-	}
-
-	// WriteToFile wants a tag to write to the tarball, but we might have
-	// been given a digest.
-	// If the original ref was a tag, use that. Otherwise, if it was a
-	// digest, tag the image with :i-was-a-digest instead.
-	tag, ok := ref.(name.Tag)
-	if !ok {
-		d, ok := ref.(name.Digest)
-		if !ok {
-			log.Fatal("ref wasn't a tag or digest")
-		}
-		s := fmt.Sprintf("%s:%s", d.Repository.Name(), iWasADigestTag)
-		tag, err = name.NewTag(s)
-		if err != nil {
-			log.Fatalf("parsing digest as tag (%s): %v", s, err)
-		}
-	}
-
-	if err := tarball.WriteToFile(dstPath, tag, i); err != nil {
-		log.Fatalf("writing image %q: %v", dstPath, err)
-	}
 }

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -51,8 +51,7 @@ const iWasADigestTag = "i-was-a-digest"
 
 // NOTE: This function is adapted from https://github.com/google/go-containerregistry/blob/master/pkg/crane/pull.go
 // with slight modification to take in a platform argument.
-// Pull the image with given <imgName> to destination <dstPath> with optional
-// cache files and required platform specifications.
+// Pull the image with given <imgName> to destination <dstPath> with optional required platform specifications.
 func pull(imgName, dstPath string, platform v1.Platform) {
 	// Get a digest/tag based on the name.
 	ref, err := name.ParseReference(imgName)

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -38,8 +38,8 @@ var (
 	clientConfigDir = flag.String("client-config-dir", "", "The path to the directory where the client configuration files are located. Overiddes the value from DOCKER_CONFIG.")
 	arch            = flag.String("architecture", "", "Image platform's CPU architecture.")
 	os              = flag.String("os", "", "Image's operating system, if referring to a multi-platform manifest list. Default linux.")
-	osVersion       = flag.String("os-version", "", "Image's operating system version, if referring to a multi-platform manifest list.")
-	osFeatures      = flag.String("os-features", "", "Image's operating system features, if referring to a multi-platform manifest list.")
+	osVersion       = flag.String("os-version", "", "Image's operating system version, if referring to a multi-platform manifest list. Input strings are space separated.")
+	osFeatures      = flag.String("os-features", "", "Image's operating system features, if referring to a multi-platform manifest list. Input strings are space separated.")
 	variant         = flag.String("variant", "", "Image's CPU variant, if referring to a multi-platform manifest list.")
 	features        = flag.String("features", "", "Image's CPU features, if referring to a multi-platform manifest list.")
 )
@@ -84,12 +84,12 @@ func main() {
 	}
 
 	// If the user provided a client config directory, instruct the keychain resolver
-	// to use it to look for the docker client config
+	// to use it to look for the docker client config.
 	if *clientConfigDir != "" {
 		ospkg.Setenv("DOCKER_CONFIG", *clientConfigDir)
 	}
 
-	// Create a Platform struct with arguments
+	// Create a Platform struct with given arguments.
 	platform := v1.Platform{
 		Architecture: *arch,
 		OS:           *os,

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 //////////////////////////////////////////////////////////////////////
 // This binary pulls images from a Docker Registry using the go-containerregistry as backend.
+// The pulled image is in OCI Image Format and this binary can also accomodate manifest lists.
 // Unlike regular docker pull, the format this package uses is proprietary.
 
 package main

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -1,4 +1,4 @@
-/// Copyright 2015 The Bazel Authors. All rights reserved.
+// Copyright 2015 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,7 +68,6 @@ func pull(imgName, dstPath string, platform v1.Platform) {
 
 	// // Image file to write to disk.
 	if err := oci.Write(img, dstPath); err != nil {
-		// if err := oci.Write(img, path); err != nil {
 		log.Fatalf("failed to write image to %q: %v", dstPath, err)
 	}
 }

--- a/container/go/pkg/oci/BUILD
+++ b/container/go/pkg/oci/BUILD
@@ -1,12 +1,31 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ###
+# Build for the new writer function to write OCI Format Images to disk.
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["reader.go"],
+    srcs = [
+        "reader.go",
+        "write.go",
+    ],
     importpath = "github.com/bazelbuild/rules_docker/container/go/pkg/oci",
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/empty:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1/layout:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
     ],

--- a/container/go/pkg/oci/write.go
+++ b/container/go/pkg/oci/write.go
@@ -1,0 +1,49 @@
+/// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////
+// This binary writes images into the OCI Image Layout format.
+// Uses the go-containerregistry API as backend.
+
+package oci
+
+import (
+	"fmt"
+	"log"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+)
+
+// Write writes a v1.Image to the Path and updates the index.json to reference it.
+// This is just syntactic sugar wrapping Path.AppendImage from the go-container registry.
+func Write(img v1.Image, dstPath string) error {
+	// Path represents an OCI image layout ooted in a file system path
+	var path layout.Path
+	var err error
+
+	// Open the layout, if it already exists.
+	if path, err = layout.FromPath(dstPath); err != nil {
+		// Does not already exist, so initialize it with an empty index.
+		if path, err = layout.Write(dstPath, empty.Index); err != nil {
+			log.Fatalf("cannot initialize layout: %v", err)
+		}
+
+	}
+
+	if err := path.AppendImage(img); err != nil {
+		return fmt.Errorf("unable to write image to path")
+	}
+	return nil
+}

--- a/container/go/pkg/oci/write.go
+++ b/container/go/pkg/oci/write.go
@@ -18,8 +18,7 @@
 package oci
 
 import (
-	"fmt"
-	"log"
+	"github.com/pkg/errors"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -29,7 +28,7 @@ import (
 // Write writes a v1.Image to the Path and updates the index.json to reference it.
 // This is just syntactic sugar wrapping Path.AppendImage from the go-container registry.
 func Write(img v1.Image, dstPath string) error {
-	// Path represents an OCI image layout ooted in a file system path
+	// Path represents an OCI image layout rooted in a file system path
 	var path layout.Path
 	var err error
 
@@ -37,13 +36,13 @@ func Write(img v1.Image, dstPath string) error {
 	if path, err = layout.FromPath(dstPath); err != nil {
 		// Does not already exist, so initialize it with an empty index.
 		if path, err = layout.Write(dstPath, empty.Index); err != nil {
-			log.Fatalf("cannot initialize layout: %v", err)
+			return errors.Wrapf(err, "cannot initialize layout")
 		}
 
 	}
 
 	if err := path.AppendImage(img); err != nil {
-		return fmt.Errorf("unable to write image to path")
+		return errors.Wrapf(err, "unable to write image to path")
 	}
 	return nil
 }


### PR DESCRIPTION
Extended rules_docker API to now contain the `Write` function which outputs the images from the puller in OCI standard format. BUILD files updated in the process.