### PR TITLE
Add symlink to puller's OCI intermediate format

### DIFF
--- a/container/go/cmd/puller/BUILD
+++ b/container/go/cmd/puller/BUILD
@@ -32,6 +32,7 @@ go_library(
     importpath = "github.com/bazelbuild/rules_docker",
     visibility = ["//visibility:private"],
     deps = [
+        "//container/go/pkg/compat:go_default_library",
         "//container/go/pkg/oci:go_default_library",
         "@com_github_google_go_containerregistry//pkg/authn:go_default_library",
         "@com_github_google_go_containerregistry//pkg/name:go_default_library",

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -103,7 +103,7 @@ func pull(imgName, dstPath, format, cachePath string, platform v1.Platform) erro
 
 	// Image file to write to disk, either a tarball, OCI layout, or both.
 	ociPath := path.Join(dstPath, compat.OCIImageDir)
-	tarPath := path.Join(dstPath, "image")
+	tarPath := path.Join(dstPath, compat.ImageDir)
 	switch format {
 	case "docker":
 		tag := getTag(ref)

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -108,17 +108,17 @@ func pull(imgName, dstPath, format, cachePath string, platform v1.Platform) erro
 
 	// Image file to write to disk, either a tarball, OCI layout, or both.
 	ociPath := path.Join(dstPath, ociImageDir)
-	tarPath := path.Join(dstPath, imageDir)
+	legacyPath := path.Join(dstPath, imageDir)
 	switch format {
 	case "docker":
 		tag := getTag(ref)
-		if err := tarball.WriteToFile(path.Join(tarPath, "image.tar"), tag, img); err != nil {
-			log.Fatalf("failed to write image tarball to %q: %v", tarPath, err)
+		if err := tarball.WriteToFile(path.Join(legacyPath, "image.tar"), tag, img); err != nil {
+			log.Fatalf("failed to write image tarball to %q: %v", legacyPath, err)
 		}
 	case "both":
 		tag := getTag(ref)
-		if err := tarball.WriteToFile(path.Join(tarPath, "image.tar"), tag, img); err != nil {
-			log.Fatalf("failed to write image tarball to %q: %v", tarPath, err)
+		if err := tarball.WriteToFile(path.Join(legacyPath, "image.tar"), tag, img); err != nil {
+			log.Fatalf("failed to write image tarball to %q: %v", legacyPath, err)
 		}
 		if err := oci.Write(img, ociPath); err != nil {
 			log.Fatalf("failed to write image to %q: %v", ociPath, err)
@@ -130,7 +130,7 @@ func pull(imgName, dstPath, format, cachePath string, platform v1.Platform) erro
 	}
 
 	if format != "docker" {
-		if err := compat.LegacyFromOCIImage(img, ociPath, tarPath); err != nil {
+		if err := compat.LegacyFromOCIImage(img, ociPath, legacyPath); err != nil {
 			return errors.Wrapf(err, "failed to generate symbolic links to pulled image at %s", dstPath)
 		}
 	}

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -102,17 +102,18 @@ func pull(imgName, dstPath, format, cachePath string, platform v1.Platform) erro
 	}
 
 	// Image file to write to disk, either a tarball, OCI layout, or both.
-	ociPath := path.Join(dstPath, "image-oci")
+	ociPath := path.Join(dstPath, compat.OCIImageDir)
+	tarPath := path.Join(dstPath, "image")
 	switch format {
 	case "docker":
 		tag := getTag(ref)
-		if err := tarball.WriteToFile(path.Join(ociPath, "image.tar"), tag, img); err != nil {
-			log.Fatalf("failed to write image tarball to %q: %v", ociPath, err)
+		if err := tarball.WriteToFile(path.Join(tarPath, "image.tar"), tag, img); err != nil {
+			log.Fatalf("failed to write image tarball to %q: %v", tarPath, err)
 		}
 	case "both":
 		tag := getTag(ref)
-		if err := tarball.WriteToFile(path.Join(ociPath, "image.tar"), tag, img); err != nil {
-			log.Fatalf("failed to write image tarball to %q: %v", ociPath, err)
+		if err := tarball.WriteToFile(path.Join(tarPath, "image.tar"), tag, img); err != nil {
+			log.Fatalf("failed to write image tarball to %q: %v", tarPath, err)
 		}
 		if err := oci.Write(img, ociPath); err != nil {
 			log.Fatalf("failed to write image to %q: %v", ociPath, err)
@@ -124,7 +125,7 @@ func pull(imgName, dstPath, format, cachePath string, platform v1.Platform) erro
 	}
 
 	if format != "docker" {
-		if err := compat.generateSymlinks(img, dstPath); err != nil {
+		if err := compat.LegacyFromOCIImage(img, dstPath); err != nil {
 			return errors.Wrapf(err, "failed to generate symbolic links to pulled image at %s", dstPath)
 		}
 	}

--- a/container/go/pkg/compat/BUILD
+++ b/container/go/pkg/compat/BUILD
@@ -1,3 +1,20 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ###
+# Build file for new utility package that handles conversions between the new OCI image layout
+# and the old intermediate format.
+
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(

--- a/container/go/pkg/compat/BUILD
+++ b/container/go/pkg/compat/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ociToLegacy.go"],
+    importpath = "github.com/bazelbuild/rules_docker/container/go/pkg/compat",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+    ],
+)

--- a/container/go/pkg/compat/ociToLegacy.go
+++ b/container/go/pkg/compat/ociToLegacy.go
@@ -1,0 +1,103 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////
+// This utility works with the new_container_pull and new_container_load targets
+// to generate the appropriate pseudo-intermediate format that is compatible
+// with container_import rule.
+
+package compat
+
+import (
+	ospkg "os"
+	"path"
+	"strconv"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/pkg/errors"
+)
+
+// Where the pulled OCI image artifacts are stored in.
+const artifactsDir = "image-oci"
+
+// Where the alias to the correct config.json and layers.tar.gz are found
+const symlinksDir = "image"
+
+// Extension for layers and config files that are made symlinks
+const targz = ".tar.gz"
+const configExt = "config.json"
+
+// generateSym creates predictable symbolic links to the config.json and layer .tar.gz files
+// so that they may be easily consumed by container_import targets.
+// The dstPath is the top level directory in which the puller will create symlinks inside an image/ directory
+// pointing to actual pulled OCI image artifacts in image-oci/ directory.
+func generateSymlinks(img v1.Image, dstPath string) error {
+	targetDir := path.Join(dstPath, artifactsDir, "blobs/sha256")
+	symlinkDir := path.Join(dstPath, symlinksDir)
+
+	// symlink for config.json, which is an expected attribute of container_import
+	// so we must rename the OCI layout's config file (named as the sha256 digest) under blobs/sha256
+	var config v1.Hash
+	var err error
+	if config, err = img.ConfigName(); err != nil {
+		return errors.Wrapf(err, "failed to get the config file's hash information for image")
+	}
+	configPath := path.Join(targetDir, config.Hex)
+	if _, err = ospkg.Stat(configPath); ospkg.IsNotExist(err) {
+		return errors.Wrapf(err, "config file does not exist at %s", configPath)
+	}
+
+	dstLink := path.Join(symlinkDir, configExt)
+	if _, err := ospkg.Lstat(dstLink); err == nil {
+		if err = ospkg.Remove(dstLink); err != nil {
+			return errors.Wrapf(err, "failed to remove the file at %s", dstLink)
+		}
+	}
+	if err := ospkg.Symlink(configPath, dstLink); err != nil {
+		return errors.Wrapf(err, "failed to create symbolic link from %s to config.json at %s", dstLink, configPath)
+	}
+
+	// symlink for the layers.
+	layers, err := img.Layers()
+	if err != nil {
+		return errors.Wrapf(err, "failed to initialize layers array, image does not have any layers")
+	}
+	if layers, err = img.Layers(); err != nil {
+		return errors.Wrapf(err, "failed to get the layers for image")
+	}
+	var layerPath string
+	for i, layer := range layers {
+		layerDigest, err := layer.Digest()
+		if err != nil {
+			return errors.Wrapf(err, "failed to fetch the layer's digest")
+		}
+
+		layerPath = path.Join(targetDir, layerDigest.Hex)
+		if _, err = ospkg.Stat(layerPath); ospkg.IsNotExist(err) {
+			return errors.Wrapf(err, "layer file does not exist at %s", layerPath)
+		}
+
+		out := strconv.Itoa(i) + targz
+		dstLink = path.Join(symlinkDir, out)
+		if _, err := ospkg.Lstat(dstLink); err == nil {
+			if err = ospkg.Remove(dstLink); err != nil {
+				return errors.Wrapf(err, "failed to remove the file at %s", dstLink)
+			}
+		}
+		if err = ospkg.Symlink(layerPath, dstLink); err != nil {
+			return errors.Wrapf(err, "failed to create symbolic link from %s to layer at %s", dstLink, layerPath)
+		}
+	}
+
+	return nil
+}

--- a/container/go/pkg/compat/ociToLegacy.go
+++ b/container/go/pkg/compat/ociToLegacy.go
@@ -31,7 +31,7 @@ import (
 const targzExt = ".tar.gz"
 const configExt = "config.json"
 
-// generateSymlinks safely generates a symbolic link from src to dst.
+// generateSymlinks safely generates a symbolic link at dst pointing to src.
 func generateSymlinks(src, dst string) error {
 	if _, err := ospkg.Stat(src); err != nil {
 		return errors.Wrapf(err, "source file does not exist at %s", src)
@@ -43,7 +43,7 @@ func generateSymlinks(src, dst string) error {
 		}
 	}
 	if err := ospkg.Symlink(src, dst); err != nil {
-		return errors.Wrapf(err, "failed to create symbolic link from %s to %s", src, dst)
+		return errors.Wrapf(err, "failed to create symbolic link from %s to %s", dst, src)
 	}
 
 	return nil
@@ -86,7 +86,7 @@ func LegacyFromOCIImage(img v1.Image, srcDir, dstDir string) error {
 		out := strconv.Itoa(i) + targzExt
 		dstLink = path.Join(dstDir, out)
 		if err = generateSymlinks(layerPath, dstLink); err != nil {
-			return errors.Wrap(err, "failed to generate layers symlinks")
+			return errors.Wrap(err, "failed to generate legacy symlink for layer %d with digest %s", i, layerDigest)
 		}
 	}
 

--- a/container/go/pkg/compat/ociToLegacy.go
+++ b/container/go/pkg/compat/ociToLegacy.go
@@ -86,7 +86,7 @@ func LegacyFromOCIImage(img v1.Image, srcDir, dstDir string) error {
 		out := strconv.Itoa(i) + targzExt
 		dstLink = path.Join(dstDir, out)
 		if err = generateSymlinks(layerPath, dstLink); err != nil {
-			return errors.Wrap(err, "failed to generate legacy symlink for layer %d with digest %s", i, layerDigest)
+			return errors.Wrapf(err, "failed to generate legacy symlink for layer %d with digest %s", i, layerDigest)
 		}
 	}
 

--- a/container/go/pkg/compat/ociToLegacy.go
+++ b/container/go/pkg/compat/ociToLegacy.go
@@ -27,11 +27,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Where the pulled OCI image artifacts are stored in.
+// Directory containing the pulled OCI image artifacts without modification.
 const OCIImageDir = "image-oci"
 
-// Where the alias to the correct config.json and layers.tar.gz are found
-const symlinksDir = "image"
+// Directory containing actual images (symlinks or image.tar) to be used by container_import as the image.
+const ImageDir = "image"
 
 // Extension for layers and config files that are made symlinks
 const targz = ".tar.gz"
@@ -43,7 +43,7 @@ const configExt = "config.json"
 // pointing to actual pulled OCI image artifacts in image-oci/ directory.
 func LegacyFromOCIImage(img v1.Image, dstPath string) error {
 	targetDir := path.Join(dstPath, OCIImageDir, "blobs/sha256")
-	symlinkDir := path.Join(dstPath, symlinksDir)
+	symlinkDir := path.Join(dstPath, ImageDir)
 
 	// symlink for config.json, which is an expected attribute of container_import
 	// so we must rename the OCI layout's config file (named as the sha256 digest) under blobs/sha256
@@ -52,7 +52,7 @@ func LegacyFromOCIImage(img v1.Image, dstPath string) error {
 		return errors.Wrap(err, "failed to get the config file's hash information for image")
 	}
 	configPath := path.Join(targetDir, config.Hex)
-	if _, err = ospkg.Stat(configPath); ospkg.IsNotExist(err) {
+	if _, err = ospkg.Stat(configPath); err != nil {
 		return errors.Wrapf(err, "config file does not exist at %s", configPath)
 	}
 

--- a/container/go/pkg/compat/ociToLegacy.go
+++ b/container/go/pkg/compat/ociToLegacy.go
@@ -14,7 +14,7 @@
 //////////////////////////////////////////////////////////////////////
 // This utility works with the new_container_pull and new_container_load targets
 // to generate the appropriate pseudo-intermediate format that is compatible
-// with container_import rule.
+// with the rules_docker container_import rule.
 
 package compat
 
@@ -31,6 +31,7 @@ import (
 const targzExt = ".tar.gz"
 const configExt = "config.json"
 
+// generateSymlinks safely generates a symbolic link from src to dst.
 func generateSymlinks(src, dst string) error {
 	if _, err := ospkg.Stat(dst); err != nil {
 		return errors.Wrapf(err, "layer file does not exist at %s", dst)
@@ -56,7 +57,7 @@ func LegacyFromOCIImage(img v1.Image, ociPath, symlinkDir string) error {
 	targetDir := path.Join(ociPath, "blobs/sha256")
 
 	// symlink for config.json, which is an expected attribute of container_import
-	// so we must rename the OCI layout's config file (named as the sha256 digest) under blobs/sha256
+	// so we must rename the OCI layout's config file (named as the sha256 digest) under blobs/sha256.
 	config, err := img.ConfigName()
 	if err != nil {
 		return errors.Wrap(err, "failed to get the config file's hash information for image")
@@ -67,7 +68,9 @@ func LegacyFromOCIImage(img v1.Image, ociPath, symlinkDir string) error {
 		return errors.Wrap(err, "failed to generate config.json symlinks")
 	}
 
-	// symlink for the layers.
+	// symlink for the tarred layers pulled into OCI layout to x.tar.gz, which is an expected
+	// attribute of container_import, so we must rename the layer current named after its sha256
+	// digest under blobs/sha256.
 	layers, err := img.Layers()
 	if err != nil {
 		return errors.Wrap(err, "unable to get layers from image")


### PR DESCRIPTION
For compatibility with the current `container_import` rule, modifies the puller to generate symbolic links to the layers (named `0-n.tar.gz`) and the config as `config.json`.