### PR TITLE
Use the default shell for docker commands

### DIFF
--- a/docker/package_managers/download_pkgs.bzl
+++ b/docker/package_managers/download_pkgs.bzl
@@ -114,6 +114,7 @@ def _impl(ctx, image_tar = None, packages = None, additional_repos = None, outpu
         executable = output_script,
         inputs = [image_tar],
         tools = [ctx.executable._extract_image_id],
+        use_default_shell_env = True,
     )
 
     # Generate a very similar one as output executable, but with short paths

--- a/docker/package_managers/install_pkgs.bzl
+++ b/docker/package_managers/install_pkgs.bzl
@@ -116,6 +116,7 @@ def _impl(ctx, image_tar = None, installables_tar = None, installation_cleanup_c
         ],
         tools = [ctx.executable._extract_image_id, ctx.executable._to_json_tool],
         executable = script,
+        use_default_shell_env = True,
     )
 
     ctx.actions.run(
@@ -123,6 +124,7 @@ def _impl(ctx, image_tar = None, installables_tar = None, installation_cleanup_c
         inputs = [unstripped_tar],
         executable = ctx.executable._config_stripper,
         arguments = ["--in_tar_path=%s" % unstripped_tar.path, "--out_tar_path=%s" % output_tar.path],
+        use_default_shell_env = True,
     )
 
     return struct()

--- a/docker/util/run.bzl
+++ b/docker/util/run.bzl
@@ -79,6 +79,7 @@ def _extract_impl(
         outputs = [output_file],
         tools = [image, ctx.executable._extract_image_id],
         executable = script,
+        use_default_shell_env = True,
     )
 
     return struct()
@@ -197,6 +198,7 @@ def _commit_impl(
         inputs = runfiles,
         executable = script,
         tools = [ctx.executable._extract_image_id, ctx.executable._to_json_tool],
+        use_default_shell_env = True,
     )
 
     return struct()


### PR DESCRIPTION
Porting from https://github.com/GoogleContainerTools/base-images-docker/pull/366
From that change:

If you are not running docker locally, you need to set some
environment variables to be able to access the docker host.

These environment variables are DOCKER_MACHINE_NAME, DOCKER_CERT_PATH,
DOCKER_TLS_VERIFY & DOCKER_HOST.

Bazel does not pass environment variables to all actions by
default. You need to set use_default_shell_env. This patch enables
this option for docker actions so that a remote docker node can be
used (like is done with CircleCI).