### PR TITLE
Update dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -352,8 +352,8 @@ d_repositories()
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "84abf7ac4234a70924628baa9a73a5a5cbad944c4358cf9abdb4aab29c9a5b77",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.7.0/rules_nodejs-1.7.0.tar.gz"],
+    sha256 = "10fffa29f687aa4d8eb6dfe8731ab5beb63811ab00981fc84a93899641fd4af1",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.0.3/rules_nodejs-2.0.3.tar.gz"],
 )
 
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")

--- a/container/image_test.py
+++ b/container/image_test.py
@@ -794,6 +794,8 @@ class ImageTest(unittest.TestCase):
       './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/internal/linker/runfiles_helper.js',
       './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/internal/node',
       './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/internal/node/node_patches.js',
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/internal/coverage',
+      './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/internal/coverage/lcov_merger-js.js',
       './app/testdata/nodejs_image_binary.runfiles/io_bazel_rules_docker/testdata/_nodejs_image_binary.module_mappings.json',
       './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party',
       './app/testdata/nodejs_image_binary.runfiles/build_bazel_rules_nodejs/third_party/github.com',

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -15,7 +15,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("@npm//@bazel/typescript:index.bzl", "ts_library")
 load("@pip_deps//:requirements.bzl", "requirement")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//cc:image.bzl", "cc_image")

--- a/testdata/package.json
+++ b/testdata/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@bazel/typescript": "1.7.0",
+    "@bazel/typescript": "2.0.3",
     "@types/jsesc": "2.5.1",
     "@types/node": "12.12.47",
     "jsesc": "3.0.1",

--- a/testdata/yarn.lock
+++ b/testdata/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@bazel/typescript@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-1.7.0.tgz#8dc02b8a161f4fff3285186066b5f73666793452"
-  integrity sha512-M6JPXJZ+W6457QZfPHmGg/Mejnp7//YTnffGmnmeK9vDqybXeCCRWW1/iEOwopLJYQViBHfaoulde0VXelx9sA==
+"@bazel/typescript@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-2.0.3.tgz#0be019014ef973f3a415c4671c65d943afc62023"
+  integrity sha512-yESlesTHX7gOuBzuc61HtHB8h/gRCaEB3C6guJnBVPuz4tGMLJ069fJz/SW/pfgrACP7ixqWqHXIAEnPsRU+tw==
   dependencies:
     protobufjs "6.8.8"
     semver "5.6.0"


### PR DESCRIPTION
build_bazel_rules_nodejs to v2.0.3 (From #1568)
@bazel/typescript to v2.0.3 (From #1566)

These two updates need to happen together to prevent errors from the major version mismatching.
Per https://github.com/bazelbuild/rules_nodejs/wiki#migrating-to-20, load statements of the form @npm_bazel_ were converted to the form @npm//@bazel/.

Fixes #1594