### PR TITLE
Implement UncompressedSize to take advantage of memory opt

### DIFF
--- a/container/go/pkg/compat/image.go
+++ b/container/go/pkg/compat/image.go
@@ -75,6 +75,15 @@ func (l *fullLayer) Uncompressed() (io.ReadCloser, error) {
 	return f, nil
 }
 
+// UncompressedSize returns the size of the uncompressed layer contents.
+func (l *fullLayer) UncompressedSize() (int64, error) {
+	f, err := os.Stat(l.uncompressedTarball)
+	if err != nil {
+		return 0, errors.Wrapf(err, "unable to stat %s to determine size of uncompressed layer", l.uncompressedTarball)
+	}
+	return f.Size(), nil
+}
+
 // Size returns the compressed size of the Layer.
 func (l *fullLayer) Size() (int64, error) {
 	f, err := os.Stat(l.compressedTarball)

--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -37,7 +37,7 @@ def go_deps():
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(
             name = "com_github_google_go_containerregistry",
-            commit = "b02f5c5c90539d88cec4eb4450c3d6f135457942",
+            commit = "379933c9c22b8ff1b396b5b7f4ec322d27f0a206",
             importpath = "github.com/google/go-containerregistry",
         )
     if "com_github_pkg_errors" not in excludes:


### PR DESCRIPTION
Take advantage of
https://github.com/google/go-containerregistry/pull/655 and avoid
loading an uncompressed layer into memory when writing out an image
tarball.

This fixes #1349