### PR TITLE
Remove required node_modules arg and layers

### DIFF
--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -93,7 +93,6 @@ def nodejs_image(
         base = None,
         data = [],
         layers = [],
-        node_modules = "//:node_modules",
         binary = None,
         **kwargs):
     """Constructs a container image wrapping a nodejs_binary target.
@@ -104,22 +103,14 @@ def nodejs_image(
     data: Runtime dependencies of the nodejs_image.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
-    node_modules: The list of Node modules to include in the nodejs image.
     binary: An alternative binary target to use instead of generating one.
     **kwargs: See nodejs_binary.
   """
-    layers = [
-        # Put the Node binary into its own layer.
-        "@nodejs//:node",
-        # node_modules can get large, it should be in its own layer.
-        node_modules,
-    ] + layers
 
     if not binary:
         binary = name + ".binary"
         nodejs_binary(
             name = binary,
-            node_modules = node_modules,
             data = data + layers,
             **kwargs
         )


### PR DESCRIPTION
The layers never really worked properly as all the nodejs_binary runfiles, including node_modules and the nodejs binary, where still being put into the top-layer anyway. Now that rules_nodejs are supporting toolchain we could fix that partially by also requiring the toolchain, but that would still not fix node_modules. For that we would need a provider from nodejs_binary, which is proposed here: https://github.com/bazelbuild/rules_nodejs/pull/863

So we should fix the layering once it is really possible from the rules_nodejs side.

cc @gregmagolan