### PR TITLE
fix json print command for py3

### DIFF
--- a/docker/util/to_json.py
+++ b/docker/util/to_json.py
@@ -17,4 +17,4 @@
 import json
 import sys
 
-print json.dumps(sys.stdin.read().strip().split())
+print(json.dumps(sys.stdin.read().strip().split()))


### PR DESCRIPTION
Python3 is preferred for running bazel, but somehow some code was committed using incompatible code.