### PR TITLE
fix launcher args not being passed correctly

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -179,7 +179,7 @@ def _add_create_image_config_args(
         fail("launcher_args does nothing when launcher is not specified.", attr = "launcher_args")
     if ctx.attr.launcher:
         args.add("-entrypointPrefix", ctx.file.launcher.basename, format = "/%s")
-        args.add_all(ctx.attr.launcher_args)
+        args.add_all(ctx.attr.launcher_args, before_each="-entrypointPrefix")
 
 def _format_legacy_label(t):
     return ("--labels=%s=%s" % (t[0], t[1]))


### PR DESCRIPTION
the launcher arguments were not being passed correctly to the `create_image_config` binary, it seems to be an issue with the cli flag parser. 

i was passing arguments like so, when i noticed that the arguments were not propagated to the entrypoint:
```
    container_image(
        name = name,
        base = go_image_name,
        launcher = "//rules:dlv",
        launcher_args = [
            "exec",
            "--continue",
            "--headless",
            "--listen=:2345",
            "--accept-multiclient",
        ],
    )
```

the fix seems to line up with how the `list<string>` type is passed elsewhere to this program.

additionally, there seems to be an e2e test to ensure that this functionality works, but it doesn't seem to be enabled for CI (please correct me if i'm wrong). i'd be happy to enable it.
