### PR TITLE
Update image.bzl to optionally utilize new createImageConfig Go binary

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -110,7 +110,7 @@ def _add_go_args(
         base_config,
         base_manifest,
         operating_system):
-    args = [
+    args += [
         "-outputConfig",
         "%s" % config.path,
     ] + [
@@ -154,7 +154,7 @@ def _add_go_args(
     if workdir:
         args += ["-workdir", workdir]
 
-    inputs = layer_names
+    inputs += layer_names
     for layer_name in layer_names:
         args += ["-layerDigestFile", "@" + layer_name.path]
 
@@ -203,7 +203,7 @@ def _add_legacy_args(
         base_config,
         base_manifest,
         operating_system):
-    args = [
+    args += [
         "--output=%s" % config.path,
     ] + [
         "--manifestoutput=%s" % manifest.path,
@@ -242,7 +242,7 @@ def _add_legacy_args(
     if workdir:
         args += ["--workdir=" + workdir]
 
-    inputs = layer_names
+    inputs += layer_names
     for layer_name in layer_names:
         args += ["--layer=@" + layer_name.path]
 
@@ -272,15 +272,6 @@ def _add_legacy_args(
             "--entrypoint_prefix=%s" % x
             for x in ["/" + ctx.file.launcher.basename] + ctx.attr.launcher_args
         ]
-    
-    ctx.actions.run(
-        executable = ctx.executable.create_image_config,
-        arguments = args,
-        inputs = inputs,
-        outputs = [config, manifest],
-        use_default_shell_env = True,
-        mnemonic = "ImageConfig",
-    )
 
 def _image_config(
         ctx,
@@ -324,7 +315,6 @@ def _image_config(
             inputs,
             manifest,
             config,
-            manifest,
             labels,
             entrypoint,
             cmd,
@@ -345,7 +335,6 @@ def _image_config(
             inputs,
             manifest,
             config,
-            manifest,
             labels,
             entrypoint,
             cmd,
@@ -359,7 +348,7 @@ def _image_config(
             base_manifest,
             operating_system)
         exec = ctx.executable.go_create_image_config
-    
+
     ctx.actions.run(
         executable = exec,
         arguments = args,
@@ -368,7 +357,7 @@ def _image_config(
         use_default_shell_env = True,
         mnemonic = "ImageConfig",
     )
-    
+
     return config, _sha256(ctx, config), manifest, _sha256(ctx, manifest)
 
 def _repository_name(ctx):
@@ -635,18 +624,8 @@ def _impl(
 _attrs = dicts.add(_layer.attrs, {
     "base": attr.label(allow_files = container_filetype),
     "cmd": attr.string_list(),
-    "legacy_create_image_config": attr.bool(
-        default = True,
-        doc = ("If set to False, the Go create_image_config binary will be run instead."),
-    ),
     "create_image_config": attr.label(
         default = Label("//container:create_image_config"),
-        cfg = "host",
-        executable = True,
-        allow_files = True,
-    ),
-    "go_create_image_config": attr.label(
-        default = Label("//container/go/cmd/create_image_config:create_image_config"),
         cfg = "host",
         executable = True,
         allow_files = True,
@@ -654,6 +633,12 @@ _attrs = dicts.add(_layer.attrs, {
     "creation_time": attr.string(),
     "docker_run_flags": attr.string(),
     "entrypoint": attr.string_list(),
+    "go_create_image_config": attr.label(
+        default = Label("//container/go/cmd/create_image_config:create_image_config"),
+        cfg = "host",
+        executable = True,
+        allow_files = True,
+    ),
     "label_file_strings": attr.string_list(),
     # Implicit/Undocumented dependencies.
     "label_files": attr.label_list(
@@ -663,6 +648,10 @@ _attrs = dicts.add(_layer.attrs, {
     "launcher": attr.label(allow_single_file = True),
     "launcher_args": attr.string_list(default = []),
     "layers": attr.label_list(providers = [LayerInfo]),
+    "legacy_create_image_config": attr.bool(
+        default = True,
+        doc = ("If set to False, the Go create_image_config binary will be run instead."),
+    ),
     "legacy_repository_naming": attr.bool(default = False),
     "legacy_run_behavior": attr.bool(
         # TODO(mattmoor): Default this to False.

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -326,7 +326,8 @@ def _image_config(
             layer_names,
             base_config,
             base_manifest,
-            operating_system)
+            operating_system,
+        )
         exec = ctx.executable.create_image_config
     else:
         _add_go_args(
@@ -346,7 +347,8 @@ def _image_config(
             layer_names,
             base_config,
             base_manifest,
-            operating_system)
+            operating_system,
+        )
         exec = ctx.executable.go_create_image_config
 
     ctx.actions.run(

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -124,84 +124,168 @@ def _image_config(
         else:
             labels[label] = fname
 
-    args = [
-        "--output=%s" % config.path,
-    ] + [
-        "--manifestoutput=%s" % manifest.path,
-    ] + [
-        "--entrypoint=%s" % x
-        for x in entrypoint
-    ] + [
-        "--command=%s" % x
-        for x in cmd
-    ] + [
-        "--ports=%s" % x
-        for x in ctx.attr.ports
-    ] + [
-        "--volumes=%s" % x
-        for x in ctx.attr.volumes
-    ] + [
-        "--null_entrypoint=%s" % null_entrypoint,
-    ] + [
-        "--null_cmd=%s" % null_cmd,
-    ]
-    if creation_time:
-        args += ["--creation_time=%s" % creation_time]
-    elif ctx.attr.stamp:
-        # If stamping is enabled, and the creation_time is not manually defined,
-        # default to '{BUILD_TIMESTAMP}'.
-        args += ["--creation_time={BUILD_TIMESTAMP}"]
+    if ctx.attr.legacy_create_image_config:
+        args = [
+            "--output=%s" % config.path,
+        ] + [
+            "--manifestoutput=%s" % manifest.path,
+        ] + [
+            "--entrypoint=%s" % x
+            for x in entrypoint
+        ] + [
+            "--command=%s" % x
+            for x in cmd
+        ] + [
+            "--ports=%s" % x
+            for x in ctx.attr.ports
+        ] + [
+            "--volumes=%s" % x
+            for x in ctx.attr.volumes
+        ] + [
+            "--null_entrypoint=%s" % null_entrypoint,
+        ] + [
+            "--null_cmd=%s" % null_cmd,
+        ]
+        if creation_time:
+            args += ["--creation_time=%s" % creation_time]
+        elif ctx.attr.stamp:
+            # If stamping is enabled, and the creation_time is not manually defined,
+            # default to '{BUILD_TIMESTAMP}'.
+            args += ["--creation_time={BUILD_TIMESTAMP}"]
 
-    args += ["--labels=%s" % "=".join([key, value]) for key, value in labels.items()]
-    args += ["--env=%s" % "=".join([
-        ctx.expand_make_variables("env", key, {}),
-        ctx.expand_make_variables("env", value, {}),
-    ]) for key, value in env.items()]
+        args += ["--labels=%s" % "=".join([key, value]) for key, value in labels.items()]
+        args += ["--env=%s" % "=".join([
+            ctx.expand_make_variables("env", key, {}),
+            ctx.expand_make_variables("env", value, {}),
+        ]) for key, value in env.items()]
 
-    if ctx.attr.user:
-        args += ["--user=" + ctx.attr.user]
-    if workdir:
-        args += ["--workdir=" + workdir]
+        if ctx.attr.user:
+            args += ["--user=" + ctx.attr.user]
+        if workdir:
+            args += ["--workdir=" + workdir]
 
-    inputs = layer_names
-    for layer_name in layer_names:
-        args += ["--layer=@" + layer_name.path]
+        inputs = layer_names
+        for layer_name in layer_names:
+            args += ["--layer=@" + layer_name.path]
 
-    if ctx.attr.label_files:
-        inputs += ctx.files.label_files
+        if ctx.attr.label_files:
+            inputs += ctx.files.label_files
 
-    if base_config:
-        args += ["--base=%s" % base_config.path]
-        inputs += [base_config]
+        if base_config:
+            args += ["--base=%s" % base_config.path]
+            inputs += [base_config]
 
-    if base_manifest:
-        args += ["--basemanifest=%s" % base_manifest.path]
-        inputs += [base_manifest]
+        if base_manifest:
+            args += ["--basemanifest=%s" % base_manifest.path]
+            inputs += [base_manifest]
 
-    if operating_system:
-        args += ["--operating_system=%s" % operating_system]
+        if operating_system:
+            args += ["--operating_system=%s" % operating_system]
 
-    if ctx.attr.stamp:
-        stamp_inputs = [ctx.info_file, ctx.version_file]
-        args += ["--stamp-info-file=%s" % f.path for f in stamp_inputs]
-        inputs += stamp_inputs
+        if ctx.attr.stamp:
+            stamp_inputs = [ctx.info_file, ctx.version_file]
+            args += ["--stamp-info-file=%s" % f.path for f in stamp_inputs]
+            inputs += stamp_inputs
 
-    if ctx.attr.launcher_args and not ctx.attr.launcher:
-        fail("launcher_args does nothing when launcher is not specified.", attr = "launcher_args")
-    if ctx.attr.launcher:
-        args += [
-            "--entrypoint_prefix=%s" % x
-            for x in ["/" + ctx.file.launcher.basename] + ctx.attr.launcher_args
+        if ctx.attr.launcher_args and not ctx.attr.launcher:
+            fail("launcher_args does nothing when launcher is not specified.", attr = "launcher_args")
+        if ctx.attr.launcher:
+            args += [
+                "--entrypoint_prefix=%s" % x
+                for x in ["/" + ctx.file.launcher.basename] + ctx.attr.launcher_args
+            ]
+        
+        ctx.actions.run(
+            executable = ctx.executable.create_image_config,
+            arguments = args,
+            inputs = inputs,
+            outputs = [config, manifest],
+            use_default_shell_env = True,
+            mnemonic = "ImageConfig",
+        )
+    else:
+        args = [
+            "-outputConfig",
+            "%s" % config.path,
+        ] + [
+            "-outputManifest",
+            "%s" % manifest.path,
         ]
 
-    ctx.actions.run(
-        executable = ctx.executable.create_image_config,
-        arguments = args,
-        inputs = inputs,
-        outputs = [config, manifest],
-        use_default_shell_env = True,
-        mnemonic = "ImageConfig",
-    )
+        if null_entrypoint:
+            args += ["-nullEntryPoint"]
+
+        if null_cmd:
+            args += ["-nullCmd"]
+
+        for x in entrypoint:
+            args += ["-entrypoint", "%s" % x]
+        for x in cmd:
+            args += ["-command", "%s" % x]
+        for x in ctx.attr.ports:
+            args += ["-ports", "%s" % x]
+        for x in ctx.attr.volumes:
+            args += ["-volumes", "%s" % x]
+
+        if creation_time:
+            args += ["-creationTime", "%s" % creation_time]
+        elif ctx.attr.stamp:
+            # If stamping is enabled, and the creation_time is not manually defined,
+            # default to '{BUILD_TIMESTAMP}'.
+            args += ["-creationTime", "{BUILD_TIMESTAMP}"]
+
+        for key, value in labels.items():
+            args += ["-labels", "%s" % "=".join([key, value])]
+
+        for key, value in env.items():
+            args += ["-env", "%s" % "=".join([
+                ctx.expand_make_variables("env", key, {}),
+                ctx.expand_make_variables("env", value, {}),
+            ])]
+
+        if ctx.attr.user:
+            args += ["-user", ctx.attr.user]
+        if workdir:
+            args += ["-workdir", workdir]
+
+        inputs = layer_names
+        for layer_name in layer_names:
+            args += ["-layerDigestFile", "@" + layer_name.path]
+
+        if ctx.attr.label_files:
+            inputs += ctx.files.label_files
+
+        if base_config:
+            args += ["-baseConfig", "%s" % base_config.path]
+            inputs += [base_config]
+
+        if base_manifest:
+            args += ["-baseManifest", "%s" % base_manifest.path]
+            inputs += [base_manifest]
+
+        if operating_system:
+            args += ["-operatingSystem", "%s" % operating_system]
+
+        if ctx.attr.stamp:
+            stamp_inputs = [ctx.info_file, ctx.version_file]
+            for f in stamp_inputs:
+                args += ["-stampInfoFile", "%s" % f.path]
+            inputs += stamp_inputs
+
+        if ctx.attr.launcher_args and not ctx.attr.launcher:
+            fail("launcher_args does nothing when launcher is not specified.", attr = "launcher_args")
+        if ctx.attr.launcher:
+            for x in ["/" + ctx.file.launcher.basename]:
+                args += ["-entrypointPrefix", "%s" % x]
+            args += ctx.attr.launcher_args
+        ctx.actions.run(
+            executable = ctx.executable.go_create_image_config,
+            arguments = args,
+            inputs = inputs,
+            outputs = [config, manifest],
+            use_default_shell_env = True,
+            mnemonic = "Go ImageConfig",
+        )
     return config, _sha256(ctx, config), manifest, _sha256(ctx, manifest)
 
 def _repository_name(ctx):
@@ -468,8 +552,18 @@ def _impl(
 _attrs = dicts.add(_layer.attrs, {
     "base": attr.label(allow_files = container_filetype),
     "cmd": attr.string_list(),
+    "legacy_create_image_config": attr.bool(
+        default = True,
+        doc = ("If set to False, the Go create_image_config binary will be ran instead."),
+    ),
     "create_image_config": attr.label(
         default = Label("//container:create_image_config"),
+        cfg = "host",
+        executable = True,
+        allow_files = True,
+    ),
+    "go_create_image_config": attr.label(
+        default = Label("//container/go/cmd/create_image_config:create_image_config"),
         cfg = "host",
         executable = True,
         allow_files = True,


### PR DESCRIPTION
* Modify `image.bzl` to accept Golang flags

Note: the image_test.py will fail when using the new Go createImageConfig binary until the sha256 sums are updated to reflect these new changes. See https://github.com/bazelbuild/rules_docker/pull/1024 for how to update the tests accordingly.