### PR TITLE
define gzip in the docker toolchain not as a local tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ docker_toolchain_configure(
   # See https://docs.docker.com/engine/reference/commandline/cli/#configuration-files
   # for more details.
   client_config="<enter absolute path to your docker config directory here>",
+  # OPTIONAL: Path to the docker binary.
+  # Should be set explcitly for remote execution.
+  docker_path="<enter absolute path to the docker binary (in the remote exec env) here>",
+  # OPTIONAL: Path to the gzip binary.
+  # Either gzip_path or gzip_target should be set explcitly for remote execution.
+  gzip_path="<enter absolute path to the gzip binary (in the remote exec env) here>",
+  # OPTIONAL: Bazel target for the gzip tool.
+  # Either gzip_path or gzip_target should be set explcitly for remote execution.
+  gzip_target="<enter path to an executable gzip target>",
+  # OPTIONAL: Path to the xz binary.
+  # Should be set explcitly for remote execution.
+  xz_path="<enter absolute path to the xz binary (in the remote exec env) here>",
 )
 # End of OPTIONAL segment.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ docker_toolchain_configure(
   gzip_path="<enter absolute path to the gzip binary (in the remote exec env) here>",
   # OPTIONAL: Bazel target for the gzip tool.
   # Either gzip_path or gzip_target should be set explcitly for remote execution.
-  gzip_target="<enter path to an executable gzip target>",
+  gzip_target="<enter absolute path (i.e., must start with repo name @...//:...) to an executable gzip target>",
   # OPTIONAL: Path to the xz binary.
   # Should be set explcitly for remote execution.
   xz_path="<enter absolute path to the xz binary (in the remote exec env) here>",

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -74,10 +74,6 @@ load(
     "//skylib:path.bzl",
     _join_path = "join",
 )
-load(
-    "//skylib:zip.bzl",
-    _zip_tools = "tools",
-)
 
 def _get_base_config(ctx, name, base):
     if ctx.files.base or base:
@@ -553,7 +549,7 @@ _attrs = dicts.add(_layer.attrs, {
         cfg = "host",
         executable = True,
     ),
-}, _hash_tools, _layer_tools, _zip_tools)
+}, _hash_tools, _layer_tools)
 
 _outputs = dict(_layer.outputs)
 

--- a/container/import.bzl
+++ b/container/import.bzl
@@ -39,7 +39,6 @@ load(
     "//skylib:zip.bzl",
     _gunzip = "gunzip",
     _gzip = "gzip",
-    _zip_tools = "tools",
 )
 
 def _is_filetype(filename, extensions):
@@ -168,7 +167,7 @@ container_import = rule(
             mandatory = False,
         ),
         "repository": attr.string(default = "bazel"),
