### PR TITLE
migrating security check to rules_docker

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -70,6 +70,9 @@ platforms:
     build_targets:
     - "--"
     - "..."
+    # tests/docker/security require gcloud setup to access asci-toolchains images
+    - "-//tests/docker/security/..."
+    # contrib targets are not compatible with remote exec
     - "-//tests/contrib:derivative_with_volume_repro_test"
     - "-//tests/contrib:set_cmd_repro_test"
     build_flags:
@@ -87,6 +90,9 @@ platforms:
     - "--"
     - "//:structure_test_at_workspace_root"
     - "//tests/..."
+    # tests/docker/security require gcloud setup to access asci-toolchains images
+    - "-//tests/docker/security/..."
+    # contrib tests are not compatible with remote exec
     - "-//tests/contrib:derivative_with_volume_repro_test"
     - "-//tests/contrib:set_cmd_repro_test"
     - "-//tests/contrib:test_compare_ids_test_diff_ids_fails"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -16,6 +16,8 @@ platforms:
     - "-//tests/container/..."
     - "-//:structure_test_at_workspace_root"
     # Disabled tests that do not run in BuildKite CI.
+    - "-//tests/docker/security/..."
+    # tests/docker/security require gcloud
     - "-//tests/contrib:test_compare_ids_test_diff_ids_fails"
     - "-//tests/contrib:test_compare_ids_test_invalid_tar_fails"
     - "-//tests/contrib:test_compare_ids_test_invalid_tar_fails_multi_regex"
@@ -35,6 +37,8 @@ platforms:
     - "-//tests/container/..."
     - "-//:structure_test_at_workspace_root"
     # Disabled tests that do not run in BuildKite CI.
+    - "-//tests/docker/security/..."
+    # tests/docker/security require gcloud
     - "-//tests/contrib:test_compare_ids_test_diff_ids_fails"
     - "-//tests/contrib:test_compare_ids_test_invalid_tar_fails"
     - "-//tests/contrib:test_compare_ids_test_invalid_tar_fails_multi_regex"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -424,11 +424,11 @@ register_toolchains("//toolchains/python:container_py_toolchain")
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "28cb3666da80fbc62d4c46814f5468dd5d0b59f9064c0b933eee3140d706d330",
-    strip_prefix = "bazel-toolchains-0.27.1",
+    sha256 = "68e7678473090542e679ce7e6aa8a3ba5669577dede2b404f9865d556bd99f10",
+    strip_prefix = "bazel-toolchains-0.28.0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.27.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/0.27.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.28.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/0.28.0.tar.gz",
     ],
 )
 
@@ -436,6 +436,10 @@ load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
 
 rbe_autoconfig(
     name = "buildkite_config",
+    base_container_digest = "sha256:94d7d8552902d228c32c8c148cc13f0effc2b4837757a6e95b73fdc5c5e4b07b",
+    digest = "sha256: 8e1d298811a616c33eda221044bfc00c44c8ab48589cef5d206aa630d95c769f",
+    registry = "gcr.io",
+    repository = "asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud",
 )
 
 # gazelle:repo bazel_gazelle

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -436,10 +436,6 @@ load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
 
 rbe_autoconfig(
     name = "buildkite_config",
-    base_container_digest = "sha256:94d7d8552902d228c32c8c148cc13f0effc2b4837757a6e95b73fdc5c5e4b07b",
-    digest = "sha256: 8e1d298811a616c33eda221044bfc00c44c8ab48589cef5d206aa630d95c769f",
-    registry = "gcr.io",
-    repository = "asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud",
 )
 
 # gazelle:repo bazel_gazelle

--- a/docker/security/BUILD
+++ b/docker/security/BUILD
@@ -1,0 +1,41 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@pip_deps//:requirements.bzl", "requirement")
+load("@subpar//:subpar.bzl", "par_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "security_check_whitelist.json",
+])
+
+par_binary(
+    name = "security_check",
+    srcs = ["security_check.py"],
+    main = "security_check.py",
+    python_version = "PY2",
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("PyYaml"),
+    ],
+)
+
+bzl_library(
+    name = "security_check_lib",
+    srcs = [
+        "security_check.bzl",
+    ],
+)

--- a/docker/security/security_check.bzl
+++ b/docker/security/security_check.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+""" Rule for checking vulnerabilities in a given image. """
+
 def _impl(ctx):
     _security_check = ctx.executable._security_check
     output_yaml = ctx.outputs.yaml

