### PR TITLE
Correctly read users' enable_mtime_preservation config

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -60,6 +60,7 @@ TEST_TARGETS = [
     ":files_in_layer_with_files_base",
     ":files_with_tar_base",
     ":tar_base",
+    ":tar_with_mtimes_preserved",
     ":tar_with_files_base",
     ":tar_with_tar_base",
     ":tars_in_layer_with_tar_base",

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -139,7 +139,7 @@ class TarFile(object):
         self.compression,
         self.root_directory,
         self.default_mtime,
-        False,
+        self.enable_mtime_preservation,
     )
     return self
 

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -53,6 +53,12 @@ class ImageTest(unittest.TestCase):
     with tarfile.open(fileobj=buf, mode='r') as layer:
       self.assertTarballContains(layer, paths)
 
+  def assertNonZeroMtimesInTopLayer(self, img):
+    buf = cStringIO.StringIO(img.blob(img.fs_layers()[0]))
+    with tarfile.open(fileobj=buf, mode='r') as layer:
+      for member in layer.getmembers():
+        self.assertNotEqual(member.mtime, 0)
+
   def assertTopLayerContains(self, img, paths):
     self.assertLayerNContains(img, 0, paths)
 
@@ -97,6 +103,11 @@ class ImageTest(unittest.TestCase):
         './usr', './usr/bin', './usr/bin/unremarkabledeath'])
       # Check that this doesn't have a configured entrypoint.
       self.assertConfigEqual(img, 'Entrypoint', None)
+
+  def test_tar_with_mtimes_preserved(self):
+    with TestImage('tar_with_mtimes_preserved') as img:
+      self.assertDigest(img, '2b01c46f6ba7652112154e7fedfb3357b6cbf1d7eaa09cd15143bb74f8f3b617')
+      self.assertNonZeroMtimesInTopLayer(img)
 
   def test_tar_with_tar_base(self):
     with TestImage('tar_with_tar_base') as img:

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -162,6 +162,13 @@ container_image(
 )
 
 container_image(
+    name = "tar_with_mtimes_preserved",
+    base = ":tar_base",
+    enable_mtime_preservation = True,
+    tars = ["two.tar"],
+)
+
+container_image(
     name = "tar_with_tar_base",
     base = ":tar_base",
     tars = ["two.tar"],


### PR DESCRIPTION
This fixes a mistake in https://github.com/bazelbuild/rules_docker/pull/1489 - I missed one instance of hardcoding the value False. This PR also adds a test of this configuration option.