### PR TITLE
Add symlink to puller's OCI intermediate format

### DIFF
--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	ospkg "os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -117,6 +118,54 @@ func pull(imgName, dstPath, format, cachePath string, platform v1.Platform) erro
 	default:
 		if err := oci.Write(img, dstPath); err != nil {
 			log.Fatalf("failed to write image to %q: %v", dstPath, err)
+		}
+	}
+
+	if err := generateSym(img, dstPath); err != nil {
+		return errors.Wrapf(err, "failed to generate symbolic links for pulled image")
+	}
+
+	return nil
+}
+
+// generateSym creates symbolic links to the config.json and .tar.gz layers
+func generateSym(img v1.Image, dstPath string) error {
+	// create symlink via ospkg.Symlink(target, symlink)
+	targetDir := path.Join(dstPath, "blobs/sha256")
+	// symlink for config.json
+	var config v1.Hash
+	var err error
+	if config, err = img.ConfigName(); err != nil {
+		return errors.Wrapf(err, "failed to get the config hex information for image")
+	}
+	configDir := path.Join(targetDir, config.Hex)
+	dstLink := path.Join(dstPath, "config.json")
+	if _, err := ospkg.Lstat(dstLink); err == nil {
+		ospkg.Remove(dstLink)
+	}
+	if err := ospkg.Symlink(configDir, dstLink); err != nil {
+		return errors.Wrapf(err, "failed to create symbolic link to config.json at %s", configDir)
+	}
+
+	// symlink for the layers
+	var layers []v1.Layer
+	if layers, err = img.Layers(); err != nil {
+		return errors.Wrapf(err, "failed to get the layers for image")
+	}
+	var layersDir string
+	for i, layer := range layers {
+		var layerDigest v1.Hash
+		if layerDigest, err = layer.Digest(); err != nil {
+			return errors.Wrapf(err, "failed to get layer digest")
+		}
+		layersDir = path.Join(targetDir, layerDigest.Hex)
+		out := strconv.Itoa(i) + ".tar.gz"
+		dstLink = path.Join(dstPath, out)
+		if _, err := ospkg.Lstat(dstLink); err == nil {
+			ospkg.Remove(dstLink)
+		}
+		if err = ospkg.Symlink(layersDir, dstLink); err != nil {
+			return errors.Wrapf(err, "failed to symbolic link to layer")
 		}
 	}
 

--- a/container/go/pkg/oci/BUILD
+++ b/container/go/pkg/oci/BUILD
@@ -34,13 +34,19 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["reader_test.go"],
+    srcs = [
+        "reader_test.go",
+        "write_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
         "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/layout:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/tarball:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1/types:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1/validate:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
     ],
 )
 


### PR DESCRIPTION
For compatibility with the current `container_import` rule, modifies the puller to generate symbolic links to the layers (named `0-n.tar.gz`) and the config as `config.json`.