### PR TITLE
add layer for npm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,9 +626,8 @@ load("@io_bazel_rules_docker//nodejs:image.bzl", "nodejs_image")
 nodejs_image(
     name = "nodejs_image",
     entry_point = "@your_workspace//path/to:file.js",
-    # This will be put into its own layer.
-    node_modules = "@npm//:node_modules",
-    data = [":file.js"],
+    # npm deps will be put into their own layer
+    data = [":file.js", "@npm//some-npm-dep"],
     ...
 )
 ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -365,6 +365,10 @@ yarn_install(
     yarn_lock = "//testdata:yarn.lock",
 )
 
+load("@npm//:install_bazel_dependencies.bzl", "install_bazel_dependencies")
+
+install_bazel_dependencies()
+
 load(
     "//nodejs:image.bzl",
     _nodejs_image_repos = "repositories",

--- a/container/BUILD
+++ b/container/BUILD
@@ -112,6 +112,7 @@ TEST_TARGETS = [
     ":war_image",
     ":flat",
     ":flatten_with_tarball_base",
+    ":nodejs_image",
 ]
 
 TEST_DATA = [

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -760,6 +760,188 @@ class ImageTest(unittest.TestCase):
         './jetty/webapps/ROOT/WEB-INF/lib/javax.servlet-api-3.0.1.jar',
       ])
 