--- a/docker/security/security_check.bzl
+++ b/docker/security/security_check.bzl
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 The Bazel Authors. All rights reserved.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/security/security_check.bzl
+++ b/docker/security/security_check.bzl
@@ -1,0 +1,84 @@
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _impl(ctx):
+    _security_check = ctx.executable._security_check
+    output_yaml = ctx.outputs.yaml
+    args = [
+        ctx.attr.image,
+        "--output-yaml",
+        ctx.outputs.yaml.path,
+        "--severity",
+        ctx.attr.severity,
+    ]
+    if ctx.attr.whitelist != None:
+        files = ctx.attr.whitelist.files.to_list()
+        if len(files) != 1:
+            fail(
+                "Got {} files in label {} given to {}. Expected exactly 1.".format(
+                    len(files),
+                    ctx.attr.whitelist.label,
+                    ctx.label,
+                ),
+            )
+        args.append("--whitelist-file")
+        args.append(files[0].path)
+    ctx.actions.run(
+        executable = ctx.executable._security_check,
+        arguments = args,
+        outputs = [ctx.outputs.yaml],
+        mnemonic = "ImageSecurityCheck",
+        use_default_shell_env = True,
+        execution_requirements = {
+            # This is needed because security_check.py invokes gcloud which
+            # writes/reads gcloud configuration files under $HOME/.config or
+            # the directory indicated in the environment variable
+            # CLOUDSDK_CONFIG if set.
+            "no-sandbox": "True",
+        },
+    )
+
+# Run the security_check.py script on the given docker image to generate a
+# YAML output file with information about the types of vulnerabilities
+# discovered in the given image.
+security_check = rule(
+    implementation = _impl,
+    attrs = {
+        "image": attr.string(
+            mandatory = True,
+            doc = "Name of the remote image to run the security check on.",
+        ),
+        "severity": attr.string(
+            doc = "The minimum severity to filter on. " +
+                  "Options: LOW, MEDIUM, HIGH, CRITICAL",
+            default = "MEDIUM",
+            values = ["LOW", "MEDIUM", "HIGH", "CRITICAL"],
+        ),
+        "whitelist": attr.label(
+            doc = "The path to the whitelist json file",
+            default = Label("@io_bazel_rules_docker//docker/security:security_check_whitelist.json"),
+            allow_single_file = True,
+        ),
+        # The security checker python executable.
+        "_security_check": attr.label(
+            default = Label("@io_bazel_rules_docker//docker/security:security_check"),
+            cfg = "host",
+            executable = True,
+            allow_files = True,
+        ),
+    },
+    outputs = {
+        "yaml": "%{name}.yaml",
+    },
+)

