### PR TITLE
Use rules_pkg repository instead of deprecated pkg files

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ rules, you can override the default `base="..."` attribute.  Consider this
 modified sample from the `distroless` repository:
 
 ```python
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 # Create a passwd file with a root and nonroot user and uid.
 passwd_entry(

--- a/container/BUILD
+++ b/container/BUILD
@@ -44,7 +44,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_tools//third_party/py/gflags",
-        "@rules_pkg//pkg:archive",
+        "@rules_pkg//:archive",
     ],
 )
 

--- a/container/BUILD
+++ b/container/BUILD
@@ -44,7 +44,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_tools//third_party/py/gflags",
-        "@bazel_tools//tools/build_defs/pkg:archive",
+        "@rules_pkg//pkg:archive",
     ],
 )
 

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -25,7 +25,7 @@ import re
 import tarfile
 import tempfile
 
-from tools.build_defs.pkg import archive
+from rules_pkg import archive
 from third_party.py import gflags
 
 gflags.DEFINE_string('output', None, 'The output file, mandatory')
@@ -134,6 +134,7 @@ class TarFile(object):
         self.compression,
         self.root_directory,
         self.default_mtime,
+        False,
     )
     return self
 

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -143,6 +143,13 @@ def repositories():
             urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.20.0/bazel-gazelle-v0.20.0.tar.gz"],
         )
 
+    if "rules_pkg" not in excludes:
+        http_archive(
+            name = "rules_pkg",
+            sha256 = "a5cca9cf01c7fcfe4aab8ef54ce590e49c4921fa0d4d194b5f0ad732a8b207c4",
+            urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.2.6/rules_pkg-0.2.6.tar.gz"],
+        )
+
     native.register_toolchains(
         # Register the default docker toolchain that expects the 'docker'
         # executable to be in the PATH

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
@@ -285,7 +285,7 @@ container_image(
 # py_binary(
 #     name = "extras_gen",
 #     srcs = ["extras_gen.py"],
-#     deps = ["@bazel_tools//tools/build_defs/pkg:archive"],
+#     deps = ["@rules_pkg//:archive"],
 # )
 
 # genrule(

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@pip_deps//:requirements.bzl", "requirement")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//cc:image.bzl", "cc_image")
 load(
     "//container:container.bzl",

--- a/tests/docker/toolchain_container/BUILD
+++ b/tests/docker/toolchain_container/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//contrib:test.bzl", "container_test")
 load(
     "//docker/toolchain_container:toolchain_container.bzl",


### PR DESCRIPTION
This repository is currently using a deprecated version of Bazel's package management code. This PR updates all references to `@bazel_tools//tools/build_defs/pkg` so that they instead use `@rules_pkg//`, which is maintained.

Note: this PR does not replace `rules_docker`'s custom version of `build_tar.py` with the one contained in `rules_pkg`. It should not result in any changed behavior at all.