+  def test_nodejs_image(self):
+    self.maxDiff = None
+    with TestImage('nodejs_image') as img:
+      # TODO: remove all '/app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/external'
+      # once --noexternal_legacy_runfiles is enabled
+      # https://github.com/bazelbuild/rules_docker/issues/1350
+
+      # Check the application layer (top layer), which also contains symlinks to the bottom layers.
+      self.assertTopLayerContains(img, [
+      '.', 
+      './app', 
+      './app/testdata', 
+      './app/testdata/nodejs_image_binary.runfiles', 
+      './app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker', 
+      './app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/testdata', 
+      './app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/testdata/nodejs_image.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/internal', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/internal/linker', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/internal/linker/index.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/internal/linker/runfiles_helper.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/internal/node', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/internal/node/node_patches.js', 
+      './app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/testdata/_nodejs_image_binary.module_mappings.json', 
+      './app/testdata/nodejs_image_binary.runfiles/bazel_tools', 
+      './app/testdata/nodejs_image_binary.runfiles/bazel_tools/tools', 
+      './app/testdata/nodejs_image_binary.runfiles/bazel_tools/tools/bash', 
+      './app/testdata/nodejs_image_binary.runfiles/bazel_tools/tools/bash/runfiles', 
+      './app/testdata/nodejs_image_binary.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash', 
+      './app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/testdata/nodejs_image_binary_loader.js', 
+      './app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/testdata/nodejs_image_binary_require_patch.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/buffer-from/', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/buffer-from/package.json', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/buffer-from/index.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/package.json', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/source-map.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/lib/', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/lib/array-set.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/lib/base64-vlq.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/lib/base64.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/lib/binary-search.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/lib/mapping-list.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/lib/quick-sort.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/lib/source-map-consumer.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/lib/source-map-generator.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/lib/source-node.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map/lib/util.js', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map-support/', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map-support/package.json', 
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com/source-map-support/source-map-support.js', 
+      './app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/testdata/nodejs_image_lib.js', 
+      './app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/testdata/nodejs_image_lib.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/testdata/nodejs_image_binary.sh', 
+      '/app', 
+      '/app/testdata', 
+      '/app/testdata/nodejs_image_binary', 
+      '/app/testdata/nodejs_image_binary.runfiles',
+      '/app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker', 
+      '/app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/external'])
+
+      # Check that the next layer contains node_modules
+      layerOneFiles = ['.', 
+      './app', 
+      './app/testdata', 
+      './app/testdata/nodejs_image_binary.runfiles', 
+      './app/testdata/nodejs_image_binary.runfiles/npm', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/jsesc', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/jsesc/LICENSE', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/jsesc/README.md', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/jsesc/index.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/jsesc/package.json', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/LICENSE', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/README.md', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/assert.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/async_hooks.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/base.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/buffer.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/child_process.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/cluster.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/console.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/constants.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/crypto.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/dgram.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/dns.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/domain.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/events.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/fs.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/globals.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/http.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/http2.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/https.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/index.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/inspector.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/module.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/net.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/os.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/package.json', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/path.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/perf_hooks.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/process.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/punycode.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/querystring.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/readline.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/repl.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/stream.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/string_decoder.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/timers.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/tls.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/trace_events.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/ts3.2', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/ts3.2/globals.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/ts3.2/index.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/ts3.2/util.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/tty.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/url.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/util.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/v8.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/vm.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/worker_threads.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/@types/node/zlib.d.ts', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/jsesc', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/jsesc/LICENSE-MIT.txt', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/jsesc/README.md', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/jsesc/bin', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/jsesc/bin/jsesc', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/jsesc/jsesc.js', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/jsesc/man', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/jsesc/man/jsesc.1', 
+      './app/testdata/nodejs_image_binary.runfiles/npm/node_modules/jsesc/package.json', 
+      '/app', 
+      '/app/testdata', 
+      '/app/testdata/nodejs_image_binary', 
+      '/app/testdata/nodejs_image_binary.runfiles', 
+      '/app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker', 
+      '/app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/external']
+      self.assertLayerNContains(img, 1, layerOneFiles)
+
+      # Check that the next layer contains node_args
+      layerTwoFiles = [
+        '.',
+        './app',
+        './app/testdata',
+        './app/testdata/nodejs_image_binary.runfiles',
+        './app/testdata/nodejs_image_binary.runfiles/nodejs_linux_amd64',
+        './app/testdata/nodejs_image_binary.runfiles/nodejs_linux_amd64/bin',
+        './app/testdata/nodejs_image_binary.runfiles/nodejs_linux_amd64/bin/node_repo_args.sh',
+      ]
+      self.assertLayerNContains(img, 2, layerTwoFiles)
+
+      # Check that the next layer contains node runfiles
+      layerThreeFiles = [
+        '.',
+        './app',
+        './app/testdata',
+        './app/testdata/nodejs_image_binary.runfiles',
+        './app/testdata/nodejs_image_binary.runfiles/nodejs_linux_amd64',
+        './app/testdata/nodejs_image_binary.runfiles/nodejs_linux_amd64/bin',
+        './app/testdata/nodejs_image_binary.runfiles/nodejs_linux_amd64/bin/nodejs',
+        './app/testdata/nodejs_image_binary.runfiles/nodejs_linux_amd64/bin/nodejs/bin',
+        './app/testdata/nodejs_image_binary.runfiles/nodejs_linux_amd64/bin/nodejs/bin/node',
+      ]
+      self.assertLayerNContains(img, 3, layerThreeFiles)
+
+      # Check that the next layer contains node
+      layerFourFiles = [
+        '.',
+        './app',
+        './app/testdata',
+        './app/testdata/nodejs_image_binary.runfiles',
+        './app/testdata/nodejs_image_binary.runfiles/nodejs_linux_amd64',
+        './app/testdata/nodejs_image_binary.runfiles/nodejs_linux_amd64/bin',
+        './app/testdata/nodejs_image_binary.runfiles/nodejs_linux_amd64/bin/node'
+        ]
+      self.assertLayerNContains(img, 4, layerFourFiles)
+
+
   # Re-enable once https://github.com/bazelbuild/rules_d/issues/14 is fixed.
   # def test_d_image_args(self):
   #  with TestImage('d_image') as img:

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@pip_deps//:requirements.bzl", "requirement")
 load("//cc:image.bzl", "cc_image")
 load(
@@ -42,6 +44,7 @@ load(
     "java_image",
     "war_image",
 )
+load("//nodejs:image.bzl", "nodejs_image")
 load("//oci:oci.bzl", "oci_push")
 load("//python:image.bzl", "py_image", "py_layer")
 load("//python3:image.bzl", "py3_image")
@@ -990,4 +993,33 @@ container_image(
     base = ":docker_run_flags_overrides_default",
     docker_run_flags = "-i --rm --network=host -e ABC=DEF",
     legacy_run_behavior = False,
+)
+
+ts_library(
+    name = "nodejs_image_lib",
+    srcs = ["nodejs_image_lib.ts"],
+    tsconfig = ":tsconfig.json",
+    deps = [
+        "@npm//@types/jsesc",
+        "@npm//@types/node",
+        "@npm//jsesc",
+    ],
+)
+
+nodejs_binary(
+    name = "nodejs_image_binary",
+    data = [
+        ":nodejs_image.js",
+        ":nodejs_image_lib",
+    ],
+    entry_point = ":nodejs_image.js",
+)
+
+nodejs_image(
+    name = "nodejs_image",
+    args = [
+        "arg0",
+        "arg1",
+    ],
+    binary = ":nodejs_image_binary",
 )

--- a/testdata/nodejs_image.js
+++ b/testdata/nodejs_image.js
@@ -1,4 +1,4 @@
-var jsesc = require('jsesc');
+const lib = require('./nodejs_image_lib');
 
-console.log(jsesc('Hello World!'));
+console.log(lib.message());
 console.log(process.argv.slice(2))

--- a/testdata/nodejs_image_lib.ts
+++ b/testdata/nodejs_image_lib.ts
@@ -1,0 +1,5 @@
+import * as jsesc from 'jsesc';
+
+export function message() {
+    return jsesc('Hello World!')
+}

--- a/testdata/package.json
+++ b/testdata/package.json
@@ -1,5 +1,9 @@
 {
   "dependencies": {
-    "jsesc": "2.5.2"
+    "@bazel/typescript": "1.0.0",
+    "@types/jsesc": "^2.5.0",
+    "@types/node": "~12.0.0",
+    "jsesc": "2.5.2",
+    "typescript": "3.7.4"
   }
 }

--- a/testdata/yarn.lock
+++ b/testdata/yarn.lock
@@ -2,7 +2,154 @@
 # yarn lockfile v1
 
 
+"@bazel/typescript@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-1.0.0.tgz#2c7318b9a3aaa730f282b094ddf41dd16fda7b5a"
+  integrity sha512-caNOKz7EjVMgbedjVTreao9++9Sb9oYlU2nqDOMIK8MyoOUQvgGQWhFwF65XXGSb79Tzv8kaFQskoaH/iAs4ng==
+  dependencies:
+    protobufjs "6.8.8"
+    semver "5.6.0"
+    source-map-support "0.5.9"
+    tsutils "2.27.2"
+
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
+"@types/jsesc@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@types/jsesc/-/jsesc-2.5.0.tgz#40e2de0f4f0e292f172589e75cfb17b6a6db09c4"
+  integrity sha512-rhKX1CpHA4NH3H/tXpuHAOLCIrJOV6Dm2rtv5J4jQt9tJ801+IIz9yhj2lHl/m5l7NCS94pODN7kLeAcqEaq/g==
+
+"@types/long@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
+  integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
+
+"@types/node@^10.1.0":
+  version "10.17.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
+  integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
+
+"@types/node@~12.0.0":
+  version "12.0.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.12.tgz#cc791b402360db1eaf7176479072f91ee6c6c7ca"
+  integrity sha512-Uy0PN4R5vgBUXFoJrKryf5aTk3kJ8Rv3PdlHjl6UaX+Cqp1QE0yPQ68MPXGrZOfG7gZVNDIJZYyot0B9ubXUrQ==
+
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
 jsesc@2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
+protobufjs@6.8.8:
+  version "6.8.8"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
+  integrity sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.0"
+    "@types/node" "^10.1.0"
+    long "^4.0.0"
+
+semver@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+source-map-support@0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
+  integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+tslib@^1.8.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tsutils@2.27.2:
+  version "2.27.2"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.27.2.tgz#60ba88a23d6f785ec4b89c6e8179cac9b431f1c7"
+  integrity sha512-qf6rmT84TFMuxAKez2pIfR8UCai49iQsfB7YWVjV1bKpy/d0PWT5rEOSM6La9PiHZ0k1RRZQiwVdVJfQ3BPHgg==
+  dependencies:
+    tslib "^1.8.1"
+
+typescript@3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==

--- a/tests/container/nodejs/BUILD
+++ b/tests/container/nodejs/BUILD
@@ -25,44 +25,59 @@ nodejs_image(
         "arg0",
         "arg1",
     ],
-    data = ["//testdata:nodejs_image.js"],
+    data = [
+        "//testdata:nodejs_image.js",
+        "//testdata:nodejs_image_lib",
+        "@npm//jsesc",
+    ],
     entry_point = "@io_bazel_rules_docker//testdata:nodejs_image.js",
-    node_modules = "@npm//:node_modules",
 )
 
 # Docker Cmd value should be `[""]`.
 nodejs_image(
     name = "nodejs_image_list_with_empty_string_args",
     args = [""],
-    data = ["//testdata:nodejs_image.js"],
+    data = [
+        "//testdata:nodejs_image.js",
+        "//testdata:nodejs_image_lib",
+        "@npm//jsesc",
+    ],
     entry_point = "@io_bazel_rules_docker//testdata:nodejs_image.js",
-    node_modules = "@npm//:node_modules",
 )
 
 # Docker Cmd value should be `null`.
 nodejs_image(
     name = "nodejs_image_no_args",
-    data = ["//testdata:nodejs_image.js"],
+    data = [
+        "//testdata:nodejs_image.js",
+        "//testdata:nodejs_image_lib",
+        "@npm//jsesc",
+    ],
     entry_point = "@io_bazel_rules_docker//testdata:nodejs_image.js",
-    node_modules = "@npm//:node_modules",
 )
 
 # Docker Cmd value should be `null`.
 nodejs_image(
     name = "nodejs_image_empty_list_args",
     args = [],
-    data = ["//testdata:nodejs_image.js"],
+    data = [
+        "//testdata:nodejs_image.js",
+        "//testdata:nodejs_image_lib",
+        "@npm//jsesc",
+    ],
     entry_point = "@io_bazel_rules_docker//testdata:nodejs_image.js",
-    node_modules = "@npm//:node_modules",
 )
 
 # Docker Cmd value should be `null`.
 nodejs_image(
     name = "nodejs_image_none_args",
     args = None,
-    data = ["//testdata:nodejs_image.js"],
+    data = [
+        "//testdata:nodejs_image.js",
+        "//testdata:nodejs_image_lib",
+        "@npm//jsesc",
+    ],
     entry_point = "@io_bazel_rules_docker//testdata:nodejs_image.js",
-    node_modules = "@npm//:node_modules",
 )
 
 nodejs_binary(
@@ -71,15 +86,17 @@ nodejs_binary(
         "arg0",
         "arg1",
     ],
-    data = ["//testdata:nodejs_image.js"],
+    data = [
+        "//testdata:nodejs_image.js",
+        "//testdata:nodejs_image_lib",
+        "@npm//jsesc",
+    ],
     entry_point = "@io_bazel_rules_docker//testdata:nodejs_image.js",
-    node_modules = "@npm//:node_modules",
 )
 
 nodejs_image(
     name = "nodejs_image_custom_binary",
     binary = ":my_custom_binary",
-    node_modules = "@npm//:node_modules",
 )
 
 nodejs_image(
@@ -89,7 +106,6 @@ nodejs_image(
         "arg1",
     ],
     binary = ":my_custom_binary",
-    node_modules = "@npm//:node_modules",
 )
 
 container_test(


### PR DESCRIPTION
Adds support for `NodeRuntimeDepsInfo` and `NpmPackageInfo`
This ensures that npm deps are placed in their own layer, improving caching and rebuilds
Also puts nodejs and nodejs args so that it can be cached between instances of nodejs_image targets.

based off work started here https://github.com/bazelbuild/rules_docker/pull/487/files