### PR TITLE
Fixed passing data to app_layer in nodejs_image

### DIFF
--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -166,6 +166,6 @@ def nodejs_image(
         visibility = visibility,
         tags = tags,
         args = kwargs.get("args"),
-        data = kwargs.get("data"),
+        data = data,
         testonly = kwargs.get("testonly"),
     )


### PR DESCRIPTION
We were getting `data` from `kwargs`, but it will always be `None` since we declare an explicit `data` in the function parameters. This only passes the `data` function parameter to the `app_layer` data.

This fix is required for using arguments on the `nodejs_image`, e.g.:

```starlark
nodejs_image(
    name = "my_image",
    binary = ":my_bin",
    args = ["$(rootpath config.json)"],
    data = ["config.json"],
)
```