### PR TITLE
Update one remaining reference to deprecated rules pkg

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -31,7 +31,7 @@ py_binary(
     name = "build_tar",
     srcs = ["build_tar.py"],
     legacy_create_init = True,
-    python_version = "PY2",
+    python_version = "PY3",
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [":build_tar_lib"],

--- a/testdata/extras_gen.py
+++ b/testdata/extras_gen.py
@@ -16,7 +16,7 @@ import datetime
 import sys
 import tarfile
 
-from tools.build_defs.pkg import archive
+from rules_pkg import archive
 
 if __name__ == '__main__':
   mtime = int(datetime.datetime.now().strftime('%s'))


### PR DESCRIPTION
Also configure build_tar binary to use Python 3.