### PR TITLE
Refactor new_container_pull to generate fully backward compatible format

### DIFF
--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -16,7 +16,6 @@
 // For the format specification, if the format is:
 // 		1. 'docker': image is pulled as tarball and may be used with `docker load -i`.
 // 		2. 'oci' (default): image will be pulled as a collection of files in OCI layout to directory.
-// 		3. 'both': both formats of image are pulled.
 // Unlike regular docker pull, the format this package uses is proprietary.
 
 package main
@@ -31,8 +30,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/bazelbuild/rules_docker/container/go/pkg/oci"
 	"github.com/bazelbuild/rules_docker/container/go/pkg/compat"
+	"github.com/bazelbuild/rules_docker/container/go/pkg/oci"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"

--- a/container/go/pkg/compat/BUILD
+++ b/container/go/pkg/compat/BUILD
@@ -29,6 +29,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1/layout:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1/partial:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1/types:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1/validate:go_default_library",

--- a/container/go/pkg/compat/ociToLegacy.go
+++ b/container/go/pkg/compat/ociToLegacy.go
@@ -104,7 +104,7 @@ func LegacyFromOCIImage(img v1.Image, srcDir, dstDir string) error {
 		return errors.Wrap(err, "unable to get manifest from image index")
 	}
 	if len(manifest.Manifests) != 1 {
-		log.Fatalf("Image index read from %s had unexpected number of manifests: got %d want 1.", srcDir, len(manifest.Manifests))
+		log.Fatalf("Image index read from %s had unexpected number of manifests: got %d, want 1", srcDir, len(manifest.Manifests))
 	}
 	manifestHex := manifest.Manifests[0].Digest.Hex
 	dstLink = path.Join(dstDir, legacyManifestFile)

--- a/container/go/pkg/compat/ociToLegacy.go
+++ b/container/go/pkg/compat/ociToLegacy.go
@@ -103,7 +103,7 @@ func LegacyFromOCIImage(img v1.Image, srcDir, dstDir string) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to get manifest from image index")
 	}
-	if len(manifest.Manifests) > 1 {
+	if len(manifest.Manifests) != 1 {
 		log.Fatal("error: image contains more than one manifest")
 	}
 	manifestHex := manifest.Manifests[0].Digest.Hex

--- a/container/go/pkg/compat/ociToLegacy.go
+++ b/container/go/pkg/compat/ociToLegacy.go
@@ -30,6 +30,7 @@ import (
 // Extension for layers and config files that are made symlinks
 const targzExt = ".tar.gz"
 const configExt = "config.json"
+const manifestExt = "manifest.json"
 
 // generateSymlinks safely generates a symbolic link at dst pointing to src.
 func generateSymlinks(src, dst string) error {
@@ -80,7 +81,7 @@ func LegacyFromOCIImage(img v1.Image, srcDir, dstDir string) error {
 		layerDigest, err := layer.Digest()
 		if err != nil {
 			return errors.Wrap(err, "failed to fetch the layer's digest")
-	}
+		}
 
 		layerPath = path.Join(targetDir, layerDigest.Hex)
 		out := strconv.Itoa(i) + targzExt

--- a/container/go/pkg/compat/ociToLegacy.go
+++ b/container/go/pkg/compat/ociToLegacy.go
@@ -104,7 +104,7 @@ func LegacyFromOCIImage(img v1.Image, srcDir, dstDir string) error {
 		return errors.Wrap(err, "unable to get manifest from image index")
 	}
 	if len(manifest.Manifests) != 1 {
-		log.Fatal("error: image contains more than one manifest")
+		log.Fatalf("Image index read from %s had unexpected number of manifests: got %d want 1.", srcDir, len(manifest.Manifests))
 	}
 	manifestHex := manifest.Manifests[0].Digest.Hex
 	dstLink = path.Join(dstDir, legacyManifestFile)


### PR DESCRIPTION
Added manifest.json symlink to fully parallel the legacy format.