--- a/docker/security/security_check.py
+++ b/docker/security/security_check.py
@@ -1,0 +1,330 @@
+"""Checks the specified image for security vulnerabilities."""
+
+import argparse
+import json
+import subprocess
+import sys
+import logging
+import yaml
+
+import distutils.version as ver
+
+
+# Severities
+_LOW = 'LOW'
+_MEDIUM = 'MEDIUM'
+_HIGH = 'HIGH'
+_CRITICAL = 'CRITICAL'
+
+_SEV_MAP = {
+    _LOW: 0,
+    _MEDIUM: 1,
+    _HIGH: 2,
+    _CRITICAL: 3,
+}
+
+# Drydock only scans the main repository, but none of the mirrors.
+# Swap out any mirrors for gcr.io when scanning.
+_CANONICAL_IMAGE_REPOSITORY = {
+    'l.gcr.io/google': 'launcher.gcr.io/google',
+    'eu.gcr.io/google-appengine': 'gcr.io/google-appengine',
+    'us.gcr.io/google-appengine': 'gcr.io/google-appengine',
+    'asia.gcr.io/google-appengine': 'gcr.io/google-appengine'
+}
+
+REPOSITORIES_TO_IGNORE = {
+    'us-mirror.gcr.io/library'
+}
+
+
+def gcloud_path():
+  """Returns the path to the gcloud command. Requires gcloud to be on system PATH"""
+  return 'gcloud'
+
+
+def _sub_image(full_image):
+  repo, image = full_image.rsplit('/', 1)
+  if repo in REPOSITORIES_TO_IGNORE:
+    logging.info('Ignoring repository %s', repo)
+    return None
+  repo = _CANONICAL_IMAGE_REPOSITORY.get(repo, repo)
+  new_image = '/'.join((repo, image))
+  if new_image != full_image:
+    logging.info('Checking %s instead of %s', new_image, full_image)
+  return new_image
+
+
+def _run_gcloud(cmd):
+  full_cmd = [gcloud_path(), 'alpha', 'container', 'images',
+              '--format=json'] + cmd
+  output = subprocess.check_output(full_cmd)
+  return json.loads(output)
+
+
+def _find_base_image(image):
+  """Finds the base image of the given image.
+
+  Args:
+    image: The name of the image to find the base of.
+
+  Returns:
+    The name of the base image if it exists, otherwise None.
+  """
+
+  parsed = _run_gcloud(['describe', '--show-image-basis', image])
+  img = parsed['image_basis_summary'].get('base_images')
+
+  if not img:
+    return None
+
+  base_img_url = img[0]['derivedImage']['baseResourceUrl']
+  base_img = base_img_url[len('https://'):]
+  return _sub_image(base_img)
+
+
+def _check_for_vulnz(image, severity, whitelist):
+  """Checks drydock for image vulnerabilities.
+
+  Args:
+    image: full name of the docker image
+    severity: the severity of vulnerability to trigger failure
+    whitelist: list of CVEs to ignore for this test
+
+  Returns:
+    Map of vulnerabilities, if present.
+  """
+
+  logging.info('CHECKING %s', image)
+  unpatched = _check_image(image, severity, whitelist)
+  if not unpatched:
+    return unpatched
+
+  base_image = _find_base_image(image)
+  base_image = None
+  base_unpatched = {}
+  if base_image:
+    base_unpatched = _check_image(base_image, severity, whitelist)
+  else:
+    logging.info('Could not find base image for %s', image)
+
+  count = 0
+  for k, vuln in unpatched.items():
+    if k not in base_unpatched.keys():
+      count += 1
+      logging.info(format_vuln(vuln))
+    else:
+      logging.info('Vulnerability %s exists in the base '
+                   'image. Skipping.', k)
+
+  if count > 0:
+    logging.info('Found %s unpatched vulnerabilities in %s. Run '
+                 '[gcloud alpha container images describe %s] '
+                 'to see the full list.', count, image, image)
+
+    return unpatched
+
+
+def format_vuln(vuln):
+  """Formats a vulnerability dictionary into a human-readable string.
+
+  Args:
+    vuln: vulnerability dict returned from drydock.
+
+  Returns:
+    Human readable string.
+  """
+
+  packages = ''
+  fixed_packages = ''
+
+  for v in vuln['vulnerabilityDetails']['packageIssue']:
+    packages = ' '.join([packages, '{0} ({1})'.format(
+        v['affectedLocation']['package'],
+        _get_version_number(v['affectedLocation']['version']))])
+
+    fixed_packages = ' '.join([fixed_packages, '{0} ({1})'.format(
+        v['fixedLocation']['package'],
+        _get_version_number(v['fixedLocation']['version']))])
+
+  return """
+Vulnerability found.
+CVE: {0}
+SEVERITY: {1}
+PACKAGES: {2}
+FIXED PACKAGES: {3}
+  """.format(
+      vuln['noteName'],
+      vuln['vulnerabilityDetails']['severity'],
+      packages,
+      fixed_packages)
+
+
+def _check_image(image, severity, whitelist):
+  """Checks drydock for image vulnerabilities.
+
+  Args:
+    image: full name of the docker image
+    severity: the severity of vulnerability to trigger failure
+    whitelist: list of CVEs to ignore for this test
+
+  Returns:
+    Map of vulnerabilities, if present.
+  """
+
+  parsed = _run_gcloud(['describe', image, '--show-all-metadata'])
+  unpatched = {}
+
+  vuln_analysis = parsed.get('package_vulnerability_summary', {})
+
+  # If there are no fixed vulnz, we can immediately quit.
+  total_vulnz = vuln_analysis.get('total_vulnerability_found', 0)
+  unfixed_vulnz = vuln_analysis.get('not_fixed_vulnerability_count', 0)
+  if  total_vulnz <= unfixed_vulnz:
+    return unpatched
+
+  severities = _get_relevant_severities(severity)
+  vulnz = vuln_analysis['vulnerabilities']
+
+  for s in severities:
+    for v in vulnz.get(s, []):
+      vuln = v['vulnerabilityDetails']
+      if not _check_vuln_is_valid(vuln):
+        continue
+
+      if v['noteName'] in whitelist:
+        continue
+
+      unpatched[v['noteName']] = v
+
+  return unpatched
+
+
+def _get_relevant_severities(severity):
+  return [k for k, v in _SEV_MAP.iteritems()
+          if v >= _SEV_MAP.get(severity, 1)]
+
+
+def _check_vuln_is_valid(vuln):
+  """Checks whether the given vulnerability is valid.
+
+  Args:
+    vuln: The vulnerability json.
+
+  Returns:
+    boolean, whether it is valid.
+  """
+  for pkg in vuln.get('packageIssue', []):
+
+    affected_location = pkg.get('affectedLocation')
+    fixed_location = pkg.get('fixedLocation')
+
+    if affected_location and fixed_location:
+      # First, make sure the vulnerability is patched
+      if not fixed_location['version'].get('name'):
+        return False
+
+      # Make sure the fixed version is later than the affected version
+      affected_version = _get_version_number(affected_location['version'])
+      fixed_version = _get_version_number(fixed_location['version'])
+
+      if not fixed_version:
+        return False
+
+      if ver.LooseVersion(fixed_version) > ver.LooseVersion(affected_version):
+        return True
+
+  logging.info('Vulnerability %s is already fixed. '
+               'The affected package: %s is greater '
+               'than the fixed package: %s',
+               vuln.get('vulnerability'),
+               affected_version,
+               fixed_version)
+  return False
+
+
+def _get_version_number(version_obj):
+  # Only name is required for a version, epoch and revision are both optional.
+  epoch = version_obj.get('epoch', '')
+  name = version_obj.get('name', '')
+  revision = version_obj.get('revision', '')
+  delimiter1 = ':' if epoch else ''
+  delimiter2 = '-' if revision else ''
+
+  return ''.join([str(epoch), delimiter1, name, delimiter2, str(revision)])
+
+def _generate_yaml_output(output_yaml, vulnerabilities):
+  """Generate a YAML file mapping the key "tags" to the list of types of
+  vulnerabilities found.
+
+  Args:
+    output_yaml: Path to the output YAML file to generate.
+    vulnerabilities: A dictionary mapping the name of the CVE entry to details
+                     about the vulnerability.
+  """
+  tags = set()
+  for v in vulnerabilities.itervalues():
+    details = v["vulnerabilityDetails"]
+    # The service that consumes the metadata expects the tags as follows:
+    # LOW -> cveLow
+    # MEDIUM -> sveMedium
+    # and so on...
+    sev = str(details['effectiveSeverity'])
+    tags.add("cve{}".format(sev.lower().capitalize()))
+  result = {"tags": list(tags)}
+  logging.info("Creating YAML output {}".format(output_yaml))
+  with open(output_yaml, "w") as ofp:
+    ofp.write(yaml.dump(result))
+
+def security_check(image, severity=_MEDIUM, whitelist_file='whitelist.json',
+                   output_yaml=None):
+  """Main security check function.
+
+  Args:
+    image: full name of the docker image
+    severity: the severity of vulnerability to trigger failure
+    whitelist_file: file with list of whitelisted CVE
+    output_yaml: Output file which will be populated with a list of types of
+                 vulnerability that exist for the given image.
+
+  Returns:
+    Map of vulnerabilities, if present.
+  """
+
+  try:
+    logging.info("Loading whitelist JSON {}".format(whitelist_file))
+    whitelist = json.load(open(whitelist_file, 'r'))
+  except IOError:
+    whitelist = []
+  logging.info('whitelist=%s', whitelist)
+
+  result = _check_for_vulnz(_sub_image(image), severity, whitelist)
+
+  if output_yaml:
+    logging.info("Creating YAML output {}".format(output_yaml))
+    _generate_yaml_output(output_yaml, result)
+  return result
+
+
+def _main():
+  """Main."""
+  logging.basicConfig(level=logging.INFO)
+  parser = argparse.ArgumentParser()
+  parser.add_argument('image', help='The image to test')
+  parser.add_argument('--severity',
+                      choices=[_LOW, _MEDIUM, _HIGH, _CRITICAL],
+                      default=_MEDIUM,
+                      help='The minimum severity to filter on.')
+  parser.add_argument('--whitelist-file', dest='whitelist',
+                      help='The path to the whitelist json file',
+                      default='whitelist.json')
+  parser.add_argument('--output-yaml', dest='output_yaml',
+                      help='The path to the output YAML file to'+\
+                      ' generate with a list of tags indicating the types of'+\
+                      ' vulnerability fixes available for the given image.')
+  args = parser.parse_args()
+  security_check(args.image, args.severity, args.whitelist,
+                            args.output_yaml)
+
+
+if __name__ == '__main__':
+  sys.exit(_main())

