### PR TITLE
Clarify end user details for war_image macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,10 @@ war_image(
 )
 ```
 
+The produced image uses Jetty 9.x to serve the web application. Servlets included in the web application need to follow the API specification 3.0. For best compatibility, use a [Servlet dependency provided by the Jetty project](https://search.maven.org/search?q=g:org.mortbay.jetty%20AND%20a:servlet-api&core=gav).
+
+A Servlet implementation needs to declare the `@WebServlet` annotation to be auto-discovered. The use of a `web.xml` to declare the Servlet URL mapping is not supported.
+
 If you need to modify somehow the container produced by
 `war_image` (e.g., `env`, `symlink`), see note above in
 <a href=#overview-1>Language Rules Overview</a> about how to do this


### PR DESCRIPTION
The documentation currently doesn't provide any details about how the `war_image` macro works internally. Only by trying did I find out that the web application is served by a Jetty Servlet container. Users will also need to understand that you cannot use a `web.xml` but have to declare annotations instead for Servlets to be discovered.

As a side note: As an end user I do not find the name of the macro very fitting. `war_image` somewhat implies that a WAR file is built but that's not the case. Maybe `java_web_image` would be a better name.