### PR TITLE
Fix apt-get being too slow in download_pkgs in some ubuntu images

### DIFF
--- a/docker/package_managers/download_pkgs.bzl
+++ b/docker/package_managers/download_pkgs.bzl
@@ -27,6 +27,7 @@ set -ex
 # Remove /var/lib/apt/lists/* in the base image. apt-get update -y command will create them.
 rm -rf /var/lib/apt/lists/*
 # Fetch Index
+apt-get clean -y
 apt-get update -y
 # Make partial dir
 mkdir -p /tmp/install/./partial

--- a/testing/examples/WORKSPACE
+++ b/testing/examples/WORKSPACE
@@ -50,13 +50,14 @@ new_container_pull(
 
 new_container_pull(
     name = "ubuntu1604",
+    digest = "sha256:11c1bc6060236f3dd6c219bba569b887f231e17bd54b0c60b4023dc610863b15",
     registry = "l.gcr.io",
     repository = "google/ubuntu1604",
-    tag = "latest",
 )
 
 new_container_pull(
     name = "bazel_image",
+    digest = "sha256:35d7537a34314eddaa478b879f0a0725837c8840f7293210bf7f8912bbdcf9e8",
     registry = "launcher.gcr.io",
     repository = "google/bazel",
 )


### PR DESCRIPTION
Set a ulimit on the number of opened files instead of the default
unlimited.