### PR TITLE
Fix a couple of issues that made new security_check different

### DIFF
--- a/docker/security/security_check.py
+++ b/docker/security/security_check.py
@@ -114,7 +114,6 @@ def _check_for_vulnz(image, severity, whitelist):
     return unpatched
 
   base_image = _find_base_image(image)
-  base_image = None
   base_unpatched = {}
   if base_image:
     base_unpatched = _check_image(base_image, severity, whitelist)
@@ -282,7 +281,7 @@ def _generate_yaml_output(output_yaml, vulnerabilities):
     # LOW -> cveLow
     # MEDIUM -> sveMedium
     # and so on...
-    sev = str(details['effectiveSeverity'])
+    sev = str(details['severity'])
     tags.add("cve{}".format(sev.lower().capitalize()))
   result = {"tags": list(tags)}
   logging.info("Creating YAML output {}".format(output_yaml))

--- a/tests/docker/security/BUILD
+++ b/tests/docker/security/BUILD
@@ -40,5 +40,5 @@ security_check(
 file_test(
     name = "security_check_expect_cve_test",
     file = ":security_check_expect_cve.yaml",
-    regexp = "cveMedium",
+    regexp = "cveHigh",
 )


### PR DESCRIPTION
Was doing a careful line by line diff of the internal & external version
of this script and discovered the following issues:
1. Accidental debug code checked in that disabled checking
vulnerabilities in the base image of a given image.
2. The vulnerability severity being reported in the output YAML was
wrong. effectiveSeverity which was being reported != what the rest of
the script intends to report.