### PR TITLE
Add new Docker tarball feature to new Go container_pull

### DIFF
--- a/container/go/cmd/puller/BUILD
+++ b/container/go/cmd/puller/BUILD
@@ -37,5 +37,6 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/name:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1/remote:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/tarball:go_default_library",
     ],
 )

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -82,7 +82,6 @@ func pull(imgName, dstPath, format string, platform v1.Platform) {
 		log.Fatalf("parsing tag %q: %v", imgName, err)
 	}
 	log.Printf("Pulling %v", ref)
-	log.Printf(ref.String())
 
 	// Fetch the image with desired cache files and platform specs.
 	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithPlatform(platform))

--- a/container/new_pull.bzl
+++ b/container/new_pull.bzl
@@ -76,12 +76,11 @@ _container_pull_attrs = {
             "Both",
         ],
         doc = "(optional) The format of the image to be pulled, default to 'OCI', " +
-                "option for 'Docker' (tarball) or 'Both'."
+              "option for 'Docker' (tarball) or 'Both'.",
     ),
     "_puller": attr.label(
         executable = True,
-        default = Label("@go_puller//:puller"),
-        # default = Label("@go_puller//file:downloaded"),
+        default = Label("@go_puller//file:downloaded"),
         cfg = "host",
     ),
 }

--- a/container/new_pull.bzl
+++ b/container/new_pull.bzl
@@ -68,9 +68,20 @@ _container_pull_attrs = {
         doc = "(optional) The tag of the image, default to 'latest' " +
               "if this and 'digest' remain unspecified.",
     ),
+    "format": attr.string(
+        default = "OCI",
+        values = [
+            "OCI",
+            "Docker",
+            "Both",
+        ],
+        doc = "(optional) The format of the image to be pulled, default to 'OCI', " +
+                "option for 'Docker' (tarball) or 'Both'."
+    ),
     "_puller": attr.label(
         executable = True,
-        default = Label("@go_puller//file:downloaded"),
+        default = Label("@go_puller//:puller"),
+        # default = Label("@go_puller//file:downloaded"),
         cfg = "host",
     ),
 }
@@ -96,6 +107,8 @@ exports_files(glob(["**"]))""")
         repository_ctx.path(repository_ctx.attr._puller),
         "-directory",
         repository_ctx.path("image"),
+        "-format",
+        repository_ctx.attr.format,
         "-os",
         repository_ctx.attr.os,
         "-os-version",


### PR DESCRIPTION
Default is `"OCI"` format, can also specify Docker tarball only with `"Docker" `or both formats with `"Both"`. All images are still pulled into the image/ directory to remain consistent.