### PR TITLE
Declare PATH environment variable as a dependency.

### DIFF
--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -180,5 +180,8 @@ toolchain_configure = repository_rule(
                   "that use xz will fail.",
         ),
     },
+    environ = [
+        "PATH",
+    ],
     implementation = _toolchain_configure_impl,
 )


### PR DESCRIPTION
`toolchain_configure` uses `repository_ctx.which`, and saves the result into the external repository's generated `BUILD` file, so it has to be rerun if `PATH` changes.