### PR TITLE
Use Python2 in image_util.sh

### DIFF
--- a/docker/util/image_util.sh
+++ b/docker/util/image_util.sh
@@ -8,7 +8,7 @@ reset_cmd() {
     local old_cmd
     # docker inspect input cannot be piped into docker commit directly, we need to JSON format it.
     old_cmd=$(docker inspect -f "{{range .Config.Cmd}}{{.}} {{end}}" "${original_image_name}")
-    fmt_cmd=$(echo "$old_cmd" | python -c "import sys,json; print json.dumps(sys.stdin.read().strip().split())")
+    fmt_cmd=$(echo "$old_cmd" | python2 -c "import sys,json; print json.dumps(sys.stdin.read().strip().split())")
 
     # If CMD wasn't set, set it to a sane default.
     if [ "$fmt_cmd" == "" ] || [ "$fmt_cmd" == "[]" ];


### PR DESCRIPTION
While `config_stripper` is wrapped as a Bazel binary and is ran with the proper toolchain, image_util.sh isn't, and is calling an inline Python script to format a command. The script isn't Python 3 compatible, so should be calling the `python2` binary.