### PR TITLE
README.md: add the K8s Container Image Promoter to adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2503,6 +2503,7 @@ Here's a (non-exhaustive) list of companies that use `rules_docker` in productio
   * [Etsy](https://www.etsy.com)
   * [Evertz](https://evertz.com/)
   * [Jetstack](https://www.jetstack.io/)
+  * [Kubernetes Container Image Promoter](https://github.com/kubernetes-sigs/k8s-container-image-promoter)
   * [Prow](https://github.com/kubernetes/test-infra/tree/master/prow)
   * [Tink](https://www.tink.com)
   * [Wix](https://www.wix.com)


### PR DESCRIPTION
Add the Container Image Promoter project to the list of adopters.

Technically the promoter is not a "company" but it certainly uses rules_docker.