### PR TITLE
feat(toolchain): add xz_target for remote execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,16 +139,16 @@ docker_toolchain_configure(
   # for more details.
   client_config="<enter absolute path to your docker config directory here>",
   # OPTIONAL: Path to the docker binary.
-  # Should be set explcitly for remote execution.
+  # Should be set explicitly for remote execution.
   docker_path="<enter absolute path to the docker binary (in the remote exec env) here>",
   # OPTIONAL: Path to the gzip binary.
-  # Either gzip_path or gzip_target should be set explcitly for remote execution.
+  # Either gzip_path or gzip_target should be set explicitly for remote execution.
   gzip_path="<enter absolute path to the gzip binary (in the remote exec env) here>",
   # OPTIONAL: Bazel target for the gzip tool.
-  # Either gzip_path or gzip_target should be set explcitly for remote execution.
+  # Either gzip_path or gzip_target should be set explicitly for remote execution.
   gzip_target="<enter absolute path (i.e., must start with repo name @...//:...) to an executable gzip target>",
   # OPTIONAL: Path to the xz binary.
-  # Should be set explcitly for remote execution.
+  # Should be set explicitly for remote execution.
   xz_path="<enter absolute path to the xz binary (in the remote exec env) here>",
   # OPTIONAL: List of additional flags to pass to the docker command.
   docker_flags = [

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ docker_toolchain_configure(
   # OPTIONAL: Path to the xz binary.
   # Should be set explicitly for remote execution.
   xz_path="<enter absolute path to the xz binary (in the remote exec env) here>",
+  # OPTIONAL: Bazel target for the xz tool.
+  # Either xz_path or xz_target should be set explicitly for remote execution.
+  xz_target="<enter absolute path (i.e., must start with repo name @...//:...) to an executable xz target>",
   # OPTIONAL: List of additional flags to pass to the docker command.
   docker_flags = [
     "--tls",

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -113,8 +113,16 @@ def build_layer(
         args.add("--mtime=portable")
     if ctx.attr.enable_mtime_preservation:
         args.add("--enable_mtime_preservation=true")
-    if toolchain_info.xz_path != "":
-        args.add(toolchain_info.xz_path, format = "--xz_path=%s")
+
+
+    xz_path = toolchain_info.xz_path
+    if toolchain_info.xz_target:
+        xz_path = toolchain_info.xz_target.files_to_run.executable.path
+        xz_tools, _, xz_input_manifests = ctx.resolve_command(tools = [toolchain_info.xz_target])
+    elif toolchain_info.xz_path == "":
+        fail("xz could not be found. Make sure it is in the path or set it " +
+             "explicitly in the docker_toolchain_configure")
+    args.add(xz_path, format = "--xz_path=%s")
 
     # Windows layer.tar require two separate root directories instead of just 1
     # 'Files' is the equivalent of '.' in Linux images.
@@ -144,7 +152,8 @@ def build_layer(
     ctx.actions.run(
         executable = build_layer_exec,
         arguments = [args],
-        tools = files + file_map.values() + tars + debs + [manifest_file],
+        input_manifests = xz_input_manifests,
+        tools = files + file_map.values() + tars + debs + [manifest_file] + xz_tools,
         outputs = [layer],
         use_default_shell_env = True,
         mnemonic = "ImageLayer",

--- a/testing/default_toolchain/WORKSPACE
+++ b/testing/default_toolchain/WORKSPACE
@@ -30,6 +30,10 @@ local_tool(
     name = "gzip",
 )
 
+local_tool(
+    name = "xz",
+)
+
 load(
     "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
     docker_toolchain_configure = "toolchain_configure",
@@ -38,6 +42,7 @@ load(
 docker_toolchain_configure(
     name = "docker_config",
     gzip_target = "@gzip//:gzip",
+    xz_target = "@xz//:xz",
 )
 
 load(

--- a/testing/default_toolchain/local_tool.bzl
+++ b/testing/default_toolchain/local_tool.bzl
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Rule to load a local tool. Used to test gzip_target."""
+"""Rule to load a local tool. Used to test gzip_target and xz_target."""
 
 _local_tool_build_template = """
 sh_binary(

--- a/toolchains/docker/BUILD.tpl
+++ b/toolchains/docker/BUILD.tpl
@@ -24,5 +24,5 @@ docker_toolchain(
     %{GZIP_ATTR}
     tool_path = "%{DOCKER_TOOL}",
     docker_flags = ["%{DOCKER_FLAGS}"],
-    xz_path = "%{XZ_TOOL_PATH}",
+    %{XZ_ATTR}
 )

--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -31,6 +31,8 @@ DockerToolchainInfo = provider(
         "xz_path": "Optional path to the xz binary. This is used by " +
                    "build_tar.py when the Python lzma module is unavailable. " +
                    "If not set found via which.",
+        "xz_target": "Optional Bazel target for the xz tool. " +
+                       "Should only be set if xz_path is unset.",
     },
 )
 
@@ -43,6 +45,7 @@ def _docker_toolchain_impl(ctx):
             gzip_target = ctx.attr.gzip_target,
             tool_path = ctx.attr.tool_path,
             xz_path = ctx.attr.xz_path,
+            xz_target = ctx.attr.xz_target,
         ),
     )
     return [toolchain_info]
@@ -81,23 +84,34 @@ docker_toolchain = rule(
             doc = "Optional path to the xz binary. This is used by " +
                   "build_tar.py when the Python lzma module is unavailable.",
         ),
+        "xz_target": attr.label(
+            allow_files = True,
+            doc = "Bazel target for the xz tool. " +
+                  "Should only be set if xz_path is unset.",
+            cfg = "host",
+            executable = True,
+        ),
     },
 )
 
 def _toolchain_configure_impl(repository_ctx):
     if repository_ctx.attr.gzip_target and repository_ctx.attr.gzip_path:
         fail("Only one of gzip_target or gzip_path can be set.")
+    if repository_ctx.attr.xz_target and repository_ctx.attr.xz_path:
+        fail("Only one of xz_target or xz_path can be set.")
     tool_path = ""
     if repository_ctx.attr.docker_path:
         tool_path = repository_ctx.attr.docker_path
     elif repository_ctx.which("docker"):
         tool_path = repository_ctx.which("docker")
 
-    xz_path = ""
-    if repository_ctx.attr.xz_path:
-        xz_path = repository_ctx.attr.xz_path
+    xz_attr = ""
+    if repository_ctx.attr.xz_target:
+        xz_attr = "xz_target = \"%s\"," % repository_ctx.attr.xz_target
+    elif repository_ctx.attr.xz_path:
+        xz_attr = "xz_path = \"%s\"," % repository_ctx.attr.xz_path
     elif repository_ctx.which("xz"):
-        xz_path = repository_ctx.which("xz")
+        xz_attr = "xz_path = \"%s\"," % repository_ctx.which("xz")
 
     gzip_attr = ""
     if repository_ctx.attr.gzip_target:
@@ -120,7 +134,7 @@ def _toolchain_configure_impl(repository_ctx):
             "%{DOCKER_FLAGS}": "%s" % "\", \"".join(docker_flags),
             "%{DOCKER_TOOL}": "%s" % tool_path,
             "%{GZIP_ATTR}": "%s" % gzip_attr,
-            "%{XZ_TOOL_PATH}": "%s" % xz_path,
+            "%{XZ_ATTR}": "%s" % xz_attr,
         },
         False,
     )
@@ -178,6 +192,14 @@ toolchain_configure = repository_rule(
             doc = "The full path to the xz binary. If not specified, it will " +
                   "be searched for in the path. If not available, running commands " +
                   "that use xz will fail.",
+        ),
+        "xz_target": attr.label(
+            executable = True,
+            cfg = "host",
+            allow_files = True,
+            mandatory = False,
+            doc = "The bazel target for the xz tool. " +
+                  "Can only be set if xz_path is not set.",
         ),
     },
     environ = [


### PR DESCRIPTION
Allows a hermetic `xz` binary to be provided.

Worth noting that busybox provides a fully static musl busybox that
should work on any Linux system, that gives you both `gzip` and `xz`.

---

852a84b feat(toolchain): add xz_target for remote execution

Copied what is currently done for gzip_target.

<br/>

3a8f98c chore: fix typo explcitly -> explicitly


<br/>
