### PR TITLE
Implement createImageConfig for use in container_image targets

### DIFF
--- a/container/go/cmd/create_image_config/BUILD
+++ b/container/go/cmd/create_image_config/BUILD
@@ -1,0 +1,36 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ###
+# Build file for new create image config binary for creating and writing
+# new config and manifest json files using the go-containerregistry as backend.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["createImageConfig.go"],
+    importpath = "github.com/bazelbuild/rules_docker/container/go/cmd/create_image_config",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//container/go/pkg/compat:go_default_library",
+        "//container/go/pkg/utils:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "create_image_config",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/container/go/cmd/create_image_config/createImageConfig.go
+++ b/container/go/cmd/create_image_config/createImageConfig.go
@@ -1,0 +1,143 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+////////////////////////////////////////////////
+// This package manipulates v2.2 image configuration metadata.
+// It writes out both a config file and a manifest for the v2.2 image.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/bazelbuild/rules_docker/container/go/pkg/compat"
+	"github.com/bazelbuild/rules_docker/container/go/pkg/utils"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+var (
+	baseConfig         = flag.String("baseConfig", "", "The base image config.")
+	baseManifest       = flag.String("baseManifest", "", "The base image manifest.")
+	outputConfig       = flag.String("outputConfig", "", "The output image config file to generate.")
+	outputManifest     = flag.String("outputManifest", "", "The output manifest file to generate.")
+	creationTimeString = flag.String("creationTime", "", "The creation timestamp. Acceptable formats: Integer or floating point seconds since Unix Epoch, RFC 3339 date/time.")
+	user               = flag.String("user", "", "The username to run the commands under.")
+	workdir            = flag.String("workdir", "", "Set the working directory of the layer.")
+	nullEntryPoint     = flag.Bool("nullEntryPoint", false, "If true, Entrypoint will be set to null.")
+	nullCmd            = flag.Bool("nullCmd", false, "If true, Cmd will be set to null.")
+	operatingSystem    = flag.String("operatingSystem", "linux", "Operating system to create docker image for, eg. linux.")
+	labelsArray        utils.ArrayStringFlags
+	ports              utils.ArrayStringFlags
+	volumes            utils.ArrayStringFlags
+	entrypointPrefix   utils.ArrayStringFlags
+	env                utils.ArrayStringFlags
+	command            utils.ArrayStringFlags
+	entrypoint         utils.ArrayStringFlags
+	layerDigestFile    utils.ArrayStringFlags
+	stampInfoFile      utils.ArrayStringFlags
+)
+
+const (
+	// createdBy default
+	createdBy = "bazel build..."
+	// author default
+	defaultAuthor = "Bazel"
+)
+
+func main() {
+	flag.Var(&labelsArray, "labels", "Augment the Label of the previous layer.")
+	flag.Var(&ports, "ports", "Augment the ExposedPorts of the previous layer.")
+	flag.Var(&volumes, "volumes", "Augment the Volumes of the previous layer.")
+	flag.Var(&entrypointPrefix, "entrypointPrefix", "Prefix the Entrypoint with the specified arguments.")
+	flag.Var(&env, "env", "Augment the Env of the previous layer.")
+	flag.Var(&command, "command", "Override the Cmd of the previous layer.")
+	flag.Var(&entrypoint, "entrypoint", "Override the Entrypoint of the previous layer.")
+	flag.Var(&layerDigestFile, "layerDigestFile", "Layer sha256 hashes that make up this image. The order that these layers are specified matters.")
+	flag.Var(&stampInfoFile, "stampInfoFile", "A list of files from which to read substitutions to make in the provided fields.")
+
+	flag.Parse()
+
+	log.Println("Running the Image Config creator...")
+
+	if *outputConfig == "" {
+		log.Fatalln("Required option -outputConfig was not specified.")
+	}
+
+	configFile := &v1.ConfigFile{}
+	if *baseConfig != "" {
+		configPath, err := ioutil.ReadFile(*baseConfig)
+		if err != nil {
+			log.Fatalf("Failed to read the base image's config file: %v", err)
+		}
+
+		configFile, err = v1.ParseConfigFile(bytes.NewReader(configPath))
+		if err != nil {
+			log.Fatalf("Failed to successfully parse config file json contents: %v", err)
+		}
+	} else {
+		// write out an empty config file.
+		log.Println("baseConfig is empty!")
+	}
+
+	opts := compat.OverrideConfigOpts{
+		ConfigFile:         configFile,
+		OutputConfig:       *outputConfig,
+		CreationTimeString: *creationTimeString,
+		User:               *user,
+		Workdir:            *workdir,
+		NullEntryPoint:     *nullEntryPoint,
+		NullCmd:            *nullCmd,
+		OperatingSystem:    *operatingSystem,
+		CreatedBy:          createdBy,
+		Author:             defaultAuthor,
+		LabelsArray:        labelsArray[:],
+		Ports:              ports[:],
+		Volumes:            volumes[:],
+		EntrypointPrefix:   entrypointPrefix[:],
+		Env:                env[:],
+		Command:            command[:],
+		Entrypoint:         entrypoint[:],
+		Layer:              layerDigestFile[:],
+		StampInfoFile:      stampInfoFile[:],
+	}
+
+	// write out the updated config after overriding config content.
+	if err := compat.OverrideImageConfig(&opts); err != nil {
+		log.Fatalf("Failed to override values in old image config and write to dst %s: %v", err, *outputConfig)
+	}
+
+	log.Printf("Successfully created Image Config at %s.\n", *outputConfig)
+
+	log.Println("Running the Image Manifest creator...")
+
+	var manifestBlob []byte
+	var err error
+	if *baseManifest != "" {
+		manifestBlob, err = ioutil.ReadFile(*baseManifest)
+		if err != nil {
+			log.Fatalf("Failed to read manifest file from %s: %v", *baseManifest, err)
+		}
+	} else {
+		// generating an empty manifest.
+		manifestBlob = []byte("{}")
+	}
+	if err := ioutil.WriteFile(*outputManifest, manifestBlob, os.ModePerm); err != nil {
+		log.Fatalf("Writing manifest to %s was unsuccessful: %v", *outputManifest, err)
+	}
+
+	log.Printf("Successfully created Image Manifest at %s.\n", *outputManifest)
+}

