### PR TITLE
Add new Starlark container load rule new_load.bzl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -374,7 +374,7 @@ register_toolchains("//toolchains/python:container_py_toolchain")
 http_archive(
     name = "bazel_toolchains",
     sha256 = "e76afea244b1767e19fb38e1f1be448ebdf48d52ade0b3687c5794d8a1362fe8",
-    strip_prefix = "bazel-toolchains-0.26.3",
+    strip_prefix = "bazel-toolchains-0.27.0",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.26.3.tar.gz",
         "https://github.com/bazelbuild/bazel-toolchains/archive/0.26.3.tar.gz",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -373,11 +373,11 @@ register_toolchains("//toolchains/python:container_py_toolchain")
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "e76afea244b1767e19fb38e1f1be448ebdf48d52ade0b3687c5794d8a1362fe8",
+    sha256 = "4598bf5a8b4f5ced82c782899438a7ba695165d47b3bf783ce774e89a8c6e617",
     strip_prefix = "bazel-toolchains-0.27.0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.26.3.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/0.26.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.27.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/0.27.0.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,6 +97,16 @@ container_load(
     file = "//testdata:pause.tar",
 )
 
+load(
+    "//container:new_load.bzl",
+    "new_container_load",
+)
+
+new_container_load(
+    name = "new_pause_tar",
+    file = "//testdata:pause.tar",
+)
+
 container_pull(
     name = "alpine_linux_amd64",
     registry = "index.docker.io",
@@ -363,11 +373,11 @@ register_toolchains("//toolchains/python:container_py_toolchain")
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "4598bf5a8b4f5ced82c782899438a7ba695165d47b3bf783ce774e89a8c6e617",
-    strip_prefix = "bazel-toolchains-0.27.0",
+    sha256 = "e76afea244b1767e19fb38e1f1be448ebdf48d52ade0b3687c5794d8a1362fe8",
+    strip_prefix = "bazel-toolchains-0.26.3",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.27.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/0.27.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.26.3.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/0.26.3.tar.gz",
     ],
 )
 

--- a/container/new_load.bzl
+++ b/container/new_load.bzl
@@ -30,6 +30,7 @@ filegroup(
     name = "image",
     srcs = glob(["image/**"]),
 )
+exports_files(["index.json", "oci-layout"])
 """, executable = False)
 
     result = repository_ctx.execute([

--- a/container/new_load.bzl
+++ b/container/new_load.bzl
@@ -1,0 +1,64 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rule for importing an image from 'docker save' tarballs.
+
+This extracts the tarball, examines the layers and creates a
+container_import target for use with container_image.
+"""
+
+load(
+    "//container:new_pull.bzl",
+    "new_container_pull",
+)
+
+def _impl(repository_ctx):
+    """Core implementation of new_container_load."""
+
+    # Add an empty top-level BUILD file.
+    repository_ctx.file("BUILD", "")
+
+    repository_ctx.file("image/BUILD", """
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "image",
+    srcs = glob(["image/**"]),
+)
+""", executable = False)
+
+    result = repository_ctx.execute([
+        repository_ctx.path(repository_ctx.attr._loader),
+        "-directory",
+        repository_ctx.path("image"),
+        "-tarball",
+        repository_ctx.path(repository_ctx.attr.file),
+    ])
+
+    if result.return_code:
+        fail("Importing from tarball failed (status %s): %s" % (result.return_code, result.stderr))
+
+new_container_load = repository_rule(
+    attrs = {
+        "file": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "_loader": attr.label(
+            executable = True,
+            default = Label("@loader//:loader"),
+            cfg = "host",
+        )
+    },
+    implementation = _impl,
+)

--- a/container/new_load.bzl
+++ b/container/new_load.bzl
@@ -33,7 +33,7 @@ filegroup(
     name = "image",
     srcs = glob(["image/**"]),
 )
-exports_files(glob["**"])
+exports_files(glob(["**"]))
 """, executable = False)
 
     result = repository_ctx.execute([

--- a/container/new_load.bzl
+++ b/container/new_load.bzl
@@ -17,11 +17,6 @@ This extracts the tarball, examines the layers and creates a
 container_import target for use with container_image.
 """
 
-load(
-    "//container:new_pull.bzl",
-    "new_container_pull",
-)
-
 def _impl(repository_ctx):
     """Core implementation of new_container_load."""
 
@@ -58,7 +53,7 @@ new_container_load = repository_rule(
             executable = True,
             default = Label("@loader//:loader"),
             cfg = "host",
-        )
+        ),
     },
     implementation = _impl,
 )

--- a/container/new_load.bzl
+++ b/container/new_load.bzl
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Rule for loading an image from 'docker save' or container_pull (MM format) 
-   tarballs into OCI intermediate layout.
+"""Rule for loading an image from 'docker save' tarball or the current 
+   container_pull tarball format into OCI intermediate layout.
 
 This extracts the tarball amd creates a filegroup of the untarred objects in OCI layout.
 """

