### PR TITLE
Add option to preserve input tar file mtimes in container_image

### DIFF
--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -47,6 +47,9 @@ gflags.DEFINE_string(
         ' value "portable", to get the value 2000-01-01, which is'
         ' usable with non *nix OSes.')
 
+gflags.DEFINE_bool(
+    'preserve_tar_mtimes', False, 'Preserve file mtimes from input tar file.')
+
 gflags.DEFINE_multistring(
     'empty_root_dir',
     [],
@@ -121,12 +124,14 @@ class TarFile(object):
     else:
       return os.path.basename(os.path.splitext(filename)[0])
 
-  def __init__(self, output, directory, compression, root_directory, default_mtime):
+  def __init__(self, output, directory, compression, root_directory,
+               default_mtime, preserve_tar_mtimes):
     self.directory = directory
     self.output = output
     self.compression = compression
     self.root_directory = root_directory
     self.default_mtime = default_mtime
+    self.preserve_tar_mtimes = preserve_tar_mtimes
 
   def __enter__(self):
     self.tarfile = archive.TarFileWriter(
@@ -134,6 +139,7 @@ class TarFile(object):
         self.compression,
         self.root_directory,
         self.default_mtime,
+        self.preserve_tar_mtimes,
     )
     return self
 
@@ -405,7 +411,9 @@ def main(unused_argv):
       ids_map[f] = (int(user), int(group))
 
   # Add objects to the tar file
-  with TarFile(FLAGS.output, FLAGS.directory, FLAGS.compression, FLAGS.root_directory, FLAGS.mtime) as output:
+  with TarFile(FLAGS.output, FLAGS.directory, FLAGS.compression,
+               FLAGS.root_directory, FLAGS.mtime,
+               FLAGS.preserve_tar_mtimes) as output:
     def file_attributes(filename):
       if filename.startswith('/'):
         filename = filename[1:]

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -284,6 +284,7 @@ _layer_attrs = dicts.add({
         mandatory = False,
     ),
     "portable_mtime": attr.bool(default = False),
+    "preserve_tar_mtimes": attr.bool(default = False),
     "symlinks": attr.string_dict(),
     "tars": attr.label_list(allow_files = tar_filetype),
 }, _hash_tools, _layer_tools)

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -111,6 +111,8 @@ def build_layer(
         args.add(ctx.attr.mtime, format = "--mtime=%s")
     if ctx.attr.portable_mtime:
         args.add("--mtime=portable")
+    if ctx.attr.preserve_tar_mtimes:
+        args.add("--preserve_tar_mtimes=true")
 
     if toolchain_info.xz_path != "":
         args.add(toolchain_info.xz_path, format = "--xz_path=%s")


### PR DESCRIPTION
This is the second step towards resolving static file browser cache issues in application that are deployed using the container_image bazel rule. The first step is [here](https://github.com/bazelbuild/bazel/pull/11028); this PR should **not** be merged until that one has been merged.

This PR allows users to specify that they'd like their container_image to preserve file mtimes from ther input tar file. It is an additive, opt-in change and should not affect any existing functionality.