### PR TITLE
Fixes for python use in download_pkgs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -413,6 +413,7 @@ register_toolchains(
 )
 
 register_execution_platforms(
+    "@local_config_platform//:host",
     "//platforms:local_container_platform",
 )
 

--- a/docker/package_managers/download_pkgs.bzl
+++ b/docker/package_managers/download_pkgs.bzl
@@ -142,7 +142,7 @@ def _impl(ctx, image_tar = None, packages = None, additional_repos = None, outpu
     return [
         DefaultInfo(
             executable = output_executable,
-            files = depset([output_executable], transitive = [ctx.attr._extract_image_id.files]),
+            files = depset([output_executable]),
             runfiles = ctx.runfiles(
                 files = [
                     image_tar,

--- a/docker/package_managers/run_download.sh.tpl
+++ b/docker/package_managers/run_download.sh.tpl
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -ex
 
+function guess_runfiles() {
+    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
+        # Runfiles are adjacent to the current script.
+        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
+    else
+        # The current script is within some other script's runfiles.
+        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
+    fi
+}
+
+RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+
 # Resolve the docker tool path
 DOCKER="%{docker_tool_path}"
 

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -46,6 +46,7 @@ def repositories():
         "@io_bazel_rules_docker//toolchains:container_py_toolchain",
     )
     native.register_execution_platforms(
+        "@local_config_platform//:host",
         "@io_bazel_rules_docker//platforms:local_container_platform",
     )
 

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -45,6 +45,7 @@ def repositories():
         "@io_bazel_rules_docker//toolchains:container_py_toolchain",
     )
     native.register_execution_platforms(
+        "@local_config_platform//:host",
         "@io_bazel_rules_docker//platforms:local_container_platform",
     )
 


### PR DESCRIPTION
We were improperly calling the python script to extract image id from the produced executable.
Also update rule to use providers in return.
