### PR TITLE
Allow callers to specify entrypoint in py_image macro

### DIFF
--- a/python/image.bzl
+++ b/python/image.bzl
@@ -72,7 +72,7 @@ def py_layer(name, deps, filter = "", **kwargs):
     native.py_library(name = binary_name, deps = deps, **kwargs)
     filter_layer(name = name, dep = binary_name, filter = filter)
 
-def py_image(name, base = None, deps = [], layers = [], **kwargs):
+def py_image(name, base = None, deps = [], layers = [], entrypoint = None, **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
     Args:
@@ -106,7 +106,7 @@ def py_image(name, base = None, deps = [], layers = [], **kwargs):
     app_layer(
         name = name,
         base = base,
-        entrypoint = ["/usr/bin/python"],
+        entrypoint = [entrypoint or "/usr/bin/python"],
         binary = binary_name,
         visibility = visibility,
         tags = tags,

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -66,7 +66,7 @@ DEFAULT_BASE = select({
     "//conditions:default": "@py3_image_base//image",
 })
 
-def py3_image(name, base = None, deps = [], layers = [], **kwargs):
+def py3_image(name, base = None, deps = [], layers = [], entrypoint = None, **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
   Args:
@@ -101,7 +101,7 @@ def py3_image(name, base = None, deps = [], layers = [], **kwargs):
     app_layer(
         name = name,
         base = base,
-        entrypoint = ["/usr/bin/python"],
+        entrypoint = [entrypoint or "/usr/bin/python"],
         binary = binary_name,
         visibility = visibility,
         tags = tags,


### PR DESCRIPTION
Different base images have `python` installed in different locations, we should be able to specify the correct path:

```
❯ docker run --rm -it python:alpine which python
/usr/local/bin/python
```