### PR TITLE
Remove java pkg non-determinism test

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -16,7 +16,6 @@ platforms:
     - "-//tests/docker/security/..."
     # tests/docker/security require gcloud
     - "-//tests/contrib:derivative_with_volume_repro_test"
-    - "-//tests/contrib:java_pkg_want_failure"
     - "-//tests/contrib:python3_pkg_want_failure"
     - "-//tests/contrib:rbe-test-xenial_repro_test"
     - "-//tests/contrib:set_cmd_repro_test"
@@ -43,7 +42,6 @@ platforms:
     - "-//tests/docker/security/..."
     # tests/docker/security require gcloud
     - "-//tests/contrib:derivative_with_volume_repro_test"
-    - "-//tests/contrib:java_pkg_want_failure"
     - "-//tests/contrib:python3_pkg_want_failure"
     - "-//tests/contrib:rbe-test-xenial_repro_test"
     - "-//tests/contrib:set_cmd_repro_test"
@@ -114,7 +112,6 @@ platforms:
     - "-//tests/docker/security/..."
     # contrib targets are not compatible with remote exec
     - "-//tests/contrib:derivative_with_volume_repro_test"
-    - "-//tests/contrib:java_pkg_want_failure"
     - "-//tests/contrib:python3_pkg_want_failure"
     - "-//tests/contrib:rbe-test-xenial_repro_test"
     - "-//tests/contrib:set_cmd_repro_test"
@@ -137,7 +134,6 @@ platforms:
     - "-//tests/docker/security/..."
     # contrib tests are not compatible with remote exec
     - "-//tests/contrib:derivative_with_volume_repro_test"
-    - "-//tests/contrib:java_pkg_want_failure"
     - "-//tests/contrib:python3_pkg_want_failure"
     - "-//tests/contrib:rbe-test-xenial_repro_test"
     - "-//tests/contrib:set_cmd_repro_test"

--- a/tests/contrib/BUILD
+++ b/tests/contrib/BUILD
@@ -169,12 +169,6 @@ docker_push(
 ]]
 
 toolchain_container(
-    name = "java_pkg_non_deterministic",
-    base = "@official_xenial//image",
-    packages = ["openjdk-8-jdk"],
-)
-
-toolchain_container(
     name = "python3_pkg_non_deterministic",
     base = "@official_xenial//image",
     packages = ["python3-dev"],
@@ -205,13 +199,6 @@ container_repro_test(
 container_repro_test(
     name = "rbe-test-xenial_repro_test",
     image = "//tests/docker/toolchain_container:rbe-test-xenial-with-pkgs",
-    workspace_file = "//:WORKSPACE",
-)
-
-container_repro_test(
-    name = "java_pkg_want_failure",
-    image = ":java_pkg_non_deterministic",
-    want_reproducibility = False,
     workspace_file = "//:WORKSPACE",
 )
 

--- a/tests/contrib/repro_imgs.yaml
+++ b/tests/contrib/repro_imgs.yaml
@@ -57,18 +57,6 @@ steps:
   - //tests/contrib:rbe-test-xenial_repro_test
   dir: 'rules_docker'
 
-  # Test that image installing the openjdk-8-jdk apt package (without any
-  # file cleanup) is not reproducible.
-- name: "l.gcr.io/google/bazel"
-  args:
-  - --output_base=/workspace/output_base
-  - test
-  - --test_output=errors
-  - --spawn_strategy=standalone
-  - --verbose_failures
-  - //tests/contrib:java_pkg_want_failure
-  dir: 'rules_docker'
-
   # Test that image installing the python3-dev apt package (without any
   # file cleanup) is not reproducible.
 - name: "l.gcr.io/google/bazel"


### PR DESCRIPTION
This test fails sometimes, because in some cases installing the `openjdk-8-jdk` apt package is deterministic.