### PR TITLE
Change image rule to copy config instead of symlink

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -307,6 +307,7 @@ def _impl(
         output_executable = None,
         output_tarball = None,
         output_config = None,
+        output_config_digest = None,
         output_digest = None,
         output_layer = None,
         workdir = None,
@@ -339,6 +340,7 @@ def _impl(
     output_executable: File to use as output for script to load docker image
     output_tarball: File, overrides ctx.outputs.out
     output_config: File, overrides ctx.outputs.config
+    output_config_digest: File, overrides ctx.outputs.config_digest
     output_digest: File, overrides ctx.outputs.digest
     output_layer: File, overrides ctx.outputs.layer
     workdir: str, overrides ctx.attr.workdir
@@ -358,6 +360,7 @@ def _impl(
     output_tarball = output_tarball or ctx.outputs.out
     output_digest = output_digest or ctx.outputs.digest
     output_config = output_config or ctx.outputs.config
+    output_config_digest = output_config_digest or ctx.outputs.config_digest
     output_layer = output_layer or ctx.outputs.layer
     build_script = ctx.outputs.build_script
     null_cmd = null_cmd or ctx.attr.null_cmd
@@ -506,16 +509,20 @@ def _impl(
     )
     _assemble_image_digest(ctx, name, container_parts, output_tarball, output_digest)
 
-    # Symlink config file for usage in structure tests
-    ln_path = config_file.path.split("/")[-1]
+    # Copy config file and its sha file for usage in tests
     ctx.actions.run_shell(
         outputs = [output_config],
         inputs = [config_file],
-        command = "ln -s %s %s" % (ln_path, output_config.path),
+        command = "cp %s %s" % (config_file.path, output_config.path),
+    )
+    ctx.actions.run_shell(
+        outputs = [output_config_digest],
+        inputs = [config_digest],
+        command = "cp %s %s" % (config_digest.path, output_config_digest.path),
     )
 
     runfiles = ctx.runfiles(
-        files = unzipped_layers + diff_ids + [config_file, config_digest] +
+        files = unzipped_layers + diff_ids + [config_file, config_digest, output_config_digest] +
                 ([container_parts["legacy"]] if container_parts["legacy"] else []),
     )
 
@@ -596,6 +603,8 @@ _outputs["out"] = "%{name}.tar"
 _outputs["digest"] = "%{name}.digest"
 
 _outputs["config"] = "%{name}.json"
+
+_outputs["config_digest"] = "%{name}.json.sha256"
 
 _outputs["build_script"] = "%{name}.executable"
 

--- a/docker/package_managers/apt_key.bzl
+++ b/docker/package_managers/apt_key.bzl
@@ -27,7 +27,8 @@ def _impl(
         output_tarball = None,
         output_layer = None,
         output_digest = None,
-        output_config = None):
+        output_config = None,
+        output_config_digest = None):
     """Implementation for the add_apt_key rule.
 
     Args:
@@ -42,6 +43,7 @@ def _impl(
         output_layer: File, overrides ctx.outputs.layer
         output_digest: File, overrides ctx.outputs.digest
         output_config: File, overrides ctx.outputs.config
+        output_config_digest: File, overrides ctx.outputs.config_digest
     """
     name = name or ctx.label.name
     keys = keys or ctx.files.keys
@@ -52,6 +54,7 @@ def _impl(
     output_layer = output_layer or ctx.outputs.layer
     output_digest = output_digest or ctx.outputs.digest
     output_config = output_config or ctx.outputs.config
+    output_config_digest = output_config_digest or ctx.outputs.config_digest
 
     # First build an image capable of adding an apt-key.
     # This requires the keyfile and the "gnupg package."
@@ -68,6 +71,7 @@ def _impl(
     key_image_output_layer = ctx.actions.declare_file("%s-layer.tar" % key_image)
     key_image_output_digest = ctx.actions.declare_file("%s.digest" % key_image)
     key_image_output_config = ctx.actions.declare_file("%s.json" % key_image)
+    key_image_output_config_digest = ctx.actions.declare_file("%s.json.sh256" % key_image)
 
     key_image_result = _container.image.implementation(
         ctx,
@@ -80,6 +84,7 @@ def _impl(
         output_layer = key_image_output_layer,
         output_digest = key_image_output_digest,
         output_config = key_image_output_config,
+        output_config_digest = key_image_output_config_digest,
     )
 
     commands = [
@@ -114,6 +119,7 @@ def _impl(
         output_layer = output_layer,
         output_digest = output_digest,
         output_config = output_config,
+        output_config_digest = output_config_digest,
     )
 
 _attrs = dict(_container.image.attrs)

--- a/docker/toolchain_container/debian_pkg_tar.bzl
+++ b/docker/toolchain_container/debian_pkg_tar.bzl
@@ -99,6 +99,7 @@ def _generate_deb_tar(
         image_with_keys_output_layer = ctx.actions.declare_file(image_with_keys + "-layer.tar")
         image_with_keys_output_digest = ctx.actions.declare_file(image_with_keys + ".digest")
         image_with_keys_output_config = ctx.actions.declare_file(image_with_keys + ".json")
+        image_with_keys_output_config_digest = ctx.actions.declare_file(image_with_keys + ".json.sha256")
 
         _apt_key.implementation(
             ctx,
@@ -110,6 +111,7 @@ def _generate_deb_tar(
             output_layer = image_with_keys_output_layer,
             output_digest = image_with_keys_output_digest,
             output_config = image_with_keys_output_config,
+            output_config_digest = image_with_keys_output_config_digest,
         )
         download_base = image_with_keys_output_tarball
 


### PR DESCRIPTION
The image rule in container/image.bzl was symlinking the config file for
strutcture tests. This caused remote execution with
--remote_download_minimal to fail as symlinks aren't yet supported.