### PR TITLE
Fix CI failures due to Clang 10 -> 11 upgrade

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -408,10 +408,11 @@ register_execution_platforms(
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "4d348abfaddbcee0c077fc51bb1177065c3663191588ab3d958f027cbfe1818b",
-    strip_prefix = "bazel-toolchains-2.1.0",
+    sha256 = "b5a8039df7119d618402472f3adff8a1bd0ae9d5e253f53fcc4c47122e91a3d2",
+    strip_prefix = "bazel-toolchains-2.1.1",
     urls = [
-        "https://github.com/bazelbuild/bazel-toolchains/archive/2.1.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/releases/download/2.1.1/bazel-toolchains-2.1.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/2.1.1.tar.gz",
     ],
 )
 
@@ -429,8 +430,8 @@ load("@exec_properties//:constants.bzl", "DOCKER_SIBLINGS_CONTAINERS", "NETWORK_
 
 rbe_autoconfig(
     name = "buildkite_config",
-    base_container_digest = "sha256:4bfd33aa9ce73e28718385b8c01608a79bc6546906f01cf9329311cace1766a1",
-    digest = "sha256:c20046852a2d7910c55d76e0ec9c182b37532a9f0360d22dd5c9a1451b7c3a15",
+    base_container_digest = "sha256:b4dad0bfc4951d619229ab15343a311f2415a16ef83bcaa55b44f4e2bf1cf635",
+    digest = "sha256:565d0a20a4c6a4c65e219f22ae55c88b36755848ff133164bce2d443f5f6067d",
     exec_properties = dicts.add(DOCKER_SIBLINGS_CONTAINERS, NETWORK_ON),
     registry = "marketplace.gcr.io",
     repository = "google/bazel",

--- a/tests/container/cloudbuild.yaml
+++ b/tests/container/cloudbuild.yaml
@@ -16,7 +16,7 @@
 # available.
 
 steps:
-  - name: "l.gcr.io/google/bazel@sha256:c20046852a2d7910c55d76e0ec9c182b37532a9f0360d22dd5c9a1451b7c3a15"
+  - name: "l.gcr.io/google/bazel"
     args:
       - "--bazelrc=.bazelrc"
       - "test"

--- a/tests/container/cloudbuild.yaml
+++ b/tests/container/cloudbuild.yaml
@@ -16,8 +16,8 @@
 # available.
 
 steps:
-  - name: "l.gcr.io/google/bazel"
-    args: 
+  - name: "l.gcr.io/google/bazel@sha256:c20046852a2d7910c55d76e0ec9c182b37532a9f0360d22dd5c9a1451b7c3a15"
+    args:
       - "--bazelrc=.bazelrc"
       - "test"
       - "--define=ENV_KEY=my_key"


### PR DESCRIPTION
After Bazel container was updated to include Clang 11.0.0, this GCB test
started to fail because the toolchain config it uses is pinned to an
older Bazel container but the Bazel container the test runs in uses
"latest". From what I can tell, the test is meant to ensure RBE supports
the exec properties that enable sibling docker so I don't think we're
losing test coverage.