### PR TITLE
Revert to using gflags but use it from a pips package instead of Bazel Tools

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@pip_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -43,7 +44,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        "@io_abseil_py//absl/flags",
+        requirement("python-gflags"),
         "@rules_pkg//:archive",
     ],
 )

--- a/container/BUILD
+++ b/container/BUILD
@@ -45,6 +45,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         requirement("python-gflags"),
+        requirement("six"),
         "@rules_pkg//:archive",
     ],
 )

--- a/container/BUILD
+++ b/container/BUILD
@@ -43,7 +43,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_tools//third_party/py/gflags",
+        "@io_abseil_py//absl/flags",
         "@rules_pkg//:archive",
     ],
 )

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -28,83 +28,82 @@ import tempfile
 
 from rules_pkg import archive
 
+gflags.DEFINE_string('output', None, 'The output file, mandatory')
+gflags.MarkFlagAsRequired('output')
 
-flags.DEFINE_string('output', None, 'The output file, mandatory')
-flags.mark_flag_as_required('output')
+gflags.DEFINE_multistring('file', [], 'A file to add to the layer')
 
-flags.DEFINE_multi_string('file', [], 'A file to add to the layer')
+gflags.DEFINE_string('manifest', None, 'JSON manifest of contents to add to the layer')
 
-flags.DEFINE_string('manifest', None, 'JSON manifest of contents to add to the layer')
+gflags.DEFINE_multistring('empty_file', [], 'An empty file to add to the layer')
 
-flags.DEFINE_multi_string('empty_file', [], 'An empty file to add to the layer')
+gflags.DEFINE_multistring('empty_dir', [], 'An empty dir to add to the layer')
 