--- a/container/go/pkg/compat/BUILD
+++ b/container/go/pkg/compat/BUILD
@@ -23,6 +23,7 @@ go_library(
         "generateManifest.go",
         "image.go",
         "ociToLegacy.go",
+        "overrideConfig.go",
         "reader.go",
     ],
     importpath = "github.com/bazelbuild/rules_docker/container/go/pkg/compat",

--- a/container/go/pkg/compat/overrideConfig.go
+++ b/container/go/pkg/compat/overrideConfig.go
@@ -1,0 +1,530 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+////////////////////////////////////////////////
+// This package manipulates v2.2 image configuration metadata.
+// It writes out both a config file and a manifest for the v2.2 image.
+
+package compat
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+const (
+	// defaultProcArch is the default architecture type based on legacy create_image_config.py.
+	defaultProcArch = "amd64"
+	// defaultTimeStamp is the unix epoch 0 time representation in 32 bits.
+	defaultTimestamp = "1970-01-01T00:00:00Z"
+)
+
+// OverrideConfigOpts holds all configuration settings for the newly outputted config file.
+type OverrideConfigOpts struct {
+	// ConfigFile is the base config.json file.
+	ConfigFile *v1.ConfigFile
+	// OutputConfig is where to write the modified config file to.
+	OutputConfig string
+	// CreationTimeString is the creation timestamp.
+	// Accepted in integer or floating point seconds since Unix Epoch, RFC3339 date/time.
+	CreationTimeString string
+	// User is the username to run the commands under.
+	User string
+	// Workdir is the working directory to set for the layer.
+	Workdir string
+	// NullEntrypoint indicates if there is an entrypoint.
+	// If true, Entrypoint will be set to null.
+	NullEntryPoint bool
+	// NullCmd indicates if there is a command.
+	// If true, Command will be set to null.
+	NullCmd bool
+	// OperatingSystem is the operating system to creater docker image for.
+	OperatingSystem string
+	// CreatedBy is the command that generated the image. Default bazel build...
+	CreatedBy string
+	// Author is the author of the image. Default bazel.
+	Author string
+	// LabelsArray is the labels used to augment those of the previous layer.
+	LabelsArray []string
+	// Ports are the ports used to augment those of the previous layer.
+	Ports []string
+	// Volumes are the volumes used to augment those of the previous layer.
+	Volumes []string
+	// EntrypointPrefix is the prefix to the entrypoint with the specified arguments.
+	EntrypointPrefix []string
+	// Env are the environments to augment those of the previous layer.
+	Env []string
+	// Command are the command(s) to override those of the previous layer.
+	Command []string
+	// Entrypoint are the new entrypoints to override entrypoint of previous layer.
+	Entrypoint []string
+	// Layer is the list of layer sha256 hashes that compose the image for which the config is written.
+	Layer []string
+	// StampInfoFile is a list of files from which to read substitutions of variables from.
+	StampInfoFile []string
+}
+
+// validate ensures that CreatedBy and Author are set.
+// based on current implementation, we expect them to never be empty.
+func (o *OverrideConfigOpts) validate() error {
+	if o.CreatedBy == "" {
+		return errors.New("CreatedBy was not specified")
+	}
+	if o.Author == "" {
+		return errors.New("Author was not specified")
+	}
+
+	return nil
+}
+
+// emptySHA256Digest returns the sha256 sum of an empty string.
+func emptySHA256Digest() (empty string) {
+	b := sha256.Sum256([]byte(""))
+	empty = hex.EncodeToString(b[:])
+	return
+}
+
+// extractValue returns the contents of a file pointed to by value if it starts with a '@'.
+func extractValue(value string) (string, error) {
+	if strings.HasPrefix(value, "@") {
+		f, err := os.Open(value[1:])
+		defer f.Close()
+		shaHash, err := ioutil.ReadAll(f)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to read content from file %s", value)
+		}
+		return string(shaHash), nil
+	}
+	return value, errors.Wrapf(nil, "unexpected value, got: %s want: @{...}", value)
+}
+
+// keyValueToMap converts an array of strings separated by '=' into a map of key-value pairs.
+func keyValueToMap(value []string) (map[string]string, error) {
+	convMap := make(map[string]string)
+	var temp []string
+	for _, kvpair := range value {
+		temp = strings.Split(kvpair, "=")
+		if len(temp) != 2 {
+			return convMap, errors.New("value in array are not of format key=value")
+		}
+		key, val := temp[0], temp[1]
+		convMap[key] = val
+	}
+	return convMap, nil
+}
+
+// Stamp provides the substitutions of variables inside {} using info in file pointed to
+// by stampInfoFile.
+func Stamp(inp string, stampInfoFile []string) (string, error) {
+	if len(stampInfoFile) == 0 || inp == "" {
+		return inp, nil
+	}
+	formatArgs := make(map[string]interface{})
+	for _, infofile := range stampInfoFile {
+		f, err := os.Open(infofile)
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to open file %s", infofile)
+		}
+		defer f.Close()
+		// scanner reads line by line and discards '\n' character by default.
+		scanner := bufio.NewScanner(f)
+		var temp []string
+		for scanner.Scan() {
+			temp = strings.Split(scanner.Text(), " ")
+			key, val := temp[0], temp[1]
+			if _, ok := formatArgs[key]; ok {
+				fmt.Printf("WARNING: Duplicate value for key %s: using %s", key, val)
+			}
+			formatArgs[key] = val
+		}
+		if err = scanner.Err(); err != nil {
+			return "", errors.Wrapf(err, "failed to read line from file %s", infofile)
+		}
+	}
+
+	o := inp
+	for k, v := range formatArgs {
+		if vStr, ok := v.(string); ok {
+			o = strings.ReplaceAll(o, fmt.Sprintf("{%s}", k), vStr)
+		} else {
+			return "", errors.New("argument to format is not of string type")
+		}
+	}
+	return o, nil
+}
+
+// mapToKeyValue reverses a map to a '='-separated array of strings in {key}={value} format.
+func mapToKeyValue(kvMap map[string]string) []string {
+	keyVals := []string{}
+	for k, v := range kvMap {
+		keyVals = append(keyVals, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	sort.Strings(keyVals)
+	return keyVals
+}
+
+// resolveVariables resolves the environment variables embedded in the given value using
+// provided map of environment variable expansions.
+// It handles formats like "PATH=$PATH:..."
+func expandEnvVars(val string, env map[string]string) string {
+	return os.Expand(val, func(k string) string {
+		return env[k]
+	})
+}
+
+// getCreationTime returns the correct creation time for which to override the current config file.
+func getCreationTime(overrideInfo *OverrideConfigOpts) (time.Time, error) {
+	// createTime stores the input creation time with macros substituted.
+	var createTime string
+	var creationTime time.Time
+	var err error
+	if overrideInfo.CreationTimeString == "" {
+		creationTime, err = time.Parse(time.RFC3339, defaultTimestamp)
+		if err != nil {
+			return time.Time{}, errors.Wrapf(err, "unable to parse the default unix epoch time %s", defaultTimestamp)
+		}
+		return creationTime, nil
+	}
+	// Parse for specific time formats.
+	var unixTime float64
+	// Use stamp to as preliminary replacement.
+	if createTime, err = Stamp(overrideInfo.CreationTimeString, overrideInfo.StampInfoFile); err != nil {
+		return time.Time{}, errors.Wrapf(err, "unable to substitute %s from BUILD_TIMESTAMP macros", overrideInfo.CreationTimeString)
+	}
+	// If creationTime is parsable as a floating point type, assume unix epoch timestamp.
+	// otherwise, assume RFC 3339 date/time format.
+	unixTime, err = strconv.ParseFloat(createTime, 64)
+	// Assume RFC 3339 date/time format. No err means it is parsable as floating point.
+	if err == nil {
+		// Ensure that the parsed time is within the floating point range.
+		// Values > 1e11 are assumed to be unix epoch milliseconds.
+		if unixTime > 1.0e+11 {
+			unixTime = unixTime / 1000.0
+		}
+		// Construct a RFC 3339 date/time from Unix epoch.
+		sec, dec := math.Modf(unixTime)
+		creationTime = time.Unix(int64(sec), int64(dec*(1e9))).UTC()
+	} else {
+		creationTime, err = time.Parse(time.RFC3339, createTime)
+		if err != nil {
+			return time.Time{}, errors.Wrapf(err, "failed to parse %q as RFC3339. Assumed format to be RFC3339 as it failed to parse as a float as well", createTime)
+		}
+	}
+
+	return creationTime, nil
+}
+
+// stampValues returns an updated version of the input infoToStamp.
+func stampValues(values, stampInfoFiles []string) ([]string, error) {
+	var result []string
+	for _, entry := range values {
+		stampedEntry, err := Stamp(entry, stampInfoFiles)
+		if err != nil {
+			return []string{}, errors.Wrapf(err, "unable to perform substitutions to Env variable %s", entry)
+		}
+		result = append(result, stampedEntry)
+	}
+
+	return result, nil
+}
+
+// resolveEnvironment returns a string array with fully substituted environment variables.
+func resolveEnvironment(overrideInfo *OverrideConfigOpts, environMap map[string]string) ([]string, error) {
+	var baseEnvMap = make(map[string]string)
+	var err error
+	if len(overrideInfo.ConfigFile.Config.Env) > 0 {
+		baseEnvMap, err = keyValueToMap(overrideInfo.ConfigFile.Config.Env)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error converting Config env array %v to map", overrideInfo.ConfigFile.Config.Env)
+		}
+	}
+	result := make(map[string]string)
+	for k, v := range baseEnvMap {
+		result[k] = v
+	}
+	for k, v := range environMap {
+		var expanded string
+		expanded = expandEnvVars(v, baseEnvMap)
+		result[k] = expanded
+	}
+
+	return mapToKeyValue(result), nil
+}
+
+// resolveLabels returns a map of labels to their extracted and stamped formats.
+func resolveLabels(overrideInfo *OverrideConfigOpts) (map[string]string, error) {
+	var labels = make(map[string]string)
+	labels, err := keyValueToMap(overrideInfo.LabelsArray)
+	if err != nil {
+		return labels, errors.Wrapf(err, "error converting labels array %v to map", overrideInfo.LabelsArray)
+	}
+	var extractedValue string
+	for label, value := range labels {
+		if strings.HasPrefix(value, "@") {
+			if extractedValue, err = extractValue(value); err != nil {
+				return labels, errors.Wrap(err, "failed to extract the contents of labels file")
+			}
+			labels[label] = extractedValue
+			continue
+		}
+		if strings.Contains(value, "{") {
+			if extractedValue, err = Stamp(value, overrideInfo.StampInfoFile); err != nil {
+				return labels, errors.Wrapf(err, "failed to format the string accordingly at %s", value)
+			}
+			labels[label] = extractedValue
+		}
+	}
+
+	return labels, nil
+}
+
+// updateConfigLabels returns the set of labels to assign to config.
+func updateConfigLabels(overrideInfo *OverrideConfigOpts, labels map[string]string) map[string]string {
+	labelsMap := make(map[string]string)
+	if len(overrideInfo.ConfigFile.Config.Labels) > 0 {
+		labelsMap = overrideInfo.ConfigFile.Config.Labels
+	}
+	for k, v := range labels {
+		labelsMap[k] = v
+	}
+
+	return labelsMap
+}
+
+// updateExposedPorts modifies the config's exposed ports based on the input ports.
+func updateExposedPorts(overrideInfo *OverrideConfigOpts) error {
+	for _, port := range overrideInfo.Ports {
+		match, err := regexp.MatchString("[0-9]+/(tcp|udp)", port)
+		if err != nil {
+			return errors.Wrapf(err, "failed to successfully match regex to %s", port)
+		}
+		if match {
+			// the port spec has the form 80/tcp, 1234/udp so simply use it as the key.
+			overrideInfo.ConfigFile.Config.ExposedPorts[port] = struct{}{}
+		} else {
+			// assume tcp
+			overrideInfo.ConfigFile.Config.ExposedPorts[port+"/tcp"] = struct{}{}
+		}
+	}
+
+	return nil
+}
+
+// updateVolumes modifies the config's volumes based on the input volumes.
+func updateVolumes(overrideInfo *OverrideConfigOpts) error {
+	for _, volume := range overrideInfo.Volumes {
+		overrideInfo.ConfigFile.Config.Volumes[volume] = struct{}{}
+	}
+
+	return nil
+}
+
+// updateConfigLayeres modifies the config's layers metadata based on the input layer IDs and history.
+func updateConfigLayers(overrideInfo *OverrideConfigOpts, layerDigests []string, creationTime time.Time) error {
+	// diffIDs are ordered from bottom-most to top-most.
+	diffIDs := []v1.Hash{}
+	if len(overrideInfo.ConfigFile.RootFS.DiffIDs) > 0 {
+		diffIDs = overrideInfo.ConfigFile.RootFS.DiffIDs
+	}
+	if len(overrideInfo.Layer) > 0 {
+		var diffIDToAdd v1.Hash
+		for _, diffID := range layerDigests {
+			if diffID != emptySHA256Digest() {
+				diffIDToAdd = v1.Hash{Algorithm: "sha256", Hex: diffID}
+				diffIDs = append(diffIDs, diffIDToAdd)
+			}
+		}
+		overrideInfo.ConfigFile.RootFS = v1.RootFS{Type: "layers", DiffIDs: diffIDs}
+
+		// length of history is expected to match the length of diff_ids.
+		history := []v1.History{}
+		if len(overrideInfo.ConfigFile.History) > 0 {
+			history = overrideInfo.ConfigFile.History
+		}
+		var historyToAdd v1.History
+
+		for _, l := range layerDigests {
+			var createdBy = overrideInfo.CreatedBy
+			var authorToAdd = overrideInfo.Author
+
+			if err := overrideInfo.validate(); err != nil {
+				return errors.Wrapf(err, "unable to create a new config because the given options to override the existing image config/generate new config failed validation")
+			}
+
+			historyToAdd = v1.History{
+				Author:    authorToAdd,
+				Created:   v1.Time{creationTime},
+				CreatedBy: createdBy,
+			}
+			if l == emptySHA256Digest() {
+				historyToAdd.EmptyLayer = true
+			}
+			// prepend to history list.
+			history = append([]v1.History{historyToAdd}, history...)
+		}
+		overrideInfo.ConfigFile.History = history
+	}
+
+	return nil
+}
+
+// OverrideImageConfig updates the current image config file to reflect the given changes.
+func OverrideImageConfig(overrideInfo *OverrideConfigOpts) error {
+	overrideInfo.ConfigFile.Author = "Bazel"
+	overrideInfo.ConfigFile.OS = overrideInfo.OperatingSystem
+	overrideInfo.ConfigFile.Architecture = defaultProcArch
+
+	var err error
+	var creationTime time.Time
+	// creationTime is the RFC 3339 formatted time derived from createTime input.
+	if creationTime, err = getCreationTime(overrideInfo); err != nil {
+		return errors.Wrap(err, "failed to correctly parse creation time from config")
+	}
+	overrideInfo.ConfigFile.Created = v1.Time{creationTime}
+
+	if overrideInfo.NullEntryPoint {
+		overrideInfo.ConfigFile.Config.Entrypoint = nil
+	} else if len(overrideInfo.Entrypoint) > 0 {
+		overrideEntryPoint, err := stampValues(overrideInfo.Entrypoint[:], overrideInfo.StampInfoFile[:])
+		if err != nil {
+			return errors.Wrap(err, "failed to correctly parse entrypoint from config")
+		}
+		overrideInfo.ConfigFile.Config.Entrypoint = overrideEntryPoint
+	}
+
+	if overrideInfo.NullCmd {
+		overrideInfo.ConfigFile.Config.Cmd = nil
+	} else if len(overrideInfo.Command) > 0 {
+		overrideNullCmd, err := stampValues(overrideInfo.Command[:], overrideInfo.StampInfoFile[:])
+		if err != nil {
+			return errors.Wrap(err, "failed to correctly parse entrypoint from config")
+		}
+		overrideInfo.ConfigFile.Config.Cmd = overrideNullCmd
+	}
+
+	stampedUser, err := Stamp(overrideInfo.User, overrideInfo.StampInfoFile)
+	if err != nil {
+		errors.Wrapf(err, "unable to perform substitutions to user %s", overrideInfo.User)
+	}
+	overrideInfo.ConfigFile.Config.User = stampedUser
+
+	var environMap map[string]string
+	if environMap, err = keyValueToMap(overrideInfo.Env); err != nil {
+		return errors.Wrapf(err, "error converting env array %v to map", overrideInfo.Env)
+	}
+	for key, valToBeStamped := range environMap {
+		stampedValue, err := Stamp(valToBeStamped, overrideInfo.StampInfoFile)
+		if err != nil {
+			return errors.Wrapf(err, "error stamping value %s", valToBeStamped)
+		}
+		environMap[key] = stampedValue
+	}
+	// perform any substitutions of $VAR or ${VAR} with environment variables.
+	if len(environMap) != 0 {
+		overrideEnv, err := resolveEnvironment(overrideInfo, environMap)
+		if err != nil {
+			return errors.Wrap(err, "failed to correctly parse environment variables from config")
+		}
+		overrideInfo.ConfigFile.Config.Env = overrideEnv
+	}
+
+	var labels = make(map[string]string)
+	if labels, err = resolveLabels(overrideInfo); err != nil {
+		return errors.Wrap(err, "failed to correctly resolve labels from config")
+	}
+	if len(overrideInfo.LabelsArray) > 0 {
+		labelsMap := updateConfigLabels(overrideInfo, labels)
+		overrideInfo.ConfigFile.Config.Labels = labelsMap
+	}
+
+	if len(overrideInfo.Ports) > 0 {
+		if len(overrideInfo.ConfigFile.Config.ExposedPorts) == 0 {
+			overrideInfo.ConfigFile.Config.ExposedPorts = make(map[string]struct{})
+		}
+		if err = updateExposedPorts(overrideInfo); err != nil {
+			return errors.Wrap(err, "failed to correctly update exposed ports from config")
+		}
+	}
+
+	if len(overrideInfo.Volumes) > 0 {
+		if len(overrideInfo.ConfigFile.Config.Volumes) == 0 {
+			overrideInfo.ConfigFile.Config.Volumes = make(map[string]struct{})
+		}
+		if err = updateVolumes(overrideInfo); err != nil {
+			return errors.Wrap(err, "failed to correctly update volumes from config")
+		}
+	}
+
+	if overrideInfo.Workdir != "" {
+		stampedWorkdir, err := Stamp(overrideInfo.Workdir, overrideInfo.StampInfoFile)
+		if err != nil {
+			return errors.Wrapf(err, "unable to stamp the working directory %s", overrideInfo.Workdir)
+		}
+		overrideInfo.ConfigFile.Config.WorkingDir = stampedWorkdir
+	}
+
+	// layerDigests are diffIDs extracted from each layer file.
+	layerDigests := []string{}
+	for _, l := range overrideInfo.Layer {
+		newLayer, err := extractValue(l)
+		if err != nil {
+			return errors.Wrap(err, "failed to extract the contents of layer file: %v")
+		}
+		layerDigests = append(layerDigests, newLayer)
+	}
+	if err = updateConfigLayers(overrideInfo, layerDigests, creationTime); err != nil {
+		return errors.Wrap(err, "failed to correctly update layers from config")
+	}
+
+	if len(overrideInfo.EntrypointPrefix) != 0 {
+		newEntrypoint := append(overrideInfo.ConfigFile.Config.Entrypoint, overrideInfo.EntrypointPrefix...)
+		overrideInfo.ConfigFile.Config.Entrypoint = newEntrypoint
+	}
+
+	if err = writeConfig(overrideInfo.ConfigFile, overrideInfo.OutputConfig); err != nil {
+		return errors.Wrap(err, "failed to create updated Image Config.")
+	}
+
+	return nil
+}
+
+// writeConfig writes a json representation of a config file to outPath.
+func writeConfig(configFile *v1.ConfigFile, outPath string) error {
+	rawConfig, err := json.Marshal(configFile)
+	if err != nil {
+		return errors.Wrap(err, "unable to read config struct into json object")
+	}
+
+	err = ioutil.WriteFile(outPath, rawConfig, os.ModePerm)
+	if err != nil {
+		return errors.Wrapf(err, "writing config to %s was unsuccessful", outPath)
+	}
+
+	return nil
+}

--- a/container/go/pkg/compat/overrideConfig.go
+++ b/container/go/pkg/compat/overrideConfig.go
@@ -130,7 +130,7 @@ func keyValueToMap(value []string) (map[string]string, error) {
 	for _, kvpair := range value {
 		temp = strings.Split(kvpair, "=")
 		if len(temp) != 2 {
-			return convMap, errors.New("value in array are not of format key=value")
+			return convMap, errors.New(fmt.Sprintf("%q is not of format key=value", kvpair))
 		}
 		key, val := temp[0], temp[1]
 		convMap[key] = val
@@ -144,7 +144,7 @@ func Stamp(inp string, stampInfoFile []string) (string, error) {
 	if len(stampInfoFile) == 0 || inp == "" {
 		return inp, nil
 	}
-	formatArgs := make(map[string]interface{})
+	formatArgs := make(map[string]string)
 	for _, infofile := range stampInfoFile {
 		f, err := os.Open(infofile)
 		if err != nil {
@@ -169,11 +169,7 @@ func Stamp(inp string, stampInfoFile []string) (string, error) {
 
 	o := inp
 	for k, v := range formatArgs {
-		if vStr, ok := v.(string); ok {
-			o = strings.ReplaceAll(o, fmt.Sprintf("{%s}", k), vStr)
-		} else {
-			return "", errors.New("argument to format is not of string type")
-		}
+		o = strings.ReplaceAll(o, fmt.Sprintf("{%s}", k), v)
 	}
 	return o, nil
 }


### PR DESCRIPTION
* Implement `createImageConfig.go` to write out modified config file and empty/base manifest file, maintaining parity with the current behaviour
* Implement an `overrideConfig.go` binary to mutate the base config file to match the updates supplied in the flags. This also contains the `Stamp` utility function that the digester is dependent on.