### PR TITLE
Add (again) xz_path to default toolchain"

### DIFF
--- a/toolchains/docker/BUILD
+++ b/toolchains/docker/BUILD
@@ -29,11 +29,13 @@ toolchain_type(
 )
 
 # Default docker toolchain that expects the 'docker' executable
-# to be in the PATH
+# to be in the PATH.
+# Also expects xz to be in PATH if needed for xz compression.
 docker_toolchain(
     name = "default_toolchain_impl",
     tool_path = "docker",
     visibility = ["//visibility:public"],
+    xz_path = "xz",
 )
 
 toolchain(


### PR DESCRIPTION
DO NOT REVIEW YET.
Just need to have CI run on this again

This PR Reverts bazelbuild/rules_docker#1086, which in turn reverts https://github.com/bazelbuild/rules_docker/pull/1084