-flags.DEFINE_multi_string('empty_dir', [], 'An empty dir to add to the layer')
-
-flags.DEFINE_string(
+gflags.DEFINE_string(
     'mode', None, 'Force the mode on the added files (in octal).')
 
-flags.DEFINE_string(
+gflags.DEFINE_string(
     'mtime', None, 'Set mtime on tar file entries. May be an integer or the'
         ' value "portable", to get the value 2000-01-01, which is'
         ' usable with non *nix OSes.')
 
-flags.DEFINE_bool(
+gflags.DEFINE_bool(
     'enable_mtime_preservation', False, 'Preserve file mtimes from input tar file.')
 
-flags.DEFINE_multi_string(
+gflags.DEFINE_multistring(
     'empty_root_dir',
     [],
     'An empty root directory to add to the layer.  This will create a directory that'
     'is a peer of "root_directory".  "empty_dir" creates an empty directory inside of'
     '"root_directory"')
 
-flags.DEFINE_multi_string('tar', [], 'A tar file to add to the layer')
+gflags.DEFINE_multistring('tar', [], 'A tar file to add to the layer')
 
-flags.DEFINE_multi_string('deb', [], 'A debian package to add to the layer')
+gflags.DEFINE_multistring('deb', [], 'A debian package to add to the layer')
 
-flags.DEFINE_multi_string(
+gflags.DEFINE_multistring(
     'link', [],
     'Add a symlink a inside the layer ponting to b if a:b is specified')
-flags.register_validator(
+gflags.RegisterValidator(
     'link',
     lambda l: all(value.find(':') > 0 for value in l),
     message='--link value should contains a : separator')
 
-flags.DEFINE_string(
+gflags.DEFINE_string(
     'directory', None, 'Directory in which to store the file inside the layer')
 
-flags.DEFINE_string(
+gflags.DEFINE_string(
     'compression', None, 'Compression (`gz` or `bz2`), default is none.')
 
-flags.DEFINE_multi_string(
+gflags.DEFINE_multistring(
     'modes', None,
     'Specific mode to apply to specific file (from the file argument),'
     ' e.g., path/to/file=0o455.')
 
-flags.DEFINE_multi_string('owners', None,
+gflags.DEFINE_multistring('owners', None,
                           'Specify the numeric owners of individual files, '
                           'e.g. path/to/file=0.0.')
 
-flags.DEFINE_string('owner', '0.0',
+gflags.DEFINE_string('owner', '0.0',
                      'Specify the numeric default owner of all files,'
                      ' e.g., 0.0')
 
-flags.DEFINE_string('owner_name', None,
+gflags.DEFINE_string('owner_name', None,
                      'Specify the owner name of all files, e.g. root.root.')
 
-flags.DEFINE_multi_string('owner_names', None,
+gflags.DEFINE_multistring('owner_names', None,
                           'Specify the owner names of individual files, e.g. '
                           'path/to/file=root.root.')
 
-flags.DEFINE_string(
+gflags.DEFINE_string(
     'root_directory', './', 'Default root directory is named "."'
     'Windows docker images require this be named "Files" instead of "."')
 
-flags.DEFINE_string('xz_path', None,
+gflags.DEFINE_string('xz_path', None,
                      'Specify the path to xz as a fallback when the Python '
                      'lzma module is unavailable.')
 
-FLAGS = flags.FLAGS
+FLAGS = gflags.FLAGS
 
 
 class TarFile(object):
@@ -149,6 +148,7 @@ class TarFile(object):
 
   def add_file(self, f, destfile, mode=None, ids=None, names=None):
     """Add a file to the tar file.
+
     Args:
        f: the file to add to the layer
        destfile: the name of the file in the layer
@@ -181,12 +181,14 @@ class TarFile(object):
   def add_empty_file(self, destfile, mode=None, ids=None, names=None,
                      kind=tarfile.REGTYPE):
     """Add a file to the tar file.
+
     Args:
        destfile: the name of the file in the layer
        mode: force to set the specified mode, defaults to 644
        ids: (uid, gid) for the file to set ownership
        names: (username, groupname) for the file to set ownership.
        kind: type of the file. tarfile.DIRTYPE for directory.
+
     An empty file will be created as `destfile` in the layer.
     """
     dest = destfile.lstrip('/')  # Remove leading slashes
@@ -210,11 +212,13 @@ class TarFile(object):
 
   def add_empty_dir(self, destpath, mode=None, ids=None, names=None):
     """Add a directory to the tar file.
+
     Args:
        destpath: the name of the directory in the layer
        mode: force to set the specified mode, defaults to 644
        ids: (uid, gid) for the file to set ownership
        names: (username, groupname) for the file to set ownership.
+
     An empty file will be created as `destfile` in the layer.
     """
     self.add_empty_file(destpath, mode=mode, ids=ids, names=names,
@@ -222,11 +226,13 @@ class TarFile(object):
 
   def add_empty_root_dir(self, destpath, mode=None, ids=None, names=None):
     """Add a directory to the root of the tar file.
+
     Args:
        destpath: the name of the directory in the layer
        mode: force to set the specified mode, defaults to 644
        ids: (uid, gid) for the file to set ownership
        names: (username, groupname) for the file to set ownership.
+
     An empty directory will be created as `destfile` in the root layer.
     """
     original_root_directory = self.tarfile.root_directory
@@ -237,9 +243,11 @@ class TarFile(object):
 
   def add_tar(self, tar):
     """Merge a tar file into the destination tar file.
+
     All files presents in that tar will be added to the output file
     under self.directory/path. No user name nor group name will be
     added to the output.
+
     Args:
       tar: the tar file to add
     """
@@ -250,6 +258,7 @@ class TarFile(object):
 
   def add_link(self, symlink, destination):
     """Add a symbolic link pointing to `destination`.
+
     Args:
       symlink: the name of the symbolic link to add.
       destination: where the symbolic link point to.
@@ -297,11 +306,14 @@ class TarFile(object):
 
   def add_deb(self, deb):
     """Extract a debian package in the output tar.
+
     All files presents in that debian package will be added to the
     output tar under the same paths. No user name nor group names will
     be added to the output.
+
     Args:
       deb: the tar file to add
+
     Raises:
       DebError: if the format of the deb archive is incorrect.
     """

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -25,85 +25,86 @@ import re
 import tarfile
 import tempfile
 
+from absl import flags
 from rules_pkg import archive
-from third_party.py import gflags
 
-gflags.DEFINE_string('output', None, 'The output file, mandatory')
-gflags.MarkFlagAsRequired('output')
 
-gflags.DEFINE_multistring('file', [], 'A file to add to the layer')
+flags.DEFINE_string('output', None, 'The output file, mandatory')
+flags.mark_flag_as_required('output')
 
-gflags.DEFINE_string('manifest', None, 'JSON manifest of contents to add to the layer')
+flags.DEFINE_multi_string('file', [], 'A file to add to the layer')
 
-gflags.DEFINE_multistring('empty_file', [], 'An empty file to add to the layer')
+flags.DEFINE_string('manifest', None, 'JSON manifest of contents to add to the layer')
 
-gflags.DEFINE_multistring('empty_dir', [], 'An empty dir to add to the layer')
+flags.DEFINE_multi_string('empty_file', [], 'An empty file to add to the layer')
 
-gflags.DEFINE_string(
+flags.DEFINE_multi_string('empty_dir', [], 'An empty dir to add to the layer')
+
+flags.DEFINE_string(
     'mode', None, 'Force the mode on the added files (in octal).')
 
-gflags.DEFINE_string(
+flags.DEFINE_string(
     'mtime', None, 'Set mtime on tar file entries. May be an integer or the'
         ' value "portable", to get the value 2000-01-01, which is'
         ' usable with non *nix OSes.')
 
-gflags.DEFINE_bool(
+flags.DEFINE_bool(
     'enable_mtime_preservation', False, 'Preserve file mtimes from input tar file.')
 
-gflags.DEFINE_multistring(
+flags.DEFINE_multi_string(
     'empty_root_dir',
     [],
     'An empty root directory to add to the layer.  This will create a directory that'
     'is a peer of "root_directory".  "empty_dir" creates an empty directory inside of'
     '"root_directory"')
 
-gflags.DEFINE_multistring('tar', [], 'A tar file to add to the layer')
+flags.DEFINE_multi_string('tar', [], 'A tar file to add to the layer')
 
-gflags.DEFINE_multistring('deb', [], 'A debian package to add to the layer')
+flags.DEFINE_multi_string('deb', [], 'A debian package to add to the layer')
 
-gflags.DEFINE_multistring(
+flags.DEFINE_multi_string(
     'link', [],
     'Add a symlink a inside the layer ponting to b if a:b is specified')
-gflags.RegisterValidator(
+flags.register_validator(
     'link',
     lambda l: all(value.find(':') > 0 for value in l),
     message='--link value should contains a : separator')
 
-gflags.DEFINE_string(
+flags.DEFINE_string(
     'directory', None, 'Directory in which to store the file inside the layer')
 
-gflags.DEFINE_string(
+flags.DEFINE_string(
     'compression', None, 'Compression (`gz` or `bz2`), default is none.')
 
-gflags.DEFINE_multistring(
+flags.DEFINE_multi_string(
     'modes', None,
     'Specific mode to apply to specific file (from the file argument),'
     ' e.g., path/to/file=0o455.')
 
-gflags.DEFINE_multistring('owners', None,
+flags.DEFINE_multi_string('owners', None,
                           'Specify the numeric owners of individual files, '
                           'e.g. path/to/file=0.0.')
 
-gflags.DEFINE_string('owner', '0.0',
+flags.DEFINE_string('owner', '0.0',
                      'Specify the numeric default owner of all files,'
                      ' e.g., 0.0')
 
-gflags.DEFINE_string('owner_name', None,
+flags.DEFINE_string('owner_name', None,
                      'Specify the owner name of all files, e.g. root.root.')
 
-gflags.DEFINE_multistring('owner_names', None,
+flags.DEFINE_multi_string('owner_names', None,
                           'Specify the owner names of individual files, e.g. '
                           'path/to/file=root.root.')
 
-gflags.DEFINE_string(
+flags.DEFINE_string(
     'root_directory', './', 'Default root directory is named "."'
     'Windows docker images require this be named "Files" instead of "."')
 
-gflags.DEFINE_string('xz_path', None,
+flags.DEFINE_string('xz_path', None,
                      'Specify the path to xz as a fallback when the Python '
                      'lzma module is unavailable.')
 
-FLAGS = gflags.FLAGS
+FLAGS = flags.FLAGS
 
 
 class TarFile(object):

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -26,7 +26,6 @@ import re
 import tarfile
 import tempfile
 
-from absl import flags
 from rules_pkg import archive
 
 

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -149,7 +149,7 @@ def repositories():
             sha256 = "aeca78988341a2ee1ba097641056d168320ecc51372ef7ff8e64b139516a4937",
             urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.2.6-1/rules_pkg-0.2.6.tar.gz"],
         )
-    
+
     if "io_abseil_py" not in excludes:
         http_archive(
             name = "io_abseil_py",

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -150,41 +150,6 @@ def repositories():
             urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.2.6-1/rules_pkg-0.2.6.tar.gz"],
         )
 
-    if "io_abseil_py" not in excludes:
-        http_archive(
-            name = "io_abseil_py",
-            strip_prefix = "abseil-py-pypi-v0.9.0",
-            sha256 = "603febc9b95a8f2979a7bdb77d2f5e4d9b30d4e0d59579f88eba67d4e4cc5462",
-            urls = ["https://github.com/abseil/abseil-py/archive/pypi-v0.9.0.tar.gz"],
-        )
-
-    # Abseil dependency https://github.com/abseil/abseil-py/blob/f24641ca72815e2643659cb7c8a966e5faa6e580/WORKSPACE#L18
-    if "six_archive" not in excludes:
-        http_archive(
-            name = "six_archive",
-            urls = [
-                "http://mirror.bazel.build/pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
-                "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
-            ],
-            sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
-            strip_prefix = "six-1.10.0",
-            build_file_content = """# Description:
-#   Six provides simple utilities for wrapping over differences between Python 2
-#   and Python 3.
-
-licenses(["notice"])  # MIT
-
-exports_files(["LICENSE"])
-
-py_library(
-    name = "six",
-    srcs = ["six.py"],
-    srcs_version = "PY2AND3",
-    visibility = ["//visibility:public"],
-)
-""",
-        )
-
     native.register_toolchains(
         # Register the default docker toolchain that expects the 'docker'
         # executable to be in the PATH

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -149,6 +149,41 @@ def repositories():
             sha256 = "aeca78988341a2ee1ba097641056d168320ecc51372ef7ff8e64b139516a4937",
             urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.2.6-1/rules_pkg-0.2.6.tar.gz"],
         )
+    
+    if "io_abseil_py" not in excludes:
+        http_archive(
+            name = "io_abseil_py",
+            strip_prefix = "abseil-py-pypi-v0.9.0",
+            sha256 = "603febc9b95a8f2979a7bdb77d2f5e4d9b30d4e0d59579f88eba67d4e4cc5462",
+            urls = ["https://github.com/abseil/abseil-py/archive/pypi-v0.9.0.tar.gz"],
+        )
+
+    # Abseil dependency https://github.com/abseil/abseil-py/blob/f24641ca72815e2643659cb7c8a966e5faa6e580/WORKSPACE#L18
+    if "six_archive" not in excludes:
+        http_archive(
+            name = "six_archive",
+            urls = [
+                "http://mirror.bazel.build/pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
+                "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
+            ],
+            sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
+            strip_prefix = "six-1.10.0",
+            build_file_content = """# Description:
+#   Six provides simple utilities for wrapping over differences between Python 2
+#   and Python 3.
+
+licenses(["notice"])  # MIT
+
+exports_files(["LICENSE"])
+
+py_library(
+    name = "six",
+    srcs = ["six.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+)
+""",
+        )
 
     native.register_toolchains(
         # Register the default docker toolchain that expects the 'docker'

--- a/repositories/requirements-pip.txt
+++ b/repositories/requirements-pip.txt
@@ -3,4 +3,5 @@ six==1.11.0
 addict==2.1.2
 # required by docker/security & deps
 PyYAML==5.1
-
+# Required by //container/build_tar.py
+python-gflags==3.1.2

--- a/testing/custom_toolchain_auth/WORKSPACE
+++ b/testing/custom_toolchain_auth/WORKSPACE
@@ -51,6 +51,10 @@ load(
 
 container_deps()
 
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
+
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_pull",

--- a/testing/custom_toolchain_auth/WORKSPACE
+++ b/testing/custom_toolchain_auth/WORKSPACE
@@ -45,11 +45,11 @@ load(
 container_repositories()
 
 load(
-    "@io_bazel_rules_docker//repositories:go_repositories.bzl",
-    container_go_deps = "go_deps",
+    "@io_bazel_rules_docker//repositories:deps.bzl",
+    container_deps = "deps",
 )
 
-container_go_deps()
+container_deps()
 
 load(
     "@io_bazel_rules_docker//container:container.bzl",

--- a/testing/custom_toolchain_flags/WORKSPACE
+++ b/testing/custom_toolchain_flags/WORKSPACE
@@ -47,6 +47,10 @@ load(
 
 container_deps()
 
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
+
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_pull(

--- a/testing/custom_toolchain_flags/WORKSPACE
+++ b/testing/custom_toolchain_flags/WORKSPACE
@@ -41,11 +41,11 @@ load(
 container_repositories()
 
 load(
-    "@io_bazel_rules_docker//repositories:go_repositories.bzl",
-    container_go_deps = "go_deps",
+    "@io_bazel_rules_docker//repositories:deps.bzl",
+    container_deps = "deps",
 )
 
-container_go_deps()
+container_deps()
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 

--- a/testing/default_toolchain/WORKSPACE
+++ b/testing/default_toolchain/WORKSPACE
@@ -54,6 +54,10 @@ load(
 
 container_deps()
 
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
+
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_pull",

--- a/testing/default_toolchain/WORKSPACE
+++ b/testing/default_toolchain/WORKSPACE
@@ -48,11 +48,11 @@ load(
 container_repositories()
 
 load(
-    "@io_bazel_rules_docker//repositories:go_repositories.bzl",
-    container_go_deps = "go_deps",
+    "@io_bazel_rules_docker//repositories:deps.bzl",
+    container_deps = "deps",
 )
 
-container_go_deps()
+container_deps()
 
 load(
     "@io_bazel_rules_docker//container:container.bzl",

--- a/testing/download_pkgs_at_root/WORKSPACE
+++ b/testing/download_pkgs_at_root/WORKSPACE
@@ -34,6 +34,10 @@ load(
 
 container_deps()
 
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # base_images_docker is needed to build ubuntu1604

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -304,7 +304,7 @@ function test_container_push_with_auth() {
   # Run the container_push test in the Bazel workspace that configured
   # the docker toolchain rule to use authentication.
   cd "${ROOT}/testing/custom_toolchain_auth"
-  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT} --host_force_python=PY2"
+  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT}"
   echo "Attempting authenticated container_push..."
   EXPECT_CONTAINS "$(bazel run $bazel_opts @io_bazel_rules_docker//tests/container:push_test 2>&1)" "Successfully pushed Docker image to localhost:5000/docker/test:test"
   bazel clean
@@ -313,7 +313,7 @@ function test_container_push_with_auth() {
   # configured docker toolchain. The default configuration doesn't setup
   # authentication and this should fail.
   cd "${ROOT}/testing/default_toolchain"
-  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT} --host_force_python=PY2"
+  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT}"
   echo "Attempting unauthenticated container_push..."
   EXPECT_CONTAINS "$(bazel run $bazel_opts @io_bazel_rules_docker//tests/container:push_test  2>&1)" "unable to push image to localhost:5000/docker/test:test"
   bazel clean
@@ -350,7 +350,7 @@ function test_container_pull_with_auth() {
   launch_private_registry_with_auth
 
   cd "${ROOT}/testing/custom_toolchain_auth"
-  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT} --host_force_python=PY2"
+  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT}"
   # Remove the old image if it exists
   docker rmi bazel/image:image || true
   # Push the locally built container to the private repo
@@ -362,7 +362,7 @@ function test_container_pull_with_auth() {
   # configured docker toolchain. The default configuration doesn't setup
   # authentication and this should fail.
   cd "${ROOT}/testing/default_toolchain"
-  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT} --host_force_python=PY2"
+  bazel_opts=" --override_repository=io_bazel_rules_docker=${ROOT}"
   echo "Attempting unauthenticated container_pull..."
   EXPECT_CONTAINS "$(bazel run $bazel_opts @local_pull//image 2>&1)" "Image pull was unsuccessful: reading image \"localhost:5000/docker/test:test\""
 }

--- a/testing/e2e/top_level.sh
+++ b/testing/e2e/top_level.sh
@@ -51,11 +51,15 @@ load(
 container_repositories()
 
 load(
-    "@io_bazel_rules_docker//repositories:go_repositories.bzl",
-    container_go_deps = "go_deps",
+    "@io_bazel_rules_docker//repositories:deps.bzl",
+    container_deps = "deps",
 )
 
-container_go_deps()
+container_deps()
+
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
 
 load(
   "@io_bazel_rules_docker//docker:docker.bzl",

--- a/testing/examples/WORKSPACE
+++ b/testing/examples/WORKSPACE
@@ -29,11 +29,11 @@ load(
 container_repositories()
 
 load(
-    "@io_bazel_rules_docker//repositories:go_repositories.bzl",
-    container_go_deps = "go_deps",
+    "@io_bazel_rules_docker//repositories:deps.bzl",
+    container_deps = "deps",
 )
 
-container_go_deps()
+container_deps()
 
 load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
 load("@io_bazel_rules_docker//contrib:dockerfile_build.bzl", "dockerfile_image")

--- a/testing/examples/WORKSPACE
+++ b/testing/examples/WORKSPACE
@@ -35,6 +35,10 @@ load(
 
 container_deps()
 
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
+
 load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
 load("@io_bazel_rules_docker//contrib:dockerfile_build.bzl", "dockerfile_image")
 load("@io_bazel_rules_docker//java:image.bzl", _java_image_repos = "repositories")

--- a/testing/java_image/WORKSPACE
+++ b/testing/java_image/WORKSPACE
@@ -39,6 +39,13 @@ load(
 container_repositories()
 
 load(
+    "@io_bazel_rules_docker//repositories:deps.bzl",
+    container_deps = "deps",
+)
+
+container_deps()
+
+load(
     "@io_bazel_rules_docker//java:image.bzl",
     _java_image_repos = "repositories",
 )

--- a/testing/java_image/WORKSPACE
+++ b/testing/java_image/WORKSPACE
@@ -45,6 +45,10 @@ load(
 
 container_deps()
 
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
+
 load(
     "@io_bazel_rules_docker//java:image.bzl",
     _java_image_repos = "repositories",

--- a/testing/new_pusher_tests/WORKSPACE
+++ b/testing/new_pusher_tests/WORKSPACE
@@ -35,6 +35,10 @@ load(
 
 container_deps()
 
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
+
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_pull",

--- a/testing/new_pusher_tests/WORKSPACE
+++ b/testing/new_pusher_tests/WORKSPACE
@@ -29,11 +29,11 @@ load(
 container_repositories()
 
 load(
-    "@io_bazel_rules_docker//repositories:go_repositories.bzl",
-    container_go_deps = "go_deps",
+    "@io_bazel_rules_docker//repositories:deps.bzl",
+    container_deps = "deps",
 )
 
-container_go_deps()
+container_deps()
 
 load(
     "@io_bazel_rules_docker//container:container.bzl",


### PR DESCRIPTION
Next version of Bazel is expected to stop providing gflags via Bazel tools according to #1533 