### PR TITLE
Revert "Change to using python 3 in host configuration"

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -31,7 +31,7 @@ py_binary(
     name = "build_tar",
     srcs = ["build_tar.py"],
     legacy_create_init = True,
-    python_version = "PY3",
+    python_version = "PY2",
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [":build_tar_lib"],

--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -31,7 +31,7 @@ py_binary(
     name = "extract_image_id",
     srcs = [":extract_image_id.py"],
     legacy_create_init = False,
-    python_version = "PY3",
+    python_version = "PY2",
     deps = [":extract_image_id_lib"],
 )
 
@@ -44,7 +44,7 @@ py_binary(
     name = "compare_ids_test",
     srcs = [":compare_ids_test.py"],
     legacy_create_init = False,
-    python_version = "PY3",
+    python_version = "PY2",
     deps = [":extract_image_id_lib"],
 )
 

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -501,7 +501,7 @@ container_bundle(
 py_binary(
     name = "gen_deb",
     srcs = ["gen_deb.py"],
-    python_version = "PY3",
+    python_version = "PY2",
 )
 
 generate_deb(

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -304,7 +304,7 @@ function test_container_push_with_auth() {
   # Run the container_push test in the Bazel workspace that configured
   # the docker toolchain rule to use authentication.
   cd "${ROOT}/testing/custom_toolchain_auth"
-  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT}"
+  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT} --host_force_python=PY2"
   echo "Attempting authenticated container_push..."
   EXPECT_CONTAINS "$(bazel run $bazel_opts @io_bazel_rules_docker//tests/container:push_test 2>&1)" "Successfully pushed Docker image to localhost:5000/docker/test:test"
   bazel clean
@@ -313,7 +313,7 @@ function test_container_push_with_auth() {
   # configured docker toolchain. The default configuration doesn't setup
   # authentication and this should fail.
   cd "${ROOT}/testing/default_toolchain"
-  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT}"
+  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT} --host_force_python=PY2"
   echo "Attempting unauthenticated container_push..."
   EXPECT_CONTAINS "$(bazel run $bazel_opts @io_bazel_rules_docker//tests/container:push_test  2>&1)" "unable to push image to localhost:5000/docker/test:test"
   bazel clean
@@ -350,7 +350,7 @@ function test_container_pull_with_auth() {
   launch_private_registry_with_auth
 
   cd "${ROOT}/testing/custom_toolchain_auth"
-  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT}"
+  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT} --host_force_python=PY2"
   # Remove the old image if it exists
   docker rmi bazel/image:image || true
   # Push the locally built container to the private repo
@@ -362,7 +362,7 @@ function test_container_pull_with_auth() {
   # configured docker toolchain. The default configuration doesn't setup
   # authentication and this should fail.
   cd "${ROOT}/testing/default_toolchain"
-  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT}"
+  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT} --host_force_python=PY2"
   echo "Attempting unauthenticated container_pull..."
   EXPECT_CONTAINS "$(bazel run $bazel_opts @local_pull//image 2>&1)" "Image pull was unsuccessful: reading image \"localhost:5000/docker/test:test\""
 }

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -408,7 +408,7 @@ docker_push_all(
 py_test(
     name = "build_tar_test",
     srcs = ["build_tar_test.py"],
-    python_version = "PY3",
+    python_version = "PY2",
     deps = ["//container:build_tar_lib"],
 )
 


### PR DESCRIPTION
Reverts bazelbuild/rules_docker#1318

Breaks internal tests because internally we depend on some libraries that haven't been migrated to PY3. In order to use PY3, we'll have to migrate to using absl.flags instead of gflags.