### PR TITLE
Escape backslashes in Starlark code

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -568,7 +568,7 @@ container_image_ = rule(
 def _validate_command(name, argument, operating_system):
     if type(argument) == type(""):
         if (operating_system == "windows"):
-            return ["%WinDir%\system32\cmd.exe", "/c", argument]
+            return ["%WinDir%\\system32\\cmd.exe", "/c", argument]
         else:
             return ["/bin/sh", "-c", argument]
     elif type(argument) == type([]):

--- a/contrib/repro_test.bzl
+++ b/contrib/repro_test.bzl
@@ -148,7 +148,7 @@ def _impl(ctx):
         command = "exit 0",
         outputs = [bazel_out1, bazel_out2],
     )
-    cd_cmd = ["cd \$(cat /%s)" % proj_root.basename]
+    cd_cmd = ["cd \\$(cat /%s)" % proj_root.basename]
 
     # Commands to copy the files required for image
     # comparison to a known location in the container.
@@ -156,7 +156,7 @@ def _impl(ctx):
         "mkdir %s" % extract_path,
         "cp bazel-bin/%s/%s %s/%s" % (img_pkg, img_tar, extract_path, img_tar),
         "cp bazel-bin/%s/%s %s/%s" % (img_pkg, img_digest, extract_path, img_digest),
-        "cp \$(readlink -f bazel-bin/%s/%s).sha256 %s/%s" % (img_pkg, img_name + ".json", extract_path, img_name + ".id"),
+        "cp \\$(readlink -f bazel-bin/%s/%s).sha256 %s/%s" % (img_pkg, img_name + ".json", extract_path, img_name + ".id"),
     ]
 
     # We need to use absolute paths to the directory being mounted

--- a/docker/package_managers/apt_key.bzl
+++ b/docker/package_managers/apt_key.bzl
@@ -85,7 +85,7 @@ def _impl(
         "apt-get update",
         "apt-get install -y -q gnupg",
         # Put keys in a special directory and use glob.
-        "for file in /gpg/*; do apt-key add \$file; done",
+        "for file in /gpg/*; do apt-key add \\$file; done",
     ]
     extract_file_name = "/etc/apt/trusted.gpg"
     extract_file_out = ctx.actions.declare_file(name + "-trusted.gpg")


### PR DESCRIPTION
The escape sequence \s doesn't exist. The current behavior of Starlark
is to insert both `\` and `s` in the string. However, it can be
confusing and not future-proof: backslashes need to be escaped.

Bazel will require it in the future (see
--incompatible_restrict_string_escapes).