### PR TITLE
Generate v1 image tarballs in Go join_layers

### DIFF
--- a/container/go/cmd/join_layers/BUILD
+++ b/container/go/cmd/join_layers/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//container/go/pkg/compat:go_default_library",
         "//container/go/pkg/utils:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/legacy/tarball:go_default_library",
         "@com_github_google_go_containerregistry//pkg/name:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1/tarball:go_default_library",

--- a/container/go/cmd/join_layers/join_layers.go
+++ b/container/go/cmd/join_layers/join_layers.go
@@ -18,8 +18,10 @@ package main
 import (
 	"flag"
 	"log"
+	"os"
 	"strings"
 
+	legacyTarball "github.com/google/go-containerregistry/pkg/legacy/tarball"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 
@@ -98,7 +100,15 @@ func writeOutput(outputTarball string, tagToConfigs, tagToBaseManifests map[name
 		}
 		tagToImg[tag] = img
 	}
-	return tarball.MultiWriteToFile(outputTarball, tagToImg)
+	refToImage := make(map[name.Reference]v1.Image, len(tagToImg))
+	for i, d := range tagToImg {
+		refToImage[i] = d
+	}
+	o, err := os.Create(outputTarball)
+	if err != nil {
+		return errors.Wrapf(err, "unable to create image tarball file %q for writing", outputTarball)
+	}
+	return legacyTarball.MultiWrite(refToImage, o)
 }
 
 func main() {

--- a/container/go/pkg/compat/BUILD
+++ b/container/go/pkg/compat/BUILD
@@ -39,5 +39,8 @@ go_test(
     name = "go_default_test",
     srcs = ["config_test.go"],
     embed = [":go_default_library"],
-    deps = ["@com_github_kylelemons_godebug//pretty:go_default_library"],
+    deps = [
+        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
+        "@com_github_kylelemons_godebug//pretty:go_default_library",
+    ],
 )

--- a/container/go/pkg/compat/image.go
+++ b/container/go/pkg/compat/image.go
@@ -235,6 +235,11 @@ func (li *legacyImage) RawManifest() ([]byte, error) {
 	return li.rawManifest, nil
 }
 
+// Size returns the size of the raw manifest.
+func (li *legacyImage) Size() (int64, error) {
+	return int64(len(li.rawManifest)), nil
+}
+
 // RawConfigFile returns the serialized bytes of config.json metadata.
 func (li *legacyImage) RawConfigFile() ([]byte, error) {
 	return li.rawConfig, nil

--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -37,7 +37,7 @@ def go_deps():
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(
             name = "com_github_google_go_containerregistry",
-            commit = "a8228cdaedffd366395d5a0b3022cd2142fddadb",
+            commit = "38d665cadff75b725c843e04ae79c7354e430a69",
             importpath = "github.com/google/go-containerregistry",
         )
     if "com_github_pkg_errors" not in excludes:


### PR DESCRIPTION
Pulled in new go-containerregistry version that adds ability to generate
v1 image tarballs & add Size method to legacyImage because v1.Image in
go-containerregistry now requires it.