### PR TITLE
Revert digester deps for container_push and container_image 

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -566,7 +566,7 @@ container_image_ = rule(
 def _validate_command(name, argument, operating_system):
     if type(argument) == type(""):
         if (operating_system == "windows"):
-            return ["%WinDir%\system32\cmd.exe", "/c", argument]
+            return ["%WinDir%\\system32\\cmd.exe", "/c", argument]
         else:
             return ["/bin/sh", "-c", argument]
     elif type(argument) == type([]):

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -216,25 +216,23 @@ def _repository_name(ctx):
     return _join_path(ctx.attr.repository, ctx.label.package)
 
 def _assemble_image_digest(ctx, name, image, image_tarball, output_digest):
-    digester_args = ctx.actions.args()
+    blobsums = image.get("blobsum", [])
+    digest_args = ["--digest=%s" % f.path for f in blobsums]
     blobs = image.get("zipped_layer", [])
-    config = image["config"]
-    digester_input = [config] + blobs
+    layer_args = ["--layer=%s" % f.path for f in blobs]
+    config_arg = "--config=%s" % image["config"].path
+    output_digest_arg = "--output-digest=%s" % output_digest.path
 
-    digester_args.add_all(["-configPath", str(config.path), "-dst", str(output_digest.path), "-format", "legacy"])
-    for layer_file in blobs:
-        digester_args.add("-layers", layer_file.path)
-
+    arguments = [config_arg, output_digest_arg] + layer_args + digest_args
     if image.get("legacy"):
-        digester_input += [image.get("legacy")]
-        digester_args.add("-legacyBaseImage", "%s" % image["legacy"].path)
+        arguments.append("--tarball=%s" % image["legacy"].path)
 
     ctx.actions.run(
         outputs = [output_digest],
-        inputs = digester_input,
+        inputs = [image["config"]] + blobsums + blobs,
         tools = ([image["legacy"]] if image.get("legacy") else []),
         executable = ctx.executable._digester,
-        arguments = [digester_args],
+        arguments = arguments,
         mnemonic = "ImageDigest",
         progress_message = "Extracting image digest of %s" % image_tarball.short_path,
     )
@@ -510,7 +508,7 @@ _attrs = dicts.add(_layer.attrs, {
     "volumes": attr.string_list(),
     "workdir": attr.string(),
     "_digester": attr.label(
-        default = "@io_bazel_rules_docker//container/go/cmd/digester",
+        default = "@containerregistry//:digester",
         cfg = "host",
         executable = True,
     ),
@@ -568,7 +566,7 @@ container_image_ = rule(
 def _validate_command(name, argument, operating_system):
     if type(argument) == type(""):
         if (operating_system == "windows"):
-            return ["%WinDir%\\system32\\cmd.exe", "/c", argument]
+            return ["%WinDir%\system32\cmd.exe", "/c", argument]
         else:
             return ["/bin/sh", "-c", argument]
     elif type(argument) == type([]):

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -513,7 +513,7 @@ file_test(
 
 file_test(
     name = "new_alpine_linux_armv6_image_tar_digest_test",
-    content = "sha256:f209a250c03b2b96b9adb685a68e799f81bad44c8d500812dd8a19f32ece189e",
+    content = "sha256:a0b19fd8750d6e5442c61d43fc8bb7a854548c570fbf6601ab5ab0c92d520eab",
     file = ":new_alpine_linux_armv6_image_tar.digest",
 )
 

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -213,13 +213,13 @@ container_test(
 # BEGIN_DO_NOT_IMPORT
 file_test(
     name = "test_digest_output1",
-    content = "sha256:bfe2a9d4b2c37ceaa0b5db475c54f356846f4ebbb70a8e8c4b10525f9270ac72",
+    content = "sha256:12f16b811707264bb51f96e85a5f08f0d23fe874dd857a4cd39f7a90844a8bdb",
     file = ":deb_image_with_dpkgs.digest",
 )
 
 file_test(
     name = "test_digest_output2",
-    content = "sha256:437978f37315238cca48d540a5dbdcfbc8a6b617f17a04e6be931718414abbd6",
+    content = "sha256:5126c97392b596711e00f5af71675581978475cf1490d12a55d4b321ceeee392",
     file = ":null_cmd_and_entrypoint_none.digest",
 )
 # END_DO_NOT_IMPORT
@@ -483,7 +483,7 @@ new_container_push(
 # BEGIN_DO_NOT_IMPORT
 file_test(
     name = "test_push_digest_output",
-    content = "sha256:3b7f28bf8caefd13d4a22513727f3e8cd8d3a464c72df387f0fd7a74a0f82f2b",
+    content = "sha256:515b5206d4232e54ac4a0c2b45fb9fbe678ccc4f6c228e59024ac3ef61e08133",
     file = ":push_test.digest",
 )
 


### PR DESCRIPTION
Reverted changes in `container_push` and `container_image` to use new digester in go. 
  - The digest differs since  `container_push` and `container_image` still rely on manifest created in python containerregistry, which results in a difference in the uploaded manifest and the manifest in `digester.go` used to compute sha256 sum. 
  - Resolves issue #1051 