-    }, _hash_tools, _layer_tools, _zip_tools),
+    }, _hash_tools, _layer_tools),
     executable = True,
     outputs = {
         "out": "%{name}.tar",

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -39,7 +39,6 @@ load(
 load(
     "//skylib:zip.bzl",
     _gzip = "gzip",
-    _zip_tools = "tools",
 )
 
 def _magic_path(ctx, f, output_layer):
@@ -244,7 +243,7 @@ _layer_attrs = dicts.add({
     ),
     "symlinks": attr.string_dict(),
     "tars": attr.label_list(allow_files = tar_filetype),
-}, _hash_tools, _layer_tools, _zip_tools)
+}, _hash_tools, _layer_tools)
 
 _layer_outputs = {
     "layer": "%{name}-layer.tar",

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -27,32 +27,6 @@ load(
 CONTAINERREGISTRY_RELEASE = "v0.0.36"
 RULES_DOCKER_GO_BINARY_RELEASE = "db8af45b844ed6ee5150984986b3f1ba9292e3a1"
 
-_local_tool_build_template = """
-sh_binary(
-    name = "{name}",
-    srcs = ["bin/{name}"],
-    visibility = ["//visibility:public"],
-)
-"""
-
-def _local_tool(repository_ctx):
-    rctx = repository_ctx
-    realpath = rctx.which(rctx.name)
-    rctx.symlink(realpath, "bin/%s" % rctx.name)
-    rctx.file(
-        "WORKSPACE",
-        'workspace(name = "{}")\n'.format(rctx.name),
-    )
-    rctx.file(
-        "BUILD",
-        _local_tool_build_template.format(name = rctx.name),
-    )
-
-local_tool = repository_rule(
-    local = True,
-    implementation = _local_tool,
-)
-
 def repositories():
     """Download dependencies of container rules."""
     excludes = native.existing_rules().keys()

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -241,11 +241,6 @@ py_library(
             urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.0.2.tar.gz"],
         )
 
-    if "gzip" not in excludes:
-        local_tool(
-            name = "gzip",
-        )
-
     if "bazel_gazelle" not in excludes:
         http_archive(
             name = "bazel_gazelle",

--- a/skylib/zip.bzl
+++ b/skylib/zip.bzl
@@ -25,7 +25,10 @@ def gzip(ctx, artifact):
     """
     out = ctx.actions.declare_file(artifact.basename + ".gz")
     toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
-    if toolchain_info.gzip_path == "":
+    tools = []
+    if toolchain_info.gzip_target:
+        tools = toolchain_info.gzip_target.executable
+    elif toolchain_info.gzip_path == "":
         fail("gzip could not be found. Make sure it is in the path or set it " +
              "explicitly in the docker_toolchain_configure")
     ctx.actions.run_shell(
@@ -34,6 +37,7 @@ def gzip(ctx, artifact):
         outputs = [out],
         use_default_shell_env = True,
         mnemonic = "GZIP",
+        tools = tools,
     )
     return out
 
@@ -49,7 +53,10 @@ def gunzip(ctx, artifact):
     """
     out = ctx.actions.declare_file(artifact.basename + ".nogz")
     toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
-    if toolchain_info.gzip_path == "":
+    tools = []
+    if toolchain_info.gzip_target:
+        tools = toolchain_info.gzip_target.executable
+    elif toolchain_info.gzip_path == "":
         fail("gzip could not be found. Make sure it is in the path or set it " +
              "explicitly in the docker_toolchain_configure")
     ctx.actions.run_shell(
@@ -58,5 +65,6 @@ def gunzip(ctx, artifact):
         outputs = [out],
         use_default_shell_env = True,
         mnemonic = "GUNZIP",
+        tools = tools,
     )
     return out

--- a/skylib/zip.bzl
+++ b/skylib/zip.bzl
@@ -14,36 +14,49 @@
 """Functions for producing the gzip of an artifact."""
 
 def gzip(ctx, artifact):
-    """Create an action to compute the gzipped artifact."""
+    """Create an action to compute the gzipped artifact.
+
+    Args:
+       ctx: The context
+       artifact: The artifact to zip
+
+    Returns:
+       the gzipped artifact.
+    """
     out = ctx.actions.declare_file(artifact.basename + ".gz")
+    toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
+    if toolchain_info.gzip_path == "":
+        fail("gzip could not be found. Make sure it is in the path or set it " +
+             "explicitly in the docker_toolchain_configure")
     ctx.actions.run_shell(
-        command = "%s -n < %s > %s" % (ctx.executable.gzip.path, artifact.path, out.path),
+        command = "%s -n < %s > %s" % (toolchain_info.gzip_path, artifact.path, out.path),
         inputs = [artifact],
         outputs = [out],
         use_default_shell_env = True,
         mnemonic = "GZIP",
-        tools = [ctx.executable.gzip],
     )
     return out
 
 def gunzip(ctx, artifact):
-    """Create an action to compute the gunzipped artifact."""
+    """Create an action to compute the gunzipped artifact.
+
+    Args:
+       ctx: The context
+       artifact: The artifact to zip
+
+    Returns:
+       the gunzipped artifact.
+    """
     out = ctx.actions.declare_file(artifact.basename + ".nogz")
+    toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
+    if toolchain_info.gzip_path == "":
+        fail("gzip could not be found. Make sure it is in the path or set it " +
+             "explicitly in the docker_toolchain_configure")
     ctx.actions.run_shell(
-        command = "%s -d < %s > %s" % (ctx.executable.gzip.path, artifact.path, out.path),
+        command = "%s -d < %s > %s" % (toolchain_info.gzip_path, artifact.path, out.path),
         inputs = [artifact],
         outputs = [out],
         use_default_shell_env = True,
         mnemonic = "GUNZIP",
-        tools = [ctx.executable.gzip],
     )
     return out
-
-tools = {
-    "gzip": attr.label(
-        allow_files = True,
-        cfg = "host",
-        default = Label("@gzip//:gzip"),
-        executable = True,
-    ),
-}

--- a/skylib/zip.bzl
+++ b/skylib/zip.bzl
@@ -29,7 +29,7 @@ def gzip(ctx, artifact):
     tools = []
     gzip_path = toolchain_info.gzip_path
     if toolchain_info.gzip_target:
-        gzip_path = toolchain_info.gzip_target.files.to_list()[0].path
+        gzip_path = toolchain_info.gzip_target.files_to_run.executable.path
         tools, _, input_manifests = ctx.resolve_command(tools = [toolchain_info.gzip_target])
     elif toolchain_info.gzip_path == "":
         fail("gzip could not be found. Make sure it is in the path or set it " +
@@ -62,13 +62,14 @@ def gunzip(ctx, artifact):
     tools = []
     gzip_path = toolchain_info.gzip_path
     if toolchain_info.gzip_target:
-        gzip_path = toolchain_info.gzip_target.files.to_list()[0].path
+        gzip_path = toolchain_info.gzip_target.files_to_run.executable.path
         tools, _, input_manifests = ctx.resolve_command(tools = [toolchain_info.gzip_target])
     elif toolchain_info.gzip_path == "":
         fail("gzip could not be found. Make sure it is in the path or set it " +
              "explicitly in the docker_toolchain_configure")
     ctx.actions.run_shell(
         command = "%s -d < %s > %s" % (gzip_path, artifact.path, out.path),
+        input_manifests = input_manifests,
         inputs = [artifact],
         outputs = [out],
         use_default_shell_env = True,

--- a/testing/default_toolchain/WORKSPACE
+++ b/testing/default_toolchain/WORKSPACE
@@ -18,7 +18,7 @@ workspace(name = "e2e_testing")
 # with real path on bazel invocation using --override_repository
 local_repository(
     name = "io_bazel_rules_docker",
-    path = "../../",
+    path = "replace/this/path",
 )
 
 load(

--- a/testing/default_toolchain/WORKSPACE
+++ b/testing/default_toolchain/WORKSPACE
@@ -18,7 +18,16 @@ workspace(name = "e2e_testing")
 # with real path on bazel invocation using --override_repository
 local_repository(
     name = "io_bazel_rules_docker",
-    path = "replace/this/path",
+    path = "../../",
+)
+
+load(
+    "//:local_tool.bzl",
+    "local_tool",
+)
+
+local_tool(
+    name = "gzip",
 )
 
 load(
@@ -26,7 +35,10 @@ load(
     docker_toolchain_configure = "toolchain_configure",
 )
 
-docker_toolchain_configure(name = "docker_config")
+docker_toolchain_configure(
+    name = "docker_config",
+    gzip_target = "@gzip//:gzip",
+)
 
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",

--- a/testing/default_toolchain/local_tool.bzl
+++ b/testing/default_toolchain/local_tool.bzl
@@ -1,0 +1,40 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rule to load a local tool. Used to test gzip_target."""
+
+_local_tool_build_template = """
+sh_binary(
+    name = "{name}",
+    srcs = ["bin/{name}"],
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _local_tool(repository_ctx):
+    rctx = repository_ctx
+    realpath = rctx.which(rctx.name)
+    rctx.symlink(realpath, "bin/%s" % rctx.name)
+    rctx.file(
+        "WORKSPACE",
+        'workspace(name = "{}")\n'.format(rctx.name),
+    )
+    rctx.file(
+        "BUILD",
+        _local_tool_build_template.format(name = rctx.name),
+    )
+
+local_tool = repository_rule(
+    local = True,
+    implementation = _local_tool,
+)

--- a/testing/java_image/BUILD
+++ b/testing/java_image/BUILD
@@ -27,3 +27,12 @@ java_image(
         "@bazel_tools//tools/java/runfiles",
     ],
 )
+
+# Used to test setting gzip as target.
+java_binary(
+    name = "gzip",
+    srcs = ["Gzip.java"],
+    main_class = "tools.gzip.Gzip",
+    visibility = ["//visibility:public"],
+    deps = [],
+)

--- a/testing/java_image/Gzip.java
+++ b/testing/java_image/Gzip.java
@@ -1,0 +1,36 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools.gzip;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class Gzip {
+    public static void main(String[] args) throws IOException {
+        boolean decompress = args.length > 0 && args[0].equals("-d");
+        InputStream in = decompress ? new GZIPInputStream(System.in, 8 * 1024) : System.in;
+        OutputStream out = decompress ? System.out : new GZIPOutputStream(System.out);
+        byte[] buffer = new byte[8 * 1024 * 1024];
+        int n;
+        while (-1 != (n = in.read(buffer))) {
+            out.write(buffer, 0, n);
+        }
+        out.close();
+        in.close();
+    }
+}

--- a/testing/java_image/WORKSPACE
+++ b/testing/java_image/WORKSPACE
@@ -19,6 +19,17 @@ local_repository(
     path = "../../",
 )
 
+load(
+    "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
+    docker_toolchain_configure = "toolchain_configure",
+)
+
+# Test setting gzip_target
+docker_toolchain_configure(
+    name = "docker_config",
+    gzip_target = "@java_image_example//:gzip",
+)
+
 # java_image rule dependencies.
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",

--- a/toolchains/docker/BUILD.tpl
+++ b/toolchains/docker/BUILD.tpl
@@ -21,7 +21,7 @@ load("@io_bazel_rules_docker//toolchains/docker:toolchain.bzl", "docker_toolchai
 docker_toolchain(
     name = "toolchain",
     client_config = "%{DOCKER_CONFIG}",
-    gzip_path = "%{GZIP_TOOL_PATH}",
+    %{GZIP_ATTR}
     tool_path = "%{DOCKER_TOOL}",
     xz_path = "%{XZ_TOOL_PATH}",
 )

--- a/toolchains/docker/BUILD.tpl
+++ b/toolchains/docker/BUILD.tpl
@@ -20,7 +20,8 @@ load("@io_bazel_rules_docker//toolchains/docker:toolchain.bzl", "docker_toolchai
 
 docker_toolchain(
     name = "toolchain",
-    tool_path = "%{DOCKER_TOOL}",
     client_config = "%{DOCKER_CONFIG}",
+    gzip_path = "%{GZIP_TOOL_PATH}",
+    tool_path = "%{DOCKER_TOOL}",
     xz_path = "%{XZ_TOOL_PATH}",
 )

--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -23,17 +23,20 @@ DockerToolchainInfo = provider(
                          "the value of the DOCKER_CONFIG environment variable" +
                          " will be used. DOCKER_CONFIG is not defined, the" +
                          " home directory will be used.",
+        "gzip_path": "Optional path to the gzip binary. If not set found via which.",
         "tool_path": "Path to the docker executable",
         "xz_path": "Optional path to the xz binary. This is used by " +
-                   "build_tar.py when the Python lzma module is unavailable.",
+                   "build_tar.py when the Python lzma module is unavailable. " +
+                   "If not set found via which.",
     },
 )
 
 def _docker_toolchain_impl(ctx):
     toolchain_info = platform_common.ToolchainInfo(
         info = DockerToolchainInfo(
-            tool_path = ctx.attr.tool_path,
             client_config = ctx.attr.client_config,
+            gzip_path = ctx.attr.gzip_path,
+            tool_path = ctx.attr.tool_path,
             xz_path = ctx.attr.xz_path,
         ),
     )
@@ -52,6 +55,9 @@ docker_toolchain = rule(
                   " DOCKER_CONFIG is not defined, the home directory will be" +
                   " used.",
         ),
+        "gzip_path": attr.string(
+            doc = "Path to the gzip binary.",
+        ),
         "tool_path": attr.string(
             doc = "Path to the docker binary.",
         ),
@@ -68,7 +74,18 @@ def _toolchain_configure_impl(repository_ctx):
         tool_path = repository_ctx.attr.docker_path
     elif repository_ctx.which("docker"):
         tool_path = repository_ctx.which("docker")
-    xz_path = repository_ctx.which("xz") or ""
+
+    xz_path = ""
+    if repository_ctx.attr.xz_path:
+        xz_path = repository_ctx.attr.xz_path
+    elif repository_ctx.which("xz"):
+        xz_path = repository_ctx.which("xz")
+
+    gzip_path = ""
+    if repository_ctx.attr.gzip_path:
+        gzip_path = repository_ctx.attr.gzip_path
+    elif repository_ctx.which("gzip"):
+        gzip_path = repository_ctx.which("gzip")
 
     # If client_config is not set we need to pass an empty string to the
     # template.
@@ -79,6 +96,7 @@ def _toolchain_configure_impl(repository_ctx):
         {
             "%{DOCKER_CONFIG}": "%s" % client_config,
             "%{DOCKER_TOOL}": "%s" % tool_path,
+            "%{GZIP_TOOL_PATH}": "%s" % gzip_path,
             "%{XZ_TOOL_PATH}": "%s" % xz_path,
         },
         False,
@@ -113,6 +131,18 @@ toolchain_configure = repository_rule(
             doc = "The full path to the docker binary. If not specified, it will" +
                   "be searched for in the path. If not available, running commands" +
                   "that require docker (e.g., incremental load) will fail.",
+        ),
+        "gzip_path": attr.string(
+            mandatory = False,
+            doc = "The full path to the gzip binary. If not specified, it will" +
+                  "be searched for in the path. If not available, running commands" +
+                  "that gzip will fail.",
+        ),
+        "xz_path": attr.string(
+            mandatory = False,
+            doc = "The full path to the xz binary. If not specified, it will" +
+                  "be searched for in the path. If not available, running commands" +
+                  "that xz will fail.",
         ),
     },
     implementation = _toolchain_configure_impl,

--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -62,9 +62,12 @@ docker_toolchain = rule(
             doc = "Path to the gzip binary. " +
                   "Should only be set if gzip_target is unset.",
         ),
-        "gzip_target": attr.string(
+        "gzip_target": attr.label(
+            allow_files = True,
             doc = "Bazel target for the gzip tool. " +
                   "Should only be set if gzip_path is unset.",
+            cfg = "host",
+            executable = True,
         ),
         "tool_path": attr.string(
             doc = "Path to the docker binary.",
@@ -150,7 +153,10 @@ toolchain_configure = repository_rule(
                   "be searched for in the path. If not available, running commands" +
                   "that gzip will fail.",
         ),
-        "gzip_target": attr.string(
+        "gzip_target": attr.label(
+            executable = True,
+            cfg = "host",
+            allow_files = True,
             mandatory = False,
             doc = "The bazel target for the gzip tool. " +
                   "Can only be set if gzip_path is not set.",

--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -20,9 +20,9 @@ DockerToolchainInfo = provider(
     fields = {
         "client_config": "A custom directory for the docker client " +
                          "config.json. If DOCKER_CONFIG is not specified, " +
-                         "the value of the DOCKER_CONFIG environment variable" +
-                         " will be used. DOCKER_CONFIG is not defined, the" +
-                         " home directory will be used.",
+                         "the value of the DOCKER_CONFIG environment variable " +
+                         "will be used. DOCKER_CONFIG is not defined, the " +
+                         "home directory will be used.",
         "gzip_path": "Optional path to the gzip binary. If not set found via which.",
         "gzip_target": "Optional Bazel target for the gzip tool. " +
                        "Should only be set if gzip_path is unset.",
@@ -54,9 +54,9 @@ docker_toolchain = rule(
             default = "",
             doc = "A custom directory for the docker client config.json. If " +
                   "DOCKER_CONFIG is not specified, the value of the " +
-                  "DOCKER_CONFIG environment variable will be used." +
-                  " DOCKER_CONFIG is not defined, the home directory will be" +
-                  " used.",
+                  "DOCKER_CONFIG environment variable will be used. " +
+                  "DOCKER_CONFIG is not defined, the home directory will be " +
+                  "used.",
         ),
         "gzip_path": attr.string(
             doc = "Path to the gzip binary. " +
@@ -135,23 +135,23 @@ toolchain_configure = repository_rule(
         "client_config": attr.string(
             mandatory = False,
             doc = "A custom directory for the docker client " +
-                  "config.json. If DOCKER_CONFIG is not specified, the value" +
-                  " of the DOCKER_CONFIG environment variable will be used." +
-                  " DOCKER_CONFIG is not defined, the default set for the " +
-                  " docker tool (typically, the home directory) will be" +
-                  " used.",
+                  "config.json. If DOCKER_CONFIG is not specified, the value " +
+                  "of the DOCKER_CONFIG environment variable will be used. " +
+                  "DOCKER_CONFIG is not defined, the default set for the " +
+                  "docker tool (typically, the home directory) will be " +
+                  "used.",
         ),
         "docker_path": attr.string(
             mandatory = False,
-            doc = "The full path to the docker binary. If not specified, it will" +
-                  "be searched for in the path. If not available, running commands" +
+            doc = "The full path to the docker binary. If not specified, it will " +
+                  "be searched for in the path. If not available, running commands " +
                   "that require docker (e.g., incremental load) will fail.",
         ),
         "gzip_path": attr.string(
             mandatory = False,
-            doc = "The full path to the gzip binary. If not specified, it will" +
-                  "be searched for in the path. If not available, running commands" +
-                  "that gzip will fail.",
+            doc = "The full path to the gzip binary. If not specified, it will " +
+                  "be searched for in the path. If not available, running commands " +
+                  "that use gzip will fail.",
         ),
         "gzip_target": attr.label(
             executable = True,
@@ -163,9 +163,9 @@ toolchain_configure = repository_rule(
         ),
         "xz_path": attr.string(
             mandatory = False,
-            doc = "The full path to the xz binary. If not specified, it will" +
-                  "be searched for in the path. If not available, running commands" +
-                  "that xz will fail.",
+            doc = "The full path to the xz binary. If not specified, it will " +
+                  "be searched for in the path. If not available, running commands " +
+                  "that use xz will fail.",
         ),
     },
     implementation = _toolchain_configure_impl,


### PR DESCRIPTION
local_tool is problematic as it does not work with remote execution.
Gzip, like other tools we use in these rules, should be part of the docker toolchain. This PR removes code related to using local_tool (moves it to a test, as use case is still valid) and moves gzip to the docker_toolchain. Also added tests in java_image to use a java based gzip target.