--- a/docker/security/security_check.py
+++ b/docker/security/security_check.py
@@ -1,3 +1,17 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Checks the specified image for security vulnerabilities."""
 
 import argparse

--- a/docker/security/security_check_whitelist.json
+++ b/docker/security/security_check_whitelist.json
@@ -1,0 +1,7 @@
+[
+  "projects/goog-vulnz/notes/CVE-2012-1148",
+  "projects/goog-vulnz/notes/CVE-2012-0876",
+  "projects/goog-vulnz/notes/CVE-2016-8568",
+  "projects/goog-vulnz/notes/CVE-2016-8569"
+]
+

--- a/repositories/requirements-pip.txt
+++ b/repositories/requirements-pip.txt
@@ -1,6 +1,6 @@
 # required by container_image py tests
 six==1.11.0
 addict==2.1.2
-# required by package manager tests (due to dep on ubuntu1604 base)
+# required by docker/security & deps
 PyYAML==5.1
 

--- a/tests/docker/security/BUILD
+++ b/tests/docker/security/BUILD
@@ -20,7 +20,7 @@ load("//docker/security:security_check.bzl", "security_check")
 
 security_check(
     name = "security_check",
-    image = "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest",
+    image = "gcr.io/asci-toolchain/rbe-ubuntu16_04:latest",
 )
 
 file_test(
@@ -31,7 +31,7 @@ file_test(
 
 security_check(
     name = "security_check_expect_cve",
-    image = "gcr.io/gcp-runtimes/ubuntu_16_0_4@sha256:ea9adca359f7f33afb6a1e0979d3f0baad15c7b765235c9b6e076f92e6a40837",
+    image = "gcr.io/asci-toolchain/rbe-ubuntu16_04@sha256:1e95064e2b9b4807ddb39a9d56ebb275b126faa592d4c0b8f68dd0f16f751df1",
 )
 
 # If this test fails it might be the case that the vulnerability info for an

--- a/tests/docker/security/BUILD
+++ b/tests/docker/security/BUILD
@@ -16,7 +16,6 @@ load(
     "@bazel_tools//tools/build_rules:test_rules.bzl",
     "file_test",
 )
-
 load("//docker/security:security_check.bzl", "security_check")
 
 security_check(
@@ -26,8 +25,8 @@ security_check(
 
 file_test(
     name = "security_check_test",
-    regexp = "tags:",
     file = ":security_check.yaml",
+    regexp = "tags:",
 )
 
 security_check(
@@ -40,7 +39,6 @@ security_check(
 # @nlopezgi to fix.
 file_test(
     name = "security_check_expect_cve_test",
-    regexp = "cveMedium",
     file = ":security_check_expect_cve.yaml",
+    regexp = "cveMedium",
 )
-

--- a/tests/docker/security/BUILD
+++ b/tests/docker/security/BUILD
@@ -1,0 +1,46 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@bazel_tools//tools/build_rules:test_rules.bzl",
+    "file_test",
+)
+
+load("//docker/security:security_check.bzl", "security_check")
+
+security_check(
+    name = "security_check",
+    image = "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest",
+)
+
+file_test(
+    name = "security_check_test",
+    regexp = "tags:",
+    file = ":security_check.yaml",
+)
+
+security_check(
+    name = "security_check_expect_cve",
+    image = "gcr.io/gcp-runtimes/ubuntu_16_0_4@sha256:ea9adca359f7f33afb6a1e0979d3f0baad15c7b765235c9b6e076f92e6a40837",
+)
+
+# If this test fails it might be the case that the vulnerability info for an
+# old image is no longer available. Remove it if so and mark a TODO for
+# @nlopezgi to fix.
+file_test(
+    name = "security_check_expect_cve_test",
+    regexp = "cveMedium",
+    file = ":security_check_expect_cve.yaml",
+)
+

--- a/tests/docker/security/cloudbuild.yaml
+++ b/tests/docker/security/cloudbuild.yaml
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Tests that verify that download_pkgs targets can be declared
-# in the top level BUILD file.
+# Tests that verify the security_check examples of rules_docker.
+# Needs to run on GCB as requires access to asci-toolchains images
 
 steps:
-  # Test the download_pkgs examples.
-  - name: "l.gcr.io/google/bazel"
-    args: ["test", "//..."]
-    dir: "testing/download_pkgs_at_root"
+  # Test the security_check examples.
+  - name: "gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud"
+    args: ["bazel","test", "//tests/docker/security/..."]


### PR DESCRIPTION
Continuing migration of all rules needed to build deterministic base containers to rules_docker repo.
This PR migrates a security_check that is still EXPERIMENTAL.
Security check requires gcloud to properly run.
This PR is only migrating existing code, will improve documentation (particularly as related to requirements and expectations of the checker) in upcoming PR

NOTE: PR is not yet passing CI, will need to resolve issue related to permissions and re-run.