--- a/container/new_load.bzl
+++ b/container/new_load.bzl
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Rule for importing an image from 'docker save' tarballs.
+"""Rule for loading an image from 'docker save' or container_pull (MM format) 
+   tarballs into OCI intermediate layout.
 
-This extracts the tarball, examines the layers and creates a
-container_import target for use with container_image.
+This extracts the tarball amd creates a filegroup of the untarred objects in OCI layout.
 """
 
 def _impl(repository_ctx):
@@ -26,11 +26,14 @@ def _impl(repository_ctx):
     repository_ctx.file("image/BUILD", """
 package(default_visibility = ["//visibility:public"])
 
+# TODO(xwinxu): this will be changed to new_container_import once that is implemented later
+# similar to what we have in new_pull.bzl
+
 filegroup(
     name = "image",
     srcs = glob(["image/**"]),
 )
-exports_files(["index.json", "oci-layout"])
+exports_files(glob["**"])
 """, executable = False)
 
     result = repository_ctx.execute([
@@ -52,7 +55,7 @@ new_container_load = repository_rule(
         ),
         "_loader": attr.label(
             executable = True,
-            default = Label("@loader//:loader"),
+            default = Label("@loader//file:downloaded"),
             cfg = "host",
         ),
     },

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -85,17 +85,12 @@ def repositories():
         )
 
     if "loader" not in excludes:
-        native.local_repository(
+        http_file(
             name = "loader",
-            path = "/usr/local/google/home/xwinxu/go_puller",
+            executable = True,
+            sha256 = "30bbb44eae9651a55d07fb9d39f58936fe3d9817780e1887df07d7beb21ef5ad",
+            urls = [("https://storage.googleapis.com/rules_docker/a08df0ab2a345cd07359bb69672dcf21867e50e5/loader-linux-amd64")],
         )
-        # http_file(
-        #     name = "loader",
-        #     executable = True,
-        #     sha256 = "4516a7bf62b052693001fd2b649080c4bb5228dcf698f31e77481fcb37b82ab4",
-        #     urls = [("https://storage.googleapis.com/containerregistry-releases/" +
-        #              CONTAINERREGISTRY_RELEASE + "/importer.par")],
-        # )
 
     if "containerregistry" not in excludes:
         http_archive(

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -84,6 +84,19 @@ def repositories():
                      CONTAINERREGISTRY_RELEASE + "/importer.par")],
         )
 
+    if "loader" not in excludes:
+        native.local_repository(
+            name = "loader",
+            path = "/usr/local/google/home/xwinxu/go_puller",
+        )
+        # http_file(
+        #     name = "loader",
+        #     executable = True,
+        #     sha256 = "4516a7bf62b052693001fd2b649080c4bb5228dcf698f31e77481fcb37b82ab4",
+        #     urls = [("https://storage.googleapis.com/containerregistry-releases/" +
+        #              CONTAINERREGISTRY_RELEASE + "/importer.par")],
+        # )
+
     if "containerregistry" not in excludes:
         http_archive(
             name = "containerregistry",

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -430,6 +430,30 @@ file_test(
     file = "@new_distroless_base_both//image:oci-layout",
 )
 
+# To test the new container load binary
+file_test(
+    name = "new_pause_tar_test_index_json",
+    file = "@new_pause_tar//image:index.json",
+    content = """{
+   "schemaVersion": 2,
+   "manifests": [
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 586,
+         "digest": "sha256:22e0bb47f6dd1938d7c30febe82ac37e99907fd8c76421ab87829ad6a3636bf9"
+      }
+   ]
+}""",
+)
+
+file_test(
+    name = "new_pause_tar_test_oci_layout",
+    file = "@new_pause_tar//image:oci-layout",
+    content = """{
+    "imageLayoutVersion": "1.0.0"
+}""",
+)
+
 create_banana_directory(
     name = "banana_directory",
 )

--- a/tests/docker/BUILD
+++ b/tests/docker/BUILD
@@ -433,7 +433,6 @@ file_test(
 # To test the new container load binary
 file_test(
     name = "new_pause_tar_test_index_json",
-    file = "@new_pause_tar//image:index.json",
     content = """{
    "schemaVersion": 2,
    "manifests": [
@@ -444,14 +443,15 @@ file_test(
       }
    ]
 }""",
+    file = "@new_pause_tar//image:index.json",
 )
 
 file_test(
     name = "new_pause_tar_test_oci_layout",
-    file = "@new_pause_tar//image:oci-layout",
     content = """{
     "imageLayoutVersion": "1.0.0"
 }""",
+    file = "@new_pause_tar//image:oci-layout",
 )
 
 create_banana_directory(


### PR DESCRIPTION
Starlark rule to work in accordance with the new loader.go binary.

Note: build currently failing because new loader.go binary is not uploaded.