### PR TITLE
Create new starlark rules for new_container_pull

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -29,6 +29,9 @@ platforms:
     # TODO(xingao): Remove after https://github.com/bazelbuild/rules_scala/issues/644 is addressed.
     - "--incompatible_disallow_legacy_javainfo=false"
   ubuntu1804:
+    build_targets:
+    - "@new_alpine_linux_armv6//..."
+    - "@new_distroless_base//..."
     test_targets:
     # We are running the skipped targets remotely only.
     - "--"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -29,9 +29,6 @@ platforms:
     # TODO(xingao): Remove after https://github.com/bazelbuild/rules_scala/issues/644 is addressed.
     - "--incompatible_disallow_legacy_javainfo=false"
   ubuntu1804:
-    build_targets:
-    - "@new_alpine_linux_armv6//..."
-    - "@new_distroless_base//..."
     test_targets:
     # We are running the skipped targets remotely only.
     - "--"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,6 +34,28 @@ load(
 container_repositories()
 
 load(
+    "//container:new_pull.bzl",
+    "new_container_pull",
+)
+
+# These are for testing the new container push
+new_container_pull(
+    name = "new_alpine_linux_armv6",
+    architecture = "arm",
+    cpu_variant = "v6",
+    os = "linux",
+    registry = "index.docker.io",
+    repository = "library/alpine",
+    tag = "3.8",
+)
+
+new_container_pull(
+    name = "new_distroless_base",
+    registry = "gcr.io",
+    repository = "distroless/base",
+)
+
+load(
     "//container:container.bzl",
     "container_load",
     "container_pull",

--- a/container/new_pull.bzl
+++ b/container/new_pull.bzl
@@ -81,17 +81,16 @@ def _impl(repository_ctx):
     # Add an empty top-level BUILD file.
     repository_ctx.file("BUILD", "")
 
-    # TODO(xwinxu): change container_import rule to have an oci attribute to account for new OCI Image Layout
-    # currently exclude:     exports_files(["image.digest", "digest"]) in BUILD
-    repository_ctx.file("image/BUILD", """
-package(default_visibility = ["//visibility:public"])
+    # Currently exports all files pulled by the binary and cannot be depended on by other rules_docker rules.
+    # We will implement a new_container_import rule to comprehend this oci layout.
+    repository_ctx.file("image/BUILD", """package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "image_new",
+    name = "image",
     srcs = glob(["image/**"]),
 )
-exports_files(["index.json"])
-    """)
+
+exports_files(glob(["**"]))""")
 
     args = [
         repository_ctx.path(repository_ctx.attr._puller),

--- a/container/new_pull.bzl
+++ b/container/new_pull.bzl
@@ -1,0 +1,169 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""An implementation of container_pull based on google/containerregistry using google/go-containerregistry.
+
+This wraps the rulesdocker.go.cmd.puller.puller executable in a
+Bazel rule for downloading base images without a Docker client to
+construct new images.
+"""
+
+_container_pull_attrs = {
+    "architecture": attr.string(
+        default = "amd64",
+        doc = "(optional) Which CPU architecture to pull if this image " +
+              "refers to a multi-platform manifest list, default 'amd64'.",
+    ),
+    "cpu_variant": attr.string(
+        doc = "Which CPU variant to pull if this image refers to a " +
+              "multi-platform manifest list.",
+    ),
+    "digest": attr.string(
+        doc = "(optional) The digest of the image to pull.",
+    ),
+    "docker_client_config": attr.string(
+        doc = "A custom directory for the docker client config.json. " +
+              "If DOCKER_CONFIG is not specified, the value of the " +
+              "DOCKER_CONFIG environment variable will be used. DOCKER_CONFIG" +
+              " is not defined, the home directory will be used.",
+        mandatory = False,
+    ),
+    "os": attr.string(
+        default = "linux",
+        doc = "(optional) Which os to pull if this image refers to a " +
+              "multi-platform manifest list, default 'linux'.",
+    ),
+    "os_features": attr.string_list(
+        doc = "(optional) Specifies os features when pulling a multi-platform " +
+              "manifest list.",
+    ),
+    "os_version": attr.string(
+        doc = "(optional) Which os version to pull if this image refers to a " +
+              "multi-platform manifest list.",
+    ),
+    "platform_features": attr.string_list(
+        doc = "(optional) Specifies platform features when pulling a " +
+              "multi-platform manifest list.",
+    ),
+    "registry": attr.string(
+        mandatory = True,
+        doc = "The registry from which we are pulling.",
+    ),
+    "repository": attr.string(
+        mandatory = True,
+        doc = "The name of the image.",
+    ),
+    "tag": attr.string(
+        default = "latest",
+        doc = "(optional) The tag of the image, default to 'latest' " +
+              "if this and 'digest' remain unspecified.",
+    ),
+    "_puller": attr.label(
+        executable = True,
+        default = Label("@go_puller//file:downloaded"),
+        cfg = "host",
+    ),
+}
+
+def _impl(repository_ctx):
+    """Core implementation of container_pull."""
+
+    # Add an empty top-level BUILD file.
+    repository_ctx.file("BUILD", "")
+
+    # TODO(xwinxu): change container_import rule to have an oci attribute to account for new OCI Image Layout
+    # currently exclude:     exports_files(["image.digest", "digest"]) in BUILD
+    repository_ctx.file("image/BUILD", """
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "image_new",
+    srcs = glob(["image/**"]),
+)
+exports_files(["index.json"])
+    """)
+
+    args = [
+        repository_ctx.path(repository_ctx.attr._puller),
+        "-directory",
+        repository_ctx.path("image"),
+        "-os",
+        repository_ctx.attr.os,
+        "-os-version",
+        repository_ctx.attr.os_version,
+        "-os-features",
+        " ".join(repository_ctx.attr.os_features),
+        "-architecture",
+        repository_ctx.attr.architecture,
+        "-variant",
+        repository_ctx.attr.cpu_variant,
+        "-features",
+        " ".join(repository_ctx.attr.platform_features),
+    ]
+
+    # Use the custom docker client config directory if specified.
+    if repository_ctx.attr.docker_client_config != "":
+        args += ["-client-config-dir", "{}".format(repository_ctx.attr.docker_client_config)]
+
+    # If a digest is specified, then pull by digest.  Otherwise, pull by tag.
+    if repository_ctx.attr.digest:
+        args += [
+            "-name",
+            "{registry}/{repository}@{digest}".format(
+                registry = repository_ctx.attr.registry,
+                repository = repository_ctx.attr.repository,
+                digest = repository_ctx.attr.digest,
+            ),
+        ]
+    else:
+        args += [
+            "-name",
+            "{registry}/{repository}:{tag}".format(
+                registry = repository_ctx.attr.registry,
+                repository = repository_ctx.attr.repository,
+                tag = repository_ctx.attr.tag,
+            ),
+        ]
+
+    kwargs = {}
+    if "PULLER_TIMEOUT" in repository_ctx.os.environ:
+        kwargs["timeout"] = int(repository_ctx.os.environ.get("PULLER_TIMEOUT"))
+
+    result = repository_ctx.execute(args, **kwargs)
+    if result.return_code:
+        fail("Pull command failed: %s (%s)" % (result.stderr, " ".join([str(a) for a in args])))
+
+    updated_attrs = {
+        k: getattr(repository_ctx.attr, k)
+        for k in _container_pull_attrs.keys()
+    }
+    updated_attrs["name"] = repository_ctx.name
+
+    return updated_attrs
+
+pull = struct(
+    attrs = _container_pull_attrs,
+    implementation = _impl,
+)
+
+# Pulls a container image.
+
+# This rule pulls a container image into our intermediate format (OCI Image Layout).
+new_container_pull = repository_rule(
+    attrs = _container_pull_attrs,
+    implementation = _impl,
+    environ = [
+        "HOME",
+        "PULLER_TIMEOUT",
+    ],
+)

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -56,7 +56,17 @@ def repositories():
     """Download dependencies of container rules."""
     excludes = native.existing_rules().keys()
 
+    if "go_puller" not in excludes:
+        # Go puller binary.
+        http_file(
+            name = "go_puller",
+            executable = True,
+            sha256 = "02166c47cb84a67aaf59b86782729f1d5e568b035d80bc3a8ae3b0316d3db3e2",
+            urls = [("https://storage.googleapis.com/rules_docker/4e1a68bfa2507a3e76f84f90f8993fe085e6389a/puller-linux-amd64")],
+        )
+
     if "puller" not in excludes:
+        # Python puller binary.
         http_file(
             name = "puller",
             executable = True,

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -331,9 +331,7 @@ file_test(
 # For testing the new container pull rule
 file_test(
     name = "new_alpine_linux_armv6_test",
-    file = "@new_alpine_linux_armv6//image:index.json",
-    content = """
-{
+    content = """{
    "schemaVersion": 2,
    "manifests": [
       {
@@ -342,15 +340,13 @@ file_test(
          "digest": "sha256:f29c3d10359dd0e6d0c11e4f715735b678c0ab03a7ac4565b4b6c08980f6213b"
       }
    ]
-}
-    """,
+}""",
+    file = "@new_alpine_linux_armv6//image:index.json",
 )
 
 file_test(
     name = "new_distroless_base_test",
-    file = "@new_distroless_base//image:index.json",
-    content = """
-{
+    content = """{
    "schemaVersion": 2,
    "manifests": [
       {
@@ -359,8 +355,8 @@ file_test(
          "digest": "sha256:edc3643ddf96d75032a55e240900b68b335186f1e5fea0a95af3b4cc96020b77"
       }
    ]
-}
-    """,
+}""",
+    file = "@new_distroless_base//image:index.json",
 )
 
 create_banana_directory(

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -328,6 +328,41 @@ file_test(
     file = "@k8s_pause_arm64//image:digest",
 )
 
+# For testing the new container pull rule
+file_test(
+    name = "new_alpine_linux_armv6_test",
+    file = "@new_alpine_linux_armv6//image:index.json",
+    content = """
+{
+   "schemaVersion": 2,
+   "manifests": [
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 528,
+         "digest": "sha256:f29c3d10359dd0e6d0c11e4f715735b678c0ab03a7ac4565b4b6c08980f6213b"
+      }
+   ]
+}
+    """,
+)
+
+file_test(
+    name = "new_distroless_base_test",
+    file = "@new_distroless_base//image:index.json",
+    content = """
+{
+   "schemaVersion": 2,
+   "manifests": [
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 737,
+         "digest": "sha256:edc3643ddf96d75032a55e240900b68b335186f1e5fea0a95af3b4cc96020b77"
+      }
+   ]
+}
+    """,
+)
+
 create_banana_directory(
     name = "banana_directory",
 )


### PR DESCRIPTION
Modified the starlark (`.bzl`) rules to account for the new puller binary being uploaded to the cloud.

Old puller is left intact, invoke `new_container_pull` to use new puller.

Current speculative container_import written to BUILD file in output directory, see comments for details. No compatibility issues with container_import as of now (??) but potentially will need to refactor puller.go to allow reader to ingest such pulled data.