### PR TITLE
Fix ordering of docker entrypoint and entrypoint prefix

### DIFF
--- a/container/go/pkg/compat/config.go
+++ b/container/go/pkg/compat/config.go
@@ -527,7 +527,7 @@ func updateConfig(overrideInfo *OverrideConfigOpts) error {
 	}
 
 	if len(overrideInfo.EntrypointPrefix) != 0 {
-		newEntrypoint := append(overrideInfo.ConfigFile.Config.Entrypoint, overrideInfo.EntrypointPrefix...)
+		newEntrypoint := append(overrideInfo.EntrypointPrefix, overrideInfo.ConfigFile.Config.Entrypoint...)
 		overrideInfo.ConfigFile.Config.Entrypoint = newEntrypoint
 	}
 	return nil

--- a/container/go/pkg/compat/config_test.go
+++ b/container/go/pkg/compat/config_test.go
@@ -190,3 +190,35 @@ func TestWorkdirOverride(t *testing.T) {
 		t.Errorf("WorkingDir field in config was updated to invalid value, got %q, want %q.", opts.ConfigFile.Config.WorkingDir, want)
 	}
 }
+
+func TestEntrypointPrefix(t *testing.T) {
+	want := []string{"prefix1", "prefix2", "entrypoint1", "entrypoint2"}
+	opts := &OverrideConfigOpts{
+		EntrypointPrefix: want[:2],
+		Entrypoint:       want[2:],
+		ConfigFile: &v1.ConfigFile{
+			Config: v1.Config{
+				Entrypoint: want,
+			},
+		},
+		Stamper: &Stamper{},
+	}
+	if err := updateConfig(opts); err != nil {
+		t.Fatalf("Failed to update config: %v", err)
+	}
+	if !stringSlicesEqual(opts.ConfigFile.Config.Entrypoint, want) {
+		t.Errorf("Entrypoint field in config was updated to invalid value, got %q, want %q.", opts.ConfigFile.Config.Entrypoint, want)
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
The entrypoint prefix is appended to the entrypoint but should be
prepended