### PR TITLE
Allow env args to container_image that contain "="

### DIFF
--- a/container/go/pkg/compat/config.go
+++ b/container/go/pkg/compat/config.go
@@ -129,7 +129,7 @@ func keyValueToMap(value []string) (map[string]string, error) {
 	convMap := make(map[string]string)
 	var temp []string
 	for _, kvpair := range value {
-		temp = strings.Split(kvpair, "=")
+		temp = strings.SplitN(kvpair, "=", 2)
 		if len(temp) != 2 {
 			return convMap, errors.New(fmt.Sprintf("%q is not of format key=value", kvpair))
 		}


### PR DESCRIPTION
I recently ran into an issue when attempting to use an environment variable that contained an equal sign in a container_image `env` block. My target looked a bit like this:

```
container_image(
    name = "sample_app_pkg",
    base = "@adoptopenjdk_jre8_alpine//image",
    entrypoint = ["./entrypoint.sh"],
    env = {
        "JAVA_OPTS": "-Dloader.main=com.sample.app.SampleApp",
    },
    files = [
        "src/main/docker/entrypoint.sh",
        ":sample_app",
    ]
)
```

This resulted in an error that looks a bit like this: 

`2019/10/07 22:02:00 Failed to override values in old image config and write to dst failed to create/update image config: error converting env array [JAVA_OPTS=-Dloader.main=com.sample.app.SampleApp] to map: "JAVA_OPTS=-Dloader.main=com.sample.app.SampleApp=" is not of format key=value: bazel-out/darwin-py2-fastbuild/bin/sample_app/sample_app_pkg.0.config`

It seems that current implementation of this is designed to split key-value pairs using an equal sign without limitation, but this behavior can interfere with pairs where the value itself contains an equal sign. It seems that we would only want this to split once (preserving any equal signs after the first one). 

Would it make sense to make this one-line change to make it behave in that way?