### PR TITLE
Set `container_test` to be `testonly`

### DIFF
--- a/contrib/test.bzl
+++ b/contrib/test.bzl
@@ -167,6 +167,7 @@ def container_test(name, image, configs, driver = None, verbose = None, **kwargs
             images = {
                 loaded_name: image,
             },
+            **kwargs
         )
 
     _container_test(

--- a/contrib/test.bzl
+++ b/contrib/test.bzl
@@ -167,7 +167,7 @@ def container_test(name, image, configs, driver = None, verbose = None, **kwargs
             images = {
                 loaded_name: image,
             },
-            **kwargs
+            testonly = True,
         )
 
     _container_test(

--- a/contrib/test.bzl
+++ b/contrib/test.bzl
@@ -160,7 +160,7 @@ def container_test(name, image, configs, driver = None, verbose = None, **kwargs
         # Include the package name in the new image tag to avoid conflicts on naming
         # when running multiple container_test on images with the same target name
         # from different packages.
-        sanitized_name = (native.package_name() + image).replace(":", "").replace("@", "").replace("/", "")
+        sanitized_name = (native.package_name() + image).replace(":", "").replace("@", "").replace("/", "").lower()
         loaded_name = "%s:intermediate" % sanitized_name
         container_bundle(
             name = image_loader,


### PR DESCRIPTION
Currently, one cannot use `container_test` targets that depend on other test targets,
as `container_bundle` is not a `testonly=True` target.  This change allows propagation
of the `testonly` arg to support this use case.