### PR TITLE
Properly prefix launcher_args with -entrypointPrefix when passing to create_image_config

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -179,7 +179,7 @@ def _add_create_image_config_args(
         fail("launcher_args does nothing when launcher is not specified.", attr = "launcher_args")
     if ctx.attr.launcher:
         args.add("-entrypointPrefix", ctx.file.launcher.basename, format = "/%s")
-        args.add_all(ctx.attr.launcher_args)
+        args.add_all(ctx.attr.launcher_args, before_each = "-entrypointPrefix")
 
 def _format_legacy_label(t):
     return ("--labels=%s=%s" % (t[0], t[1]))

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -945,7 +945,7 @@ container_image(
     name = "launcher_image",
     base = "//tests/container/go:go_image",
     launcher = ":launcher",
-    launcher_args = ["-env=CUSTOM_MESSAGE=Launched via launcher!"],
+    launcher_args = ["-extraEnv=CUSTOM_MESSAGE=Launched via launcher!"],
     legacy_run_behavior = False,
 )
 

--- a/testdata/launcher_main.go
+++ b/testdata/launcher_main.go
@@ -24,7 +24,7 @@ import (
 
 func main() {
 	var extraEnv stringSlice
-	flag.Var(&extraEnv, "env", "Append to the environment of the launched binary. May be specified multiple times. (eg --env=VAR_NAME=value)")
+	flag.Var(&extraEnv, "extraEnv", "Append to the environment of the launched binary. May be specified multiple times. (eg --extraEnv=VAR_NAME=value)")
 	flag.Parse()
 	envv := append(os.Environ(), extraEnv...)
 	argv := flag.Args()


### PR DESCRIPTION
Fixes #1581 