### PR TITLE
Update to HTTPS source for maven deps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -281,7 +281,7 @@ jvm_maven_import_external(
     artifact = "com.google.guava:guava:18.0",
     artifact_sha256 = "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 # For our scala_image test.

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -87,7 +87,7 @@ def repositories():
             name = "javax_servlet_api",
             artifact = "javax.servlet:javax.servlet-api:3.0.1",
             artifact_sha256 = "377d8bde87ac6bc7f83f27df8e02456d5870bb78c832dac656ceacc28b016e56",
-            server_urls = ["http://central.maven.org/maven2"],
+            server_urls = ["https://repo1.maven.org/maven2"],
             licenses = ["notice"],  # Apache 2.0
         )
 


### PR DESCRIPTION
As of January 15, 2020, maven requires an HTTPS url for package sources.
There were a few scattered references to a now-non-functional HTTP
endpoint yielding 501s in builds.  This change updates to use the
canonical HTTPS url

See https://support.sonatype.com/hc/en-us/articles/360041287334-Central-501-HTTPS-Required for background