### PR TITLE
Switch arbitrary run instruction to python3

### DIFF
--- a/testing/examples/run_instruction_arbitrary/BUILD
+++ b/testing/examples/run_instruction_arbitrary/BUILD
@@ -46,9 +46,9 @@ container_run_and_commit(
         # Install kubernetes as a component of gcloud
         "/google-cloud-sdk/bin/gcloud components install --quiet kubectl",
         "apt-get update",
-        "apt-get install -y --no-install-recommends python-pip",
+        "apt-get install -y --no-install-recommends python3-pip",
         "apt-get clean",
-        "python -m pip install --upgrade pip setuptools wheel",
+        "python3 -m pip install --upgrade pip setuptools wheel",
     ],
     image = ":gcloud_installer.tar",
 )

--- a/testing/examples/run_instruction_arbitrary/Dockerfile
+++ b/testing/examples/run_instruction_arbitrary/Dockerfile
@@ -14,7 +14,6 @@ RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/google-cloud-sdk/bin
 
 # Install python tools
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python-pip \
+RUN apt-get update && apt-get install -y --no-install-recommends python3-pip \
     && apt-get clean \
-    && python -m pip install --upgrade pip setuptools wheel
+    && python3 -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
Python2 now fails to install the same packages probably due to its deprecation.