### PR TITLE
Update rules_rust

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -316,9 +316,9 @@ _go_image_repos()
 # For our rust_image test
 http_archive(
     name = "io_bazel_rules_rust",
-    sha256 = "019958e96fcb9d8b5e5f74f31ad58f9c59804e8c04cf5aae03b983001edc79e0",
-    strip_prefix = "rules_rust-f727669b8ac3c9d237ed9bc7833b8e1eeec90506",
-    urls = ["https://github.com/bazelbuild/rules_rust/archive/f727669b8ac3c9d237ed9bc7833b8e1eeec90506.tar.gz"],
+    strip_prefix = "rules_rust-55f77017a7f5b08e525ebeab6e11d8896a4499d2",
+    url = "https://github.com/bazelbuild/rules_rust/archive/55f77017a7f5b08e525ebeab6e11d8896a4499d2.tar.gz",
+    sha256 = "b6da34e057a31b8a85e343c732de4af92a762f804fc36b0baa6c001423a70ebc",
 )
 
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")


### PR DESCRIPTION
This version contains a fix (https://github.com/bazelbuild/rules_rust/pull/252) for how rules_rust constructed C++ command lines.