### PR TITLE
Add bzl_library for lang/image.bzl

### DIFF
--- a/lang/BUILD
+++ b/lang/BUILD
@@ -11,6 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
+
+bzl_library(
+    name = "image",
+    srcs = ["image.bzl"],
+    deps = [
+        "//container",
+        "//container:layer_tools",
+        "//container:providers",
+        "@bazel_skylib//lib:dicts",
+    ],
+)


### PR DESCRIPTION
Stardoc currently requires all dependencies to also have a bzl_library, and it seems lang/image.bzl got missed when the rest of the repo has them, from what I can tell.