### PR TITLE
Update README.md to remove unnecessary part of instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,6 @@ file the following:
 
 ```
 build --host_force_python=PY2
-test --host_force_python=PY2
-run --host_force_python=PY2
 ```
 See https://github.com/bazelbuild/rules_docker/issues/842 for more
 details.


### PR DESCRIPTION
Bazel's `bazelrc` configuration files apply inheritance to *`command`* options. `test` and `run` inherit from `build` so they're no necessary to list I don't think. 

**Ref:** https://docs.bazel.build/versions/master/guide.html#option-defaults