### PR TITLE
Fix rules_python workspace name

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,7 +138,7 @@ http_file(
 
 http_file(
     name = "launchpad_openjdk_gpg",
-    sha256 = "54b6274820df34a936ccc6f5cb725a9b7bb46075db7faf0ef7e2d86452fa09fd",
+    sha256 = "429b667af38f71f727de92aa662fb535c587b870a8ed0dcfbe7d2b8971b7e616",
     urls = ["http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xEB9B1D8886F44E2A"],
 )
 

--- a/repositories/py_repositories.bzl
+++ b/repositories/py_repositories.bzl
@@ -19,7 +19,7 @@ Provides functions to pull all Python external package dependencies of this
 repository.
 """
 
-load("@io_bazel_rules_python//python:pip.bzl", "pip_import", "pip_repositories")
+load("@rules_python//python:pip.bzl", "pip_import", "pip_repositories")
 
 def py_deps():
     """Pull in external Python packages needed by py binaries in this repo.

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -135,9 +135,9 @@ def repositories():
     if "rules_python" not in excludes:
         http_archive(
             name = "rules_python",
-            sha256 = "a8d454f63f792a6b1c17b86d83aa3c954a9fe5805e64b3cb7187afe07f624f2e",
-            strip_prefix = "rules_python-640e88a6ee6b949ef131a9d512e2f71c6e0e858c",
-            urls = ["https://github.com/bazelbuild/rules_python/archive/640e88a6ee6b949ef131a9d512e2f71c6e0e858c.tar.gz"],
+            sha256 = "74a0a739cf308e23d5e6080a72daca6d4a696cf4071d78428eda05c4cac1700d",
+            strip_prefix = "rules_python-93d8b0af6d8ca1ee37816a829085d7092b04cc7b",
+            urls = ["https://github.com/bazelbuild/rules_python/archive/93d8b0af6d8ca1ee37816a829085d7092b04cc7b.tar.gz"],
         )
 
     if "httplib2" not in excludes:

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -132,9 +132,9 @@ def repositories():
                 "https://github.com/bazelbuild/rules_go/archive/4c28450eae71d4179d946dfc930b9f13dee9a76c.tar.gz",
             ],
         )
-    if "io_bazel_rules_python" not in excludes:
+    if "rules_python" not in excludes:
         http_archive(
-            name = "io_bazel_rules_python",
+            name = "rules_python",
             sha256 = "a8d454f63f792a6b1c17b86d83aa3c954a9fe5805e64b3cb7187afe07f624f2e",
             strip_prefix = "rules_python-640e88a6ee6b949ef131a9d512e2f71c6e0e858c",
             urls = ["https://github.com/bazelbuild/rules_python/archive/640e88a6ee6b949ef131a9d512e2f71c6e0e858c.tar.gz"],


### PR DESCRIPTION
Addresses [renaming canonical workspace issue](https://github.com/bazelbuild/rules_python/issues/203) and fixes #1029 