### PR TITLE
update rules scala to pick up maven to https change

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -281,7 +281,7 @@ jvm_maven_import_external(
     artifact = "com.google.guava:guava:18.0",
     artifact_sha256 = "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 # For our scala_image test.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -287,9 +287,9 @@ jvm_maven_import_external(
 # For our scala_image test.
 http_archive(
     name = "io_bazel_rules_scala",
-    sha256 = "8566ddc6899d0140a773ffd227d895bc4c79b6def606f131497f95f214df440d",
-    strip_prefix = "rules_scala-bd0c388125e12f4f173648fc4474f73160a5c628",
-    urls = ["https://github.com/bazelbuild/rules_scala/archive/bd0c388125e12f4f173648fc4474f73160a5c628.tar.gz"],
+    sha256 = "b3f980d09b8394ad513a9c126e30f54acba3164e0fd20cffbf57249dbaf8b2a0",
+    strip_prefix = "rules_scala-2ea8dbad2fee824c68d342d02e48942e2404aaa5",
+    urls = ["https://github.com/bazelbuild/rules_scala/archive/2ea8dbad2fee824c68d342d02e48942e2404aaa5.tar.gz"],
 )
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -87,7 +87,7 @@ def repositories():
             name = "javax_servlet_api",
             artifact = "javax.servlet:javax.servlet-api:3.0.1",
             artifact_sha256 = "377d8bde87ac6bc7f83f27df8e02456d5870bb78c832dac656ceacc28b016e56",
-            server_urls = ["http://central.maven.org/maven2"],
+            server_urls = ["https://repo1.maven.org/maven2"],
             licenses = ["notice"],  # Apache 2.0
         )
 


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_docker/issues/1373, subsumes https://github.com/bazelbuild/rules_docker/pull/1374, also adding change to update pin to rules_scala. But in order for anything to pass CI now, we need to also update our references to maven central.