### PR TITLE
Support env vars that contain '='

### DIFF
--- a/container/go/pkg/compat/config.go
+++ b/container/go/pkg/compat/config.go
@@ -129,7 +129,7 @@ func keyValueToMap(value []string) (map[string]string, error) {
 	convMap := make(map[string]string)
 	var temp []string
 	for _, kvpair := range value {
-		temp = strings.Split(kvpair, "=")
+		temp = strings.SplitN(kvpair, "=", 2)
 		if len(temp) != 2 {
 			return convMap, errors.New(fmt.Sprintf("%q is not of format key=value", kvpair))
 		}

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -262,6 +262,22 @@ container_test(
     image = ":set_env_csv",
 )
 
+container_image(
+    name = "set_env_equals",
+    base = "@distroless_fixed_id//image",
+    cmd = ["foo"],
+    env = {
+        "CUDA_PKG_VERSION": "-10-0=10.0.130-1",
+        "JAVA_OPTS": "-Dloader.main=com.sample.app.SampleApp",
+    },
+)
+
+container_test(
+    name = "set_env_equals_test",
+    configs = ["//tests/container/configs:set_env_equals.yaml"],
+    image = ":set_env_equals",
+)
+
 # Image with Bazel Make variables in the env field.
 container_image(
     name = "set_env_make_vars",

--- a/tests/container/configs/set_env_equals.yaml
+++ b/tests/container/configs/set_env_equals.yaml
@@ -1,0 +1,8 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  env:
+  - key: JAVA_OPTS
+    value: -Dloader.main=com.sample.app.SampleApp
+  - key: CUDA_PKG_VERSION
+    value: -10-0=10.0.130-1


### PR DESCRIPTION
Taking over https://github.com/bazelbuild/rules_docker/pull/1192 to add tests as we have already had 3 requests this week for this feature:
https://github.com/bazelbuild/rules_docker/issues/1199
https://github.com/bazelbuild/rules_docker/pull/1196
(and https://github.com/bazelbuild/rules_docker/pull/1192)