### PR TITLE
Add robot_email attr to container push bzl rules

### DIFF
--- a/container/push.bzl
+++ b/container/push.bzl
@@ -187,6 +187,11 @@ container_push = rule(
             default = Label("//container:push-tag.sh.tpl"),
             allow_single_file = True,
         ),
+        "robot_email": attr.string(
+            default = "",
+            doc = "(NOT SUPPORTED) This attr is currently being ignored.",
+            mandatory = False,
+        ),
     }, _layer_tools),
     executable = True,
     toolchains = ["@io_bazel_rules_docker//toolchains/docker:toolchain_type"],

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -156,6 +156,11 @@ container_push = rule(
             mandatory = True,
             doc = "The name of the image.",
         ),
+        "robot_email": attr.string(
+            default = "",
+            doc = "(NOT SUPPORTED) This attr is currently being ignored.",
+            mandatory = False,
+        ),
         "skip_unchanged_digest": attr.bool(
             default = False,
             doc = "Only push images if the digest has changed, default to False",
@@ -186,11 +191,6 @@ container_push = rule(
         "_tag_tpl": attr.label(
             default = Label("//container:push-tag.sh.tpl"),
             allow_single_file = True,
-        ),
-        "robot_email": attr.string(
-            default = "",
-            doc = "(NOT SUPPORTED) This attr is currently being ignored.",
-            mandatory = False,
         ),
     }, _layer_tools),
     executable = True,

--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -92,6 +92,11 @@ container_push = rule(
             mandatory = True,
             doc = "The bundle of tagged images to publish.",
         ),
+        "robot_email": attr.string(
+            default = "",
+            doc = "(NOT SUPPORTED) This attr is currently being ignored.",
+            mandatory = False,
+        ),
         "format": attr.string(
             mandatory = True,
             values = [
@@ -113,11 +118,6 @@ container_push = rule(
         "_tag_tpl": attr.label(
             default = Label("//container:push-tag.sh.tpl"),
             allow_single_file = True,
-        ),
-        "robot_email": attr.string(
-            default = "",
-            doc = "(NOT SUPPORTED) This attr is currently being ignored.",
-            mandatory = False,
         ),
     },
     executable = True,

--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -92,11 +92,6 @@ container_push = rule(
             mandatory = True,
             doc = "The bundle of tagged images to publish.",
         ),
-        "robot_email": attr.string(
-            default = "",
-            doc = "(NOT SUPPORTED) This attr is currently being ignored.",
-            mandatory = False,
-        ),
         "format": attr.string(
             mandatory = True,
             values = [
@@ -104,6 +99,11 @@ container_push = rule(
                 "Docker",
             ],
             doc = "The form to push: Docker or OCI.",
+        ),
+        "robot_email": attr.string(
+            default = "",
+            doc = "(NOT SUPPORTED) This attr is currently being ignored.",
+            mandatory = False,
         ),
         "_all_tpl": attr.label(
             default = Label("//contrib:push-all.sh.tpl"),

--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -114,6 +114,11 @@ container_push = rule(
             default = Label("//container:push-tag.sh.tpl"),
             allow_single_file = True,
         ),
+        "robot_email": attr.string(
+            default = "",
+            doc = "(NOT SUPPORTED) This attr is currently being ignored.",
+            mandatory = False,
+        ),
     },
     executable = True,
     implementation = _impl,


### PR DESCRIPTION
The robot_email attr is used at Google internally and github users should not be using it.