### PR TITLE
Add xz_path to default toolchain

### DIFF
--- a/toolchains/docker/BUILD
+++ b/toolchains/docker/BUILD
@@ -29,11 +29,13 @@ toolchain_type(
 )
 
 # Default docker toolchain that expects the 'docker' executable
-# to be in the PATH
+# to be in the PATH.
+# Also expects xz to be in PATH if needed for xz compression.
 docker_toolchain(
     name = "default_toolchain_impl",
     tool_path = "docker",
     visibility = ["//visibility:public"],
+    xz_path = "xz",
 )
 
 toolchain(


### PR DESCRIPTION
Enables use of xz_path in cases in which toolchain is not created via workspace rule.