### PR TITLE
feat(toolchain): add xz_target for remote execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ docker_toolchain_configure(
   # OPTIONAL: Path to the xz binary.
   # Should be set explicitly for remote execution.
   xz_path="<enter absolute path to the xz binary (in the remote exec env) here>",
+  # OPTIONAL: Bazel target for the xz tool.
+  # Either xz_path or xz_target should be set explicitly for remote execution.
+  xz_target="<enter absolute path (i.e., must start with repo name @...//:...) to an executable xz target>",
   # OPTIONAL: List of additional flags to pass to the docker command.
   docker_flags = [
     "--tls",

--- a/testing/default_toolchain/WORKSPACE
+++ b/testing/default_toolchain/WORKSPACE
@@ -22,12 +22,22 @@ local_repository(
 )
 
 load(
+    "//:local_tool.bzl",
+    "local_tool",
+)
+
+local_tool(
+    name = "xz",
+)
+
+load(
     "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
     docker_toolchain_configure = "toolchain_configure",
 )
 
 docker_toolchain_configure(
     name = "docker_config",
+    xz_target = "@xz//:xz",
 )
 
 load(

--- a/testing/default_toolchain/local_tool.bzl
+++ b/testing/default_toolchain/local_tool.bzl
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Rule to load a local tool. Used to test gzip_target."""
+"""Rule to load a local tool. Used to test gzip_target and xz_target."""
 
 _local_tool_build_template = """
 sh_binary(

--- a/toolchains/docker/BUILD.tpl
+++ b/toolchains/docker/BUILD.tpl
@@ -24,5 +24,5 @@ docker_toolchain(
     %{GZIP_ATTR}
     tool_path = "%{DOCKER_TOOL}",
     docker_flags = ["%{DOCKER_FLAGS}"],
-    xz_path = "%{XZ_TOOL_PATH}",
+    %{XZ_ATTR}
 )

--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -31,6 +31,8 @@ DockerToolchainInfo = provider(
         "xz_path": "Optional path to the xz binary. This is used by " +
                    "build_tar.py when the Python lzma module is unavailable. " +
                    "If not set found via which.",
+        "xz_target": "Optional Bazel target for the xz tool. " +
+                       "Should only be set if xz_path is unset.",
     },
 )
 
@@ -43,6 +45,7 @@ def _docker_toolchain_impl(ctx):
             gzip_target = ctx.attr.gzip_target,
             tool_path = ctx.attr.tool_path,
             xz_path = ctx.attr.xz_path,
+            xz_target = ctx.attr.xz_target,
         ),
     )
     return [toolchain_info]
@@ -81,23 +84,34 @@ docker_toolchain = rule(
             doc = "Optional path to the xz binary. This is used by " +
                   "build_tar.py when the Python lzma module is unavailable.",
         ),
+        "xz_target": attr.label(
+            allow_files = True,
+            doc = "Bazel target for the xz tool. " +
+                  "Should only be set if xz_path is unset.",
+            cfg = "host",
+            executable = True,
+        ),
     },
 )
 
 def _toolchain_configure_impl(repository_ctx):
     if repository_ctx.attr.gzip_target and repository_ctx.attr.gzip_path:
         fail("Only one of gzip_target or gzip_path can be set.")
+    if repository_ctx.attr.xz_target and repository_ctx.attr.xz_path:
+        fail("Only one of xz_target or xz_path can be set.")
     tool_path = ""
     if repository_ctx.attr.docker_path:
         tool_path = repository_ctx.attr.docker_path
     elif repository_ctx.which("docker"):
         tool_path = repository_ctx.which("docker")
 
-    xz_path = ""
-    if repository_ctx.attr.xz_path:
-        xz_path = repository_ctx.attr.xz_path
+    xz_attr = ""
+    if repository_ctx.attr.xz_target:
+        xz_attr = "xz_target = \"%s\"," % repository_ctx.attr.xz_target
+    elif repository_ctx.attr.xz_path:
+        xz_attr = "xz_path = \"%s\"," % repository_ctx.attr.xz_path
     elif repository_ctx.which("xz"):
-        xz_path = repository_ctx.which("xz")
+        xz_attr = "xz_path = \"%s\"," % repository_ctx.which("xz")
 
     gzip_attr = ""
     if repository_ctx.attr.gzip_target:
@@ -118,7 +132,7 @@ def _toolchain_configure_impl(repository_ctx):
             "%{DOCKER_FLAGS}": "%s" % "\", \"".join(docker_flags),
             "%{DOCKER_TOOL}": "%s" % tool_path,
             "%{GZIP_ATTR}": "%s" % gzip_attr,
-            "%{XZ_TOOL_PATH}": "%s" % xz_path,
+            "%{XZ_ATTR}": "%s" % xz_attr,
         },
         False,
     )
@@ -175,6 +189,14 @@ toolchain_configure = repository_rule(
             doc = "The full path to the xz binary. If not specified, it will " +
                   "be searched for in the path. If not available, running commands " +
                   "that use xz will fail.",
+        ),
+        "xz_target": attr.label(
+            executable = True,
+            cfg = "host",
+            allow_files = True,
+            mandatory = False,
+            doc = "The bazel target for the xz tool. " +
+                  "Can only be set if xz_path is not set.",
         ),
     },
     environ = [


### PR DESCRIPTION
Allows a hermetic `xz` binary to be provided.

Worth noting that busybox provides a fully static musl busybox that
should work on any Linux system, that gives you both `gzip` and `xz`.

---

852a84b feat(toolchain): add xz_target for remote execution

Copied what is currently done for gzip_target.

<br/>

3a8f98c chore: fix typo explcitly -> explicitly


<br/>
