### PR TITLE
Add files to reproduce Bazel error with command line flag arguments to new createImageConfig Go-binary

### DIFF
--- a/container/go/cmd/create_image_config/BUILD
+++ b/container/go/cmd/create_image_config/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["createImageConfig.go"],
+    importpath = "github.com/bazelbuild/rules_docker/container/go/cmd/create_image_config",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "create_image_config",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/container/go/cmd/create_image_config/createImageConfig.go
+++ b/container/go/cmd/create_image_config/createImageConfig.go
@@ -1,0 +1,156 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+////////////////////////////////////////////////
+// This package manipulates v2.2 image configuration metadata.
+// It writes out both a config file and a manifest for the v2.2 image.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+)
+
+var (
+	baseConfig         = flag.String("baseConfig", "", "The base image config.")
+	baseManifest       = flag.String("baseManifest", "", "The base image manifest.")
+	outputConfig       = flag.String("outputConfig", "", "The output image config file to generate.")
+	outputManifest     = flag.String("outputManifest", "", "The output manifest file to generate.")
+	creationTimeString = flag.String("creationTime", "", "The creation timestamp. Acceptable formats: Integer or floating point seconds since Unix Epoch, RFC, 3339 date/time.")
+	user               = flag.String("user", "", "The username to run the commands under.")
+	workdir            = flag.String("workdir", "", "Set the working directory of the layer.")
+	nullEntryPoint     = flag.String("nullEntryPoint", "False", "If True, Entrypoint will be set to null.")
+	nullCmd            = flag.String("nullCmd", "False", "If True, Cmd will be set to null.")
+	operatingSystem    = flag.String("operatingSystem", "linux", "Operating system to create docker image for, eg. linux.")
+	labelsArray        = arrayFlags{name: "labels"}
+	ports              = arrayFlags{name: "ports"}
+	volumes            = arrayFlags{name: "volumes"}
+	entrypointPrefix   = arrayFlags{name: "entry"}
+	env                = arrayFlags{name: "env"}
+	command            = arrayFlags{name: "command"}
+	entrypoint         = arrayFlags{name: "entrypoint"}
+	layerDigestFile    = arrayFlags{name: "layerDigest"}
+	stampInfoFile      = arrayFlags{name: "stampInfo"}
+)
+
+const (
+	// defaultProcArch is the default architecture type based on legacy create_image_config.py.
+	defaultProcArch = "amd64"
+	// defaultTimeStamp is the unix epoch 0 time representation in 32 bits.
+	defaultTimestamp = "1970-01-01T00:00:00Z"
+)
+
+// arrayFlags can be used to store multiple flags the same name.
+// the resulting data parsed in will be an array data type.
+type arrayFlags struct {
+	name  string
+	value []string
+}
+
+func (i *arrayFlags) String() string {
+	return fmt.Sprintf("%s = %s", i.name, strings.Join(i.value, ", "))
+}
+
+// Get returns an empty interface that may be type-asserted to the underlying
+// value of type bool, string, etc.
+func (i *arrayFlags) Get() interface{} {
+	return ""
+}
+
+func (i *arrayFlags) Set(value string) error {
+	// log.Printf("Set value for %s to %s", i.name, value)
+	i.value = append(i.value, value)
+	return nil
+}
+
+func main() {
+	// log.Println("Args before:", os.Args)
+	flag.Var(&labelsArray, "labels", "Augment the Label of the previous layer.")
+	flag.Var(&ports, "ports", "Augment the ExposedPorts of the previous layer.")
+	flag.Var(&volumes, "volumes", "Augment the Volumes of the previous layer.")
+	flag.Var(&entrypointPrefix, "entrypointPrefix", "Prefix the Entrypoint with the specified arguments.")
+	flag.Var(&env, "env", "Augment the Env of the previous layer.")
+	flag.Var(&command, "command", "Override the Cmd of the previous layer.")
+	flag.Var(&entrypoint, "entrypoint", "Override the Entrypoint of the previous layer.")
+	flag.Var(&layerDigestFile, "layerDigestFile", "Layer sha256 hashes that make up this image. The order that these layers are specified matters.")
+	flag.Var(&stampInfoFile, "stampInfoFile", "A list of files from which to read substitutions to make in the provided fields.")
+
+	flag.Parse()
+	// log.Println("Args after parse:", os.Args)
+	// log.Printf("output config in createimage is %s\n", *outputConfig)
+	// log.Println("the os.Args are below:....")
+	// log.Printf("%v", env)
+	// log.Println(os.Args)
+	// log.Println("Running the Image Config manipulator...")
+
+	if *outputConfig == "" {
+		log.Fatalln("Required option -outputConfig was not specified.")
+	}
+	// if *nullEntryPoint == "True" {
+	// 	entrypoint = nil
+	// }
+	// if *nullCmd == "True" {
+	// 	command = nil
+	// }
+
+	// log.Printf("the environment is: %s", env.String())
+
+	// // read config file into struct.
+	// configPath, err := os.Open(*baseConfig)
+	// log.Printf("the baseConfig is: %s", *baseConfig)
+	// if err != nil {
+	// 	log.Println("hello my name is")
+	// 	log.Fatalf("Failed to read the base image's config file: %v", err)
+	// }
+	// configFile, err := v1.ParseConfigFile(configPath)
+	// if err != nil {
+	// 	log.Fatalf("Failed to successfully parse config file json contents: %v", err)
+	// }
+
+	// // write out the updated config after overriding
+	// err = compat.OverrideContent(configFile, *outputConfig, *creationTimeString, *user, *workdir, *nullEntryPoint, *nullCmd, *operatingSystem, labelsArray[:], ports[:], volumes[:], entrypointPrefix[:], env[:], command[:], entrypoint[:], layerDigestFile[:], stampInfoFile[:])
+	// if err != nil {
+	// 	log.Fatalf("Failed to override values in old image config and write to dst %s: %v", err, *outputConfig)
+	// }
+
+	// log.Printf("Successfully created Image Config at %s.\n", *outputConfig)
+
+	// // read manifest file into struct if provided.
+	// manifestFile := v1.Manifest{}
+	// if *baseManifest != "" {
+	// 	manifestPath, err := ioutil.ReadFile(*baseManifest)
+	// 	if err != nil {
+	// 		log.Fatalf("Failed to read the base image's manifest: %v", err)
+	// 	}
+	// 	if err = json.Unmarshal([]byte(manifestPath), &manifestFile); err != nil {
+	// 		log.Fatalf("Failed to successfully read manifest file contents: %v", err)
+	// 	}
+	// }
+
+	// type Q struct{}
+
+	// // TODO(xwinxu): write out the updated manifest after updating it from compat pkg.
+	// rawManifest, err := json.Marshal(Q{})
+	// if err != nil {
+	// 	log.Fatalf("Unable to read config struct into json object: %v", err)
+	// }
+	// err = ioutil.WriteFile(*outputManifest, rawManifest, os.ModePerm)
+	// if err != nil {
+	// 	log.Fatalf("Writing config to %s was unsuccessful: %v", *outputManifest, err)
+	// }
+
+	// log.Println("Successfully created Image Manifest at %s.\n", *outputManifest)
+}

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -123,83 +123,105 @@ def _image_config(
             labels[label] = "@" + label_file_dict[fname[1:]].path
         else:
             labels[label] = fname
-
     args = [
-        "--output=%s" % config.path,
+        "-outputConfig", "%s" % config.path,
     ] + [
-        "--manifestoutput=%s" % manifest.path,
+        "-outputManifest", "%s" % manifest.path,
     ] + [
-        "--entrypoint=%s" % x
-        for x in entrypoint
+        "-nullEntryPoint", "%s" % null_entrypoint,
     ] + [
-        "--command=%s" % x
-        for x in cmd
-    ] + [
-        "--ports=%s" % x
-        for x in ctx.attr.ports
-    ] + [
-        "--volumes=%s" % x
-        for x in ctx.attr.volumes
-    ] + [
-        "--null_entrypoint=%s" % null_entrypoint,
-    ] + [
-        "--null_cmd=%s" % null_cmd,
+        "-nullCmd", "%s" % null_cmd,
     ]
+
+    for x in entrypoint:
+        args += ["-entrypoint", "%s" % x]
+    for x in cmd:
+        args += ["-command", "%s" % x]
+    for x in ctx.attr.ports:
+        args += ["-ports", "%s" % x]
+    for x in ctx.attr.volumes:
+        args += ["-volumes", "%s" % x]
+    # + [
+    #     "-entrypoint=%s" % x
+    #     for x in entrypoint
+    # ] + [
+    #     "-command", "%s" % x
+    #     for x in cmd
+    # ] + [
+    #     "-ports", "%s" % x
+    #     for x in ctx.attr.ports
+    # ] + [
+    #     "-volumes", "%s" % x
+    #     for x in ctx.attr.volumes
+    # ] 
     if creation_time:
-        args += ["--creation_time=%s" % creation_time]
+        args += ["-creationTime", "%s" % creation_time]
     elif ctx.attr.stamp:
         # If stamping is enabled, and the creation_time is not manually defined,
         # default to '{BUILD_TIMESTAMP}'.
-        args += ["--creation_time={BUILD_TIMESTAMP}"]
+        args += ["-creationTime", "{BUILD_TIMESTAMP}"]
 
-    args += ["--labels=%s" % "=".join([key, value]) for key, value in labels.items()]
-    args += ["--env=%s" % "=".join([
-        ctx.expand_make_variables("env", key, {}),
-        ctx.expand_make_variables("env", value, {}),
-    ]) for key, value in env.items()]
+    for key, value in labels.items():
+        args += ["-labels", "%s" % "=".join([key, value])]
+    # args += ["-labels, "%s" % "=".join([key, value]) for key, value in labels.items()]
+
+    # args += ["-foo", "foo", "-foo", "bar"]
+    for key, value in env.items():
+        args += ["-env", "%s" % "=".join([ctx.expand_make_variables("env", key, {}), ctx.expand_make_variables("env", value, {})])]
+    # args += ["-env", "%s" % "=".join([
+    #     ctx.expand_make_variables("env", key, {}),
+    #     ctx.expand_make_variables("env", value, {}),
+    # ]) for key, value in env.items()]
 
     if ctx.attr.user:
-        args += ["--user=" + ctx.attr.user]
+        args += ["-user", ctx.attr.user]
     if workdir:
-        args += ["--workdir=" + workdir]
+        args += ["-workdir", workdir]
 
     inputs = layer_names
     for layer_name in layer_names:
-        args += ["--layer=@" + layer_name.path]
+        args += ["-layerDigestFile", layer_name.path]
+        # args += ["-layerDigestFile", "@" + layer_name.path]
 
     if ctx.attr.label_files:
         inputs += ctx.files.label_files
 
     if base_config:
-        args += ["--base=%s" % base_config.path]
+        args += ["-baseConfig", "%s" % base_config.path]
         inputs += [base_config]
 
     if base_manifest:
-        args += ["--basemanifest=%s" % base_manifest.path]
+        args += ["-baseManifest", "%s" % base_manifest.path]
         inputs += [base_manifest]
 
     if operating_system:
-        args += ["--operating_system=%s" % operating_system]
+        args += ["-operatingSystem", "%s" % operating_system]
 
     if ctx.attr.stamp:
         stamp_inputs = [ctx.info_file, ctx.version_file]
-        args += ["--stamp-info-file=%s" % f.path for f in stamp_inputs]
+        for f in stamp_inputs:
+            args += ["-stampInfoFile", "%s" % f.path]
+        # args += ["-stampInfoFile", "%s" % f.path for f in stamp_inputs]
         inputs += stamp_inputs
 
     if ctx.attr.launcher_args and not ctx.attr.launcher:
         fail("launcher_args does nothing when launcher is not specified.", attr = "launcher_args")
     if ctx.attr.launcher:
-        args += [
-            "--entrypoint_prefix=%s" % x
-            for x in ["/" + ctx.file.launcher.basename] + ctx.attr.launcher_args
-        ]
-
-    ctx.actions.run(
-        executable = ctx.executable.create_image_config,
-        arguments = args,
+        for x in ["/" + ctx.file.launcher.basename]:
+            args += ["-entrypointPrefix", "%s" % (x + ctx.attr.launcher_args)]
+        # args += [
+        #     "-entrypointPrefix=%s" % x
+        #     for x in ["/" + ctx.file.launcher.basename] + ctx.attr.launcher_args
+        # ]
+    cmd = "echo Arguments {}".format(" ".join(args))
+    print("Running command: {}".format(cmd))
+    
+    ctx.actions.run_shell(
+        command = cmd,
+        tools = [ctx.executable.create_image_config],
         inputs = inputs,
         outputs = [config, manifest],
-        use_default_shell_env = True,
+        # use_default_shell_env = True,
         mnemonic = "ImageConfig",
     )
     return config, _sha256(ctx, config), manifest, _sha256(ctx, manifest)
@@ -469,7 +491,7 @@ _attrs = dicts.add(_layer.attrs, {
     "base": attr.label(allow_files = container_filetype),
     "cmd": attr.string_list(),
     "create_image_config": attr.label(
-        default = Label("//container:create_image_config"),
+        default = Label("//container/go/cmd/create_image_config:create_image_config"),
         cfg = "host",
         executable = True,
         allow_files = True,


### PR DESCRIPTION
Upon testing the new binary, I have noticed that the argument list changes when Bazel processes them in the shell execution command.

Running the rule `bazel test //testdata:layers_with_env`, you will notice that the input arguments are complete as:
```
DEBUG: /usr/local/google/home/xwinxu/rules_docker/container/image.bzl:222:5: Running command: echo Arguments -outputConfig bazel-out/k8-fastbuild/bin/testdata/layers_with_env.1.config -outputManifest bazel-out/k8-fastbuild/bin/testdata/layers_with_env.1.manifest -nullEntryPoint False -nullCmd False -entrypoint aaa -entrypoint bbb -env PATH=$PATH:/tmp/b:/tmp/c -env x=y -layerDigestFile bazel-out/k8-fastbuild/bin/testdata/layers_with_env-layer.tar.sha256 -baseConfig bazel-out/k8-fastbuild/bin/testdata/layers_with_env.0.config -baseManifest bazel-out/k8-fastbuild/bin/testdata/layers_with_env.0.manifest -operatingSystem linux
```

yet from the actual ImageConfig testdata/base_with_volume.0.config, some arguments (i.e. `-env` etc) are reduced:
```
Arguments -outputConfig bazel-out/k8-fastbuild/bin/testdata/base_with_volume.0.config -outputManifest bazel-out/k8-fastbuild/bin/testdata/base_with_volume.0.manifest -nullEntryPoint False -nullCmd False -volumes /logs -layerDigestFile bazel-out/k8-fastbuild/bin/testdata/base_with_volume-layer.tar.sha256 -operatingSystem linux
```

Manually testing the Go binary showed that nothing is wrong with the Go code (i.e. how it parses flags, and getting flags in multiple mentions). The issue seems to be with how Bazel handles arguments and passes them to the binary.

The output of `bazel version`:
```
Build label: 0.26.0
Build target: bazel-out/k8-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Tue May 28 08:35:14 2019 (1559032514)
Build timestamp: 1559032514
Build timestamp as int: 1559032514
```