### PR TITLE
Enable container_repro_test for toolchain_container installing deb packages

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -110,6 +110,7 @@ platforms:
     - "-//tests/docker/security/..."
     # contrib tests are not compatible with remote exec
     - "-//tests/contrib:derivative_with_volume_repro_test"
+    - "-//tests/contrib:gcloud_img_repro_test"
     - "-//tests/contrib:set_cmd_repro_test"
     - "-//tests/contrib:test_compare_ids_test_diff_ids_fails"
     - "-//tests/contrib:test_compare_ids_test_invalid_tar_fails"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,6 +15,7 @@ platforms:
     # Disabled tests that do not run in BuildKite CI.
     - "-//tests/docker/security/..."
     # tests/docker/security require gcloud
+    - "-//tests/contrib:gcloud_img_repro_test"
     - "-//tests/contrib:test_compare_ids_test_diff_ids_fails"
     - "-//tests/contrib:test_compare_ids_test_invalid_tar_fails"
     - "-//tests/contrib:test_compare_ids_test_invalid_tar_fails_multi_regex"
@@ -34,6 +35,7 @@ platforms:
     # Disabled tests that do not run in BuildKite CI.
     - "-//tests/docker/security/..."
     # tests/docker/security require gcloud
+    - "-//tests/contrib:gcloud_img_repro_test"
     - "-//tests/contrib:test_compare_ids_test_diff_ids_fails"
     - "-//tests/contrib:test_compare_ids_test_invalid_tar_fails"
     - "-//tests/contrib:test_compare_ids_test_invalid_tar_fails_multi_regex"
@@ -92,6 +94,7 @@ platforms:
     - "-//tests/docker/security/..."
     # contrib targets are not compatible with remote exec
     - "-//tests/contrib:derivative_with_volume_repro_test"
+    - "-//tests/contrib:gcloud_img_repro_test"
     - "-//tests/contrib:set_cmd_repro_test"
     build_flags:
     - "--extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/latest:toolchain_docker"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -142,6 +142,13 @@ http_file(
     urls = ["http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xEB9B1D8886F44E2A"],
 )
 
