### PR TITLE
docker/util: adding arg docker_run_flags to container_run_and_commit

### DIFF
--- a/docker/util/README.md
+++ b/docker/util/README.md
@@ -15,7 +15,7 @@ properly via
 ## container_run_and_commit
 
 <pre>
-container_run_and_commit(<a href="#container_run_and_commit-name">name</a>, <a href="#container_run_and_commit-commands">commands</a>, <a href="#container_run_and_commit-image">image</a>)
+container_run_and_commit(<a href="#container_run_and_commit-name">name</a>, <a href="#container_run_and_commit-commands">commands</a>, <a href="#container_run_and_commit-docker_run_flags">docker_run_flags</a>, <a href="#container_run_and_commit-image">image</a>)
 </pre>
 
 This rule runs a set of commands in a given image, waits for the commands
@@ -44,6 +44,15 @@ to finish, and then commits the container to a new image.
         List of strings; required
         <p>
           A list of commands to run (sequentially) in the container.
+        </p>
+      </td>
+    </tr>
+    <tr id="container_run_and_commit-docker_run_flags">
+      <td><code>docker_run_flags</code></td>
+      <td>
+        List of strings; optional
+        <p>
+          Extra flags to pass to the docker run command.
         </p>
       </td>
     </tr>

--- a/docker/util/commit.sh.tpl
+++ b/docker/util/commit.sh.tpl
@@ -18,7 +18,7 @@ fi
 image_id=$(%{image_id_extractor_path} %{image_tar})
 $DOCKER load -i %{image_tar}
 
-id=$($DOCKER run -d $image_id %{commands})
+id=$($DOCKER run -d %{docker_run_flags} $image_id %{commands})
 # Actually wait for the container to finish running its commands
 retcode=$($DOCKER wait $id)
 # Trigger a failure if the run had a non-zero exit status

--- a/docker/util/run.bzl
+++ b/docker/util/run.bzl
@@ -143,6 +143,7 @@ def _commit_impl(
         name = None,
         image = None,
         commands = None,
+        docker_run_flags = None,
         output_image_tar = None):
     """Implementation for the container_run_and_commit rule.
 
@@ -154,6 +155,7 @@ def _commit_impl(
         name: A unique name for this rule.
         image: The input image tarball
         commands: The commands to run in the input imnage container
+        docker_run_flags: String list, overrides ctx.attr.docker_run_flags
         output_image_tar: The output image obtained as a result of running
                           the commands on the input image
     """
@@ -161,6 +163,7 @@ def _commit_impl(
     name = name or ctx.attr.name
     image = image or ctx.file.image
     commands = commands or ctx.attr.commands
+    docker_run_flags = docker_run_flags or ctx.attr.docker_run_flags
     script = ctx.actions.declare_file(name + ".build")
     output_image_tar = output_image_tar or ctx.outputs.out
 
@@ -172,6 +175,7 @@ def _commit_impl(
         output = script,
         substitutions = {
             "%{commands}": _process_commands(commands),
+            "%{docker_run_flags}": " ".join(docker_run_flags),
             "%{docker_tool_path}": toolchain_info.tool_path,
             "%{image_id_extractor_path}": ctx.executable._extract_image_id.path,
             "%{image_tar}": image.path,
@@ -202,6 +206,10 @@ _commit_attrs = {
         doc = "A list of commands to run (sequentially) in the container.",
         mandatory = True,
         allow_empty = False,
+    ),
+    "docker_run_flags": attr.string_list(
+        doc = "Extra flags to pass to the docker run command.",
+        mandatory = False,
     ),
     "image": attr.label(
         doc = "The image to run the commands in.",

--- a/tests/docker/util/BUILD
+++ b/tests/docker/util/BUILD
@@ -69,6 +69,10 @@ file_test(
 container_run_and_commit(
     name = "test_container_commit",
     commands = ["touch /foo.txt"],
+    docker_run_flags = [
+        "-u",
+        "root",
+    ],
     image = "@debian_base//image",
 )
 


### PR DESCRIPTION
rules_docker _container_run_and_commit_ rule doesn't allow to provide
custom flags to the `docker run` command. custom flags are needed
e.g. setting up container network or dns servers. the
_container_run_and_extract_ rule supports custom setting
_docker_run_flags_ already. this commit adds the missing argument
and same behavior to the _containr_run_and_commit_ rule.

Issue #1026