### PR TITLE
Changed pusher default format to legacy

### DIFF
--- a/container/new_push.bzl
+++ b/container/new_push.bzl
@@ -150,13 +150,13 @@ def _impl(ctx):
 new_container_push = rule(
     attrs = dicts.add({
         "format": attr.string(
-            default = "oci",
+            default = "legacy",
             values = [
                 "oci",
                 "docker",
                 "legacy",
             ],
-            doc = "The form to push: docker, legacy or oci, default to 'oci'.",
+            doc = "The form to push: docker, legacy or oci, default to 'legacy'.",
         ),
         "image": attr.label(
             allow_files = True,


### PR DESCRIPTION
Changed pusher default format to legacy
  - Consider changing this back once `container_image` supports oci format.
  - Left puller default format to "oci" since puller pulls into two formats by default. 