### PR TITLE
fix rules_docker with bazel head

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -401,7 +401,14 @@ dockerfile_image(
 ]]
 
 # Register the default py_toolchain / platform for containerized execution
-register_toolchains("//toolchains:container_py_toolchain")
+load("//toolchains:py_toolchains.bzl", "py_toolchains")
+
+py_toolchains(name = "container_py_toolchain")
+
+register_toolchains(
+    "//toolchains:container_py_toolchain",
+    "@container_py_toolchain//:container_cc_toolchain",
+)
 
 register_execution_platforms("//platforms:local_container_platform")
 

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -29,6 +29,10 @@ load(
     "//repositories:go_repositories.bzl",
     _go_deps = "go_deps",
 )
+load(
+    "//toolchains:py_toolchains.bzl",
+    _py_toolchains = "py_toolchains",
+)
 
 # Load the resolved digests.
 load(":python.bzl", "DIGESTS")
@@ -42,7 +46,12 @@ def repositories():
     _go_deps()
 
     # Register the default py_toolchain / platform for containerized execution
-    native.register_toolchains("@io_bazel_rules_docker//toolchains:container_py_toolchain")
+    if "container_py_toolchain" not in native.existing_rules().keys():
+        _py_toolchains(name = "container_py_toolchain")
+    native.register_toolchains(
+        "@io_bazel_rules_docker//toolchains:container_py_toolchain",
+        "@container_py_toolchain//:container_cc_toolchain",
+    )
     native.register_execution_platforms("@io_bazel_rules_docker//platforms:local_container_platform")
 
     excludes = native.existing_rules().keys()

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -28,6 +28,10 @@ load(
     "//repositories:go_repositories.bzl",
     _go_deps = "go_deps",
 )
+load(
+    "//toolchains:py_toolchains.bzl",
+    _py_toolchains = "py_toolchains",
+)
 
 # Load the resolved digests.
 load(":python3.bzl", "DIGESTS")
@@ -41,7 +45,12 @@ def repositories():
     _go_deps()
 
     # Register the default py_toolchain / platform for containerized execution
-    native.register_toolchains("@io_bazel_rules_docker//toolchains:container_py_toolchain")
+    if "container_py_toolchain" not in native.existing_rules().keys():
+        _py_toolchains(name = "container_py_toolchain")
+    native.register_toolchains(
+        "@io_bazel_rules_docker//toolchains:container_py_toolchain",
+        "@container_py_toolchain//:container_cc_toolchain",
+    )
     native.register_execution_platforms("@io_bazel_rules_docker//platforms:local_container_platform")
 
     excludes = native.existing_rules().keys()

--- a/toolchains/py_toolchains.bzl
+++ b/toolchains/py_toolchains.bzl
@@ -42,6 +42,10 @@ alias(
         if cpu_value == "x64_windows":
             # Note this is not well tested
             cpu_value = "x64_windows_msys"
+        toolchain = "@local_config_cc//:cc-compiler-%s" % cpu_value
+        if cpu_value == "darwin":
+            # This needs further testing too.
+            toolchain = "@bazel_tools//tools/cpp:cc-compiler-local"
 
         repository_ctx.file("BUILD", content = ("""# Toolchain required for xx_image targets that rely on xx_binary
 # which transitively require a C/C++ toolchain (currently only
@@ -57,10 +61,10 @@ toolchain(
     name = "container_cc_toolchain",
     exec_compatible_with = HOST_CONSTRAINTS + ["@io_bazel_rules_docker//platforms:run_in_container"],
     target_compatible_with = HOST_CONSTRAINTS,
-    toolchain = "@local_config_cc//:cc-compiler-%s",
+    toolchain = "%s",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 ) 
-""") % get_cpu_value(repository_ctx), executable = False)
+""") % toolchain, executable = False)
 
 py_toolchains = repository_rule(
     attrs = {},

--- a/toolchains/py_toolchains.bzl
+++ b/toolchains/py_toolchains.bzl
@@ -1,0 +1,68 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repo rule to register toolchains required for py_image and py3_image rules.
+"""
+
+load(
+    "@bazel_tools//tools/cpp:lib_cc_configure.bzl",
+    "get_cpu_value",
+)
+
+def _impl(repository_ctx):
+    """Core implementation of _py_toolchains."""
+
+    cpu_value = get_cpu_value(repository_ctx)
+    env = repository_ctx.os.environ
+    if "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN" in env and env["BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN"] == "1":
+        # Create an alias to the bazel_tools local toolchain as no cpp toolchain will be produced
+        repository_ctx.file("BUILD", content = ("""# Alias to local toolchain
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+alias(
+    name = "container_cc_toolchain",
+    actual = "@bazel_tools//tools/cpp:cc-toolchain-local",
+)
+
+"""), executable = False)
+
+    else:
+        if cpu_value == "x64_windows":
+            # Note this is not well tested
+            cpu_value = "x64_windows_msys"
+
+        repository_ctx.file("BUILD", content = ("""# Toolchain required for xx_image targets that rely on xx_binary
+# which transitively require a C/C++ toolchain (currently only
+# py_binary). This one is for local execution and will be required
+# with versions of Bazel > 1.0.0
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
+
+toolchain(
+    name = "container_cc_toolchain",
+    exec_compatible_with = HOST_CONSTRAINTS + ["@io_bazel_rules_docker//platforms:run_in_container"],
+    target_compatible_with = HOST_CONSTRAINTS,
+    toolchain = "@local_config_cc//:cc-compiler-%s",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+) 
+""") % get_cpu_value(repository_ctx), executable = False)
+
+py_toolchains = repository_rule(
+    attrs = {},
+    implementation = _impl,
+)


### PR DESCRIPTION
Changes to python toolchains in these rules caused breakage with Bazel head: https://github.com/bazelbuild/rules_docker/commit/b5e5506d2e2c82a21f9db69ee00e3333f8377e48#commitcomment-35386395
This PR registers an cc_toolchain explicitly for local execution. This is not needed with bazel 0.29.1, but apparently it is needed with Bazel head. Registered cc_toolchain must be compatible with local cc config, so doing a bit of the repo rule dance to get that correctly.
Lets run CI for testing, though Windows will be left uncovered.