### PR TITLE
Add http(s)_proxy env var support to puller

### DIFF
--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -151,6 +151,7 @@ func main() {
 		IdleConnTimeout:       dur,
 		ResponseHeaderTimeout: dur,
 		ExpectContinueTimeout: dur,
+		Proxy:                 http.ProxyFromEnvironment,
 	}
 
 	if err := pull(*imgName, *directory, *cachePath, platform, t); err != nil {


### PR DESCRIPTION
Configure the HTTP transport used by the container puller tool to
recognise the standard http_proxy/https_proxy/no_proxy environment
variables.

If these variables are present in the host environment, Bazel sets them
in repository rule contexts by default.

Fixes #1241