### PR TITLE
Plumb os.version through container image config files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2152,6 +2152,13 @@ container_image(name, base, data_path, directory, files, legacy_repository_namin
       </td>
     </tr>
     <tr>
+      <td><code>os_version</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The desired OS version to be used in the container image config.</p>
+      </td>
+    </tr>
+    <tr>
       <td><code>compression</code></td>
       <td>
         <code>String, optional</code>

--- a/container/go/cmd/create_image_config/create_image_config.go
+++ b/container/go/cmd/create_image_config/create_image_config.go
@@ -41,6 +41,7 @@ var (
 	nullCmd            = flag.Bool("nullCmd", false, "If true, Cmd will be set to null.")
 	architecture       = flag.String("architecture", "amd64", "The architecture of the docker image.")
 	operatingSystem    = flag.String("operatingSystem", "linux", "Operating system to create docker image for, eg. linux.")
+	osVersion          = flag.String("osVersion", "", "Operating system version to create docker image for (primarily for windows).")
 	labelsArray        utils.ArrayStringFlags
 	ports              utils.ArrayStringFlags
 	volumes            utils.ArrayStringFlags
@@ -97,6 +98,7 @@ func main() {
 		NullCmd:            *nullCmd,
 		Architecture:       *architecture,
 		OperatingSystem:    *operatingSystem,
+		OSVersion:          *osVersion,
 		CreatedBy:          "bazel build ...",
 		Author:             "Bazel",
 		LabelsArray:        labelsArray,

--- a/container/go/pkg/compat/config.go
+++ b/container/go/pkg/compat/config.go
@@ -65,6 +65,8 @@ type OverrideConfigOpts struct {
 	Architecture string
 	// OperatingSystem is the operating system to creater docker image for.
 	OperatingSystem string
+	// OSVersion is the operating system version to creater docker image for.
+	OSVersion string
 	// CreatedBy is the command that generated the image. Default
 	// "bazel build ...".
 	CreatedBy string
@@ -443,6 +445,9 @@ func updateConfig(overrideInfo *OverrideConfigOpts) error {
 	overrideInfo.ConfigFile.Author = overrideInfo.Author
 	overrideInfo.ConfigFile.OS = overrideInfo.OperatingSystem
 	overrideInfo.ConfigFile.Architecture = overrideInfo.Architecture
+	if overrideInfo.OSVersion != "" {
+		overrideInfo.ConfigFile.OSVersion = overrideInfo.Stamper.Stamp(overrideInfo.OSVersion)
+	}
 
 	creationTime, err := getCreationTime(overrideInfo)
 	// creationTime is the RFC 3339 formatted time derived from createTime input.

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -107,7 +107,8 @@ def _add_create_image_config_args(
         base_config,
         base_manifest,
         architecture,
-        operating_system):
+        operating_system,
+        os_version):
     """
     Add args for the create_image_config Go binary.
     """
@@ -166,6 +167,9 @@ def _add_create_image_config_args(
     if operating_system:
         args.add("-operatingSystem", operating_system)
 
+    if os_version:
+        args.add("-osVersion", os_version)
+
     if ctx.attr.stamp:
         stamp_inputs = [ctx.info_file, ctx.version_file]
         args.add_all(stamp_inputs, before_each = "-stampInfoFile")
@@ -192,6 +196,7 @@ def _image_config(
         base_manifest = None,
         architecture = None,
         operating_system = None,
+        os_version = None,
         layer_name = None,
         workdir = None,
         null_entrypoint = False,
@@ -235,6 +240,7 @@ def _image_config(
         base_manifest,
         architecture,
         operating_system,
+        os_version,
     )
 
     ctx.actions.run(
@@ -297,6 +303,7 @@ def _impl(
         tars = None,
         architecture = None,
         operating_system = None,
+        os_version = None,
         output_executable = None,
         output_tarball = None,
         output_config = None,
@@ -328,6 +335,7 @@ def _impl(
     tars: File list, overrides ctx.files.tars
     architecture: str, overrides ctx.attr.architecture
     operating_system: Operating system to target (e.g. linux, windows)
+    os_version: Operating system version to target
     output_executable: File to use as output for script to load docker image
     output_tarball: File, overrides ctx.outputs.out
     output_config: File, overrides ctx.outputs.config
@@ -344,6 +352,7 @@ def _impl(
     compression = compression or ctx.attr.compression
     compression_options = compression_options or ctx.attr.compression_options
     operating_system = operating_system or ctx.attr.operating_system
+    os_version = os_version or ctx.attr.os_version
     creation_time = creation_time or ctx.attr.creation_time
     build_executable = output_executable or ctx.outputs.build_script
     output_tarball = output_tarball or ctx.outputs.out
@@ -434,6 +443,7 @@ def _impl(
             base_manifest = manifest_file,
             architecture = architecture,
             operating_system = operating_system,
+            os_version = os_version,
             layer_name = str(i),
             workdir = workdir or ctx.attr.workdir,
             null_entrypoint = null_entrypoint,
@@ -561,6 +571,7 @@ _attrs = dicts.add(_layer.attrs, {
     # We need these flags to distinguish them.
     "null_cmd": attr.bool(default = False),
     "null_entrypoint": attr.bool(default = False),
+    "os_version": attr.string(),
     "ports": attr.string_list(),  # Skylark doesn't support int_list...
     "repository": attr.string(default = "bazel"),
     "stamp": attr.bool(default = False),

--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -37,7 +37,7 @@ def go_deps():
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(
             name = "com_github_google_go_containerregistry",
-            commit = "379933c9c22b8ff1b396b5b7f4ec322d27f0a206",
+            commit = "221517453cf931400e6607315045445644122692",
             importpath = "github.com/google/go-containerregistry",
         )
     if "com_github_pkg_errors" not in excludes:

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -232,7 +232,7 @@ function test_new_container_push_legacy_with_auth() {
   cd "${ROOT}/testing/default_toolchain"
   bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT}"
   echo "Attempting unauthenticated new container_push..."
-  EXPECT_CONTAINS "$(bazel run $bazel_opts @io_bazel_rules_docker//tests/container:new_push_test_legacy_from_container_img_with_auth  2>&1)" "unable to push image to localhost:5000/docker/test:test: unsupported status code 401"
+  EXPECT_CONTAINS "$(bazel run $bazel_opts @io_bazel_rules_docker//tests/container:new_push_test_legacy_from_container_img_with_auth  2>&1)" "unsupported status code 401"
   bazel clean
 }
 
@@ -341,7 +341,7 @@ function test_new_container_push_oci_with_auth() {
   cd "${ROOT}/testing/default_toolchain"
   bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT}"
   echo "Attempting unauthenticated new container_push..."
-  EXPECT_CONTAINS "$(bazel run $bazel_opts @io_bazel_rules_docker//tests/container:new_push_test_oci  2>&1)" "unable to push image to localhost:5000/docker/test:test: unsupported status code 401"
+  EXPECT_CONTAINS "$(bazel run $bazel_opts @io_bazel_rules_docker//tests/container:new_push_test_oci  2>&1)" "unsupported status code 401"
   bazel clean
 }
 


### PR DESCRIPTION
Fixes #1429

Just tested this manually and it seems to work!

I'm mostly just interested in getting os.version to plumb through bazel from the intermediate form config file, which is fixed by just bumping the dependency on go-containerregistry to pick up https://github.com/google/go-containerregistry/pull/676, but it seems like a reasonable thing to also expose in the rules.

I can remove the rules changes and just update the dependency if this feels unnecessary, but exposing this just feels more "complete", y'know? Let me know what you think.