+http_file(
+    name = "gcloud_gpg",
+    downloaded_file_path = "gcloud_gpg",
+    sha256 = "1fe629470162c72777c1ed5e5b0f392acf403cf6a374cb229cf76109b5c90ed5",
+    urls = ["https://packages.cloud.google.com/apt/doc/apt-key.gpg"],
+)
+
 container_load(
     name = "pause_tar",
     file = "//testdata:pause.tar",

--- a/contrib/cmp_images.sh.tpl
+++ b/contrib/cmp_images.sh.tpl
@@ -30,15 +30,18 @@ function cmp_sha_files() {
   local content_type="${3}"
 
   local diff_ret=0
-  diff $file1 $file2 || diff_ret=$?
+  diff $file1 $file2 &>/dev/null || diff_ret=$?
   echo === Comparing image "${content_type}"s ===
   if [ $diff_ret = 0 ]; then
   	echo Both images have the same SHA256 "${content_type}": "$(<$file1)"
-  else
+  elif [ $diff_ret = 1 ]; then
   	echo Images have different SHA256 "${content_type}"s
   	echo First image "${content_type}": "$(<$file1)"
   	echo Reproduced image "${content_type}": "$(<$file2)"
     imgs_differ=true
+  else
+    echo diff command exited with error.
+    exit 1
   fi
 }
 

--- a/contrib/repro_test.bzl
+++ b/contrib/repro_test.bzl
@@ -135,6 +135,7 @@ def _impl(ctx):
     # Commands to build the image targets and copy the files required for image
     # comparison to a known location in the container (being 'extract_path').
     cd_cmd = ["cd \$(cat /%s)" % proj_root.basename]
+
     # Output base needs to be specified in order for Bazel to be able to access
     # produced files stored in the host and mount into other container within a
     # running container if needed (e.g. installing debian packages with

--- a/tests/contrib/BUILD
+++ b/tests/contrib/BUILD
@@ -170,21 +170,21 @@ docker_push(
 
 toolchain_container(
     name = "gcloud_img",
-    # additional_repos = [
-    #     "deb http://packages.cloud.google.com/apt cloud-sdk-xenial main",
-    # ],
+    additional_repos = [
+        "deb http://packages.cloud.google.com/apt cloud-sdk-xenial main",
+    ],
     base = "@official_xenial//image",
-    # keys = ["@gcloud_gpg//file"],
+    keys = ["@gcloud_gpg//file"],
     packages = [
         "curl",
-        # "g++",
-        # "gcc",
-        # "git",
-        # "google-cloud-sdk",
-        # "python-dev",
-        # "unzip",
-        # "wget",
-        # "zip",
+        "g++",
+        "gcc",
+        "git",
+        "google-cloud-sdk",
+        "python-dev",
+        "unzip",
+        "wget",
+        "zip",
     ],
 )
 

--- a/tests/contrib/BUILD
+++ b/tests/contrib/BUILD
@@ -23,6 +23,7 @@ load("//contrib:push-all.bzl", "docker_push")
 load("//contrib:rename_image.bzl", "rename_image")
 load("//contrib:repro_test.bzl", "container_repro_test")
 load("//contrib:test.bzl", "container_test")
+load("//docker/toolchain_container:toolchain_container.bzl", "toolchain_container")
 load("//tests/contrib:compare_ids_fail_test.bzl", "compare_ids_fail_test")
 
 sh_test(
@@ -167,6 +168,26 @@ docker_push(
     "kaniko_debug",
 ]]
 
+toolchain_container(
+    name = "gcloud_img",
+    additional_repos = [
+        "deb http://packages.cloud.google.com/apt cloud-sdk-xenial main",
+    ],
+    base = "@official_xenial//image",
+    keys = ["@gcloud_gpg//file"],
+    packages = [
+        "curl",
+        "g++",
+        "gcc",
+        "google-cloud-sdk",
+        "git",
+        "python-dev",
+        "unzip",
+        "wget",
+        "zip",
+    ],
+)
+
 container_repro_test(
     name = "set_cmd_repro_test",
     image = "//tests/container:set_cmd",
@@ -186,5 +207,11 @@ container_repro_test(
         "node",
     ],
     image = "//testdata:derivative_with_volume",
+    workspace_file = "//:WORKSPACE",
+)
+
+container_repro_test(
+    name = "gcloud_img_repro_test",
+    image = ":gcloud_img",
     workspace_file = "//:WORKSPACE",
 )

--- a/tests/contrib/BUILD
+++ b/tests/contrib/BUILD
@@ -170,21 +170,21 @@ docker_push(
 
 toolchain_container(
     name = "gcloud_img",
-    additional_repos = [
-        "deb http://packages.cloud.google.com/apt cloud-sdk-xenial main",
-    ],
+    # additional_repos = [
+    #     "deb http://packages.cloud.google.com/apt cloud-sdk-xenial main",
+    # ],
     base = "@official_xenial//image",
-    keys = ["@gcloud_gpg//file"],
+    # keys = ["@gcloud_gpg//file"],
     packages = [
         "curl",
-        "g++",
-        "gcc",
-        "google-cloud-sdk",
-        "git",
-        "python-dev",
-        "unzip",
-        "wget",
-        "zip",
+        # "g++",
+        # "gcc",
+        # "git",
+        # "google-cloud-sdk",
+        # "python-dev",
+        # "unzip",
+        # "wget",
+        # "zip",
     ],
 )
 

--- a/tests/contrib/repro_imgs.yaml
+++ b/tests/contrib/repro_imgs.yaml
@@ -1,0 +1,23 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests that verify image reproducibility.
+
+timeout: 1200s
+options:
+    machineType: "N1_HIGHCPU_32"
+
+steps:
+  - name: "l.gcr.io/google/bazel"
+    args: ["test", "//tests/contrib:gcloud_img_repro_test"]


### PR DESCRIPTION
In order to build a `toolchain_container` target that installs deb packages inside a container (which is what container_repro_test does) we need:
1. To mount a temp directory from the host into the container.
2. Within the container, run the `bazel build` command with `--output_base` pointing at the mounted dir.

This allows mounting generated files into the other container that needs to be run (to install packages) inside the container.