### PR TITLE
Add digest field back to to PushInfo

### DIFF
--- a/container/push.bzl
+++ b/container/push.bzl
@@ -128,6 +128,7 @@ def _impl(ctx):
             tag = tag,
             stamp = stamp,
             stamp_inputs = stamp_inputs,
+            digest = ctx.outputs.digest,
         ),
     ]
 


### PR DESCRIPTION
I noticed that the digest field was removed in https://github.com/bazelbuild/rules_docker/pull/1142 . Our internal rules were depending on this field. Can it be added back?