### PR TITLE
Fix bug in image puller execution timeout

### DIFF
--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -165,10 +165,15 @@ exports_files(["image.digest", "digest"])
     kwargs = {}
 
     if "PULLER_TIMEOUT" in repository_ctx.os.environ:
-        args += [
-            "-timeout",
-            repository_ctx.os.environ.get("PULLER_TIMEOUT"),
-        ]
+        timeout_in_secs = repository_ctx.os.environ["PULLER_TIMEOUT"]
+        if timeout_in_secs.isdigit():
+            args += [
+                "-timeout",
+                timeout_in_secs,
+            ]
+            kwargs["timeout"] = int(timeout_in_secs)
+        else:
+            fail("'%s' is invalid value for PULLER_TIMEOUT. Must be an integer." % (timeout_in_secs))
 
     result = repository_ctx.execute(args, **kwargs)
     if result.return_code:

--- a/testing/e2e/puller.sh
+++ b/testing/e2e/puller.sh
@@ -25,8 +25,11 @@ function test_puller_timeout() {
   # Ensure the puller respects the PULLER_TIMEOUT environment variable. Try
   # pulling a large image but set a very low timeout of 1s which should fail if
   # the puller is respecting timeouts.
+  # NOTE: Potential race condition between the Bazel timeout mechanism and the go puller's.
+  #       Could result in test flakes.
+  #       See: https://github.com/bazelbuild/rules_docker/pull/1495#issuecomment-627969114
   cd "${ROOT}"
-  EXPECT_CONTAINS "$(PULLER_TIMEOUT=1 bazel build @large_image_timeout_test//image 2>&1)" "i/o timeout"
+  EXPECT_CONTAINS "$(PULLER_TIMEOUT=1 bazel build @large_image_timeout_test//image 2>&1)" "ERROR: Pull command failed: Timed out"
   echo "test_puller_timeout PASSED!"
 }
 


### PR DESCRIPTION
Follow-up from my comment here https://github.com/bazelbuild/rules_docker/pull/1222#discussion_r421995883

Added some input validation to get a nicer user error message than: 

```
PULLER_TIMEOUT=foo bazel run //foo:bar-image
 - /Users/jbelotti/work/data-science/WORKSPACE:275:1
ERROR: An error occurred during the fetch of repository 'base_image':
   invalid literal for int() with base 10: "foo": For input string: "foo"
```