### PR TITLE
Updated new puller binary to generate digest file

### DIFF
--- a/container/go/cmd/digester/BUILD
+++ b/container/go/cmd/digester/BUILD
@@ -24,8 +24,6 @@ go_library(
     deps = [
         "//container/go/pkg/compat:go_default_library",
         "//container/go/pkg/utils:go_default_library",
-        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
-        "@com_github_pkg_errors//:go_default_library",
     ],
 )
 

--- a/container/go/cmd/digester/digester.go
+++ b/container/go/cmd/digester/digester.go
@@ -17,15 +17,11 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
-	"os"
 	"path/filepath"
 
 	"github.com/bazelbuild/rules_docker/container/go/pkg/compat"
 	"github.com/bazelbuild/rules_docker/container/go/pkg/utils"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -99,25 +95,9 @@ func main() {
 		log.Fatalf("Error reading from %s: %v", imgSrc, err)
 	}
 
-	if err = writeDigest(img, *dst); err != nil {
+	if err = compat.WriteDigest(img, *dst); err != nil {
 		log.Fatalf("Error outputting digest file to %s: %v", *dst, err)
 	}
 
 	log.Printf("Successfully generated image digest file at %s", *dst)
-}
-
-// writeDigest writes the sha256 digest of the manifest of the given image to the file given by dst.
-func writeDigest(image v1.Image, dst string) error {
-	digest, err := image.Digest()
-	if err != nil {
-		log.Fatalf("Error getting image digest: %v", err)
-	}
-
-	rawDigest := []byte(digest.Algorithm + ":" + digest.Hex)
-
-	if err = ioutil.WriteFile(dst, rawDigest, os.ModePerm); err != nil {
-		return errors.Wrapf(err, "unable to write digest file to %s", dst)
-	}
-
-	return nil
 }

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -126,6 +126,11 @@ func pull(imgName, dstPath, format, cachePath string, platform v1.Platform) erro
 		}
 	}
 
+	digestPath := path.Join(legacyPath, "digest")
+	if err := compat.WriteDigest(img, digestPath); err != nil {
+		return errors.Wrapf(err, "failed to generate image digest file to pulled image at %s", digestPath)
+	}
+
 	return nil
 }
 

--- a/container/go/pkg/compat/ociToLegacy.go
+++ b/container/go/pkg/compat/ociToLegacy.go
@@ -120,10 +120,9 @@ func LegacyFromOCIImage(img v1.Image, srcDir, dstDir string) error {
 
 // WriteDigest writes the sha256 digest of the manifest of the given image to the file given by dst.
 func WriteDigest(image v1.Image, dst string) error {
-	log.Println(dst)
 	digest, err := image.Digest()
 	if err != nil {
-		return errors.Wrap(err, "Error getting image digest")
+		return errors.Wrap(err, "error getting image digest")
 	}
 
 	rawDigest := []byte(digest.Algorithm + ":" + digest.Hex)

--- a/container/go/pkg/compat/ociToLegacy.go
+++ b/container/go/pkg/compat/ociToLegacy.go
@@ -19,7 +19,9 @@
 package compat
 
 import (
+	"io/ioutil"
 	"log"
+	"os"
 	ospkg "os"
 	"path"
 	"strconv"
@@ -111,6 +113,23 @@ func LegacyFromOCIImage(img v1.Image, srcDir, dstDir string) error {
 	manifestPath := path.Join(targetDir, manifestHex)
 	if err = generateSymlinks(manifestPath, dstLink); err != nil {
 		return errors.Wrapf(err, "failed to generate %s symlink", legacyManifestFile)
+	}
+
+	return nil
+}
+
+// WriteDigest writes the sha256 digest of the manifest of the given image to the file given by dst.
+func WriteDigest(image v1.Image, dst string) error {
+	log.Println(dst)
+	digest, err := image.Digest()
+	if err != nil {
+		return errors.Wrap(err, "Error getting image digest")
+	}
+
+	rawDigest := []byte(digest.Algorithm + ":" + digest.Hex)
+
+	if err = ioutil.WriteFile(dst, rawDigest, os.ModePerm); err != nil {
+		return errors.Wrapf(err, "unable to write digest file to %s", dst)
 	}
 
 	return nil


### PR DESCRIPTION
Updated new puller binary `puller.go` to generate digest file to `image/digest`.