### PR TITLE
Add Linux ARM64 go pusher and loader binaries to cloudbuild

### DIFF
--- a/container/go/cloudbuild.yaml
+++ b/container/go/cloudbuild.yaml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This cloudbuild.yaml file is used to release the go puller binary.
+# This cloudbuild.yaml file is used to release the go puller and loader
+# binaries.
 
 timeout: 3600s
 options:
@@ -29,17 +30,17 @@ steps:
 # TODO(xingao): Once we have tests for the go binary, run the tests before
 # pushing the binaries to GCS.
 
-# Step: build the puller release binary for Linux
+# Step: build the puller and loader release binaries for Linux AMD64
   - name: "l.gcr.io/google/bazel"
     args:
       - "build"
       - "--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64"
       - "//container/go/cmd/puller:puller"
       - "//container/go/cmd/loader:loader"
-    id: "build-linux"
+    id: "build-linux-amd64"
     waitFor: ["version"]
 
-# Step: push the puller release binary for Linux
+# Step: push the puller release binary for Linux AMD64
   - name: "gcr.io/cloud-builders/gsutil"
     args:
       - "cp"
@@ -47,9 +48,9 @@ steps:
       - "public-read"
       - "bazel-bin/container/go/cmd/puller/linux_amd64_pure_stripped/puller"
       - "gs://rules_docker/$COMMIT_SHA/puller-linux-amd64"
-    waitFor: ["build-linux"]
+    waitFor: ["build-linux-amd64"]
 
-# Step: push the loader release binary for Linux
+# Step: push the loader release binary for Linux AMD64
   - name: "gcr.io/cloud-builders/gsutil"
     args:
       - "cp"
@@ -57,19 +58,49 @@ steps:
       - "public-read"
       - "bazel-bin/container/go/cmd/loader/linux_amd64_pure_stripped/loader"
       - "gs://rules_docker/$COMMIT_SHA/loader-linux-amd64"
-    waitFor: ["build-linux"]
+    waitFor: ["build-linux-amd64"]
 
-# Step: build the puller release binary for Darwin
+# Step: build the puller and loader release binaries for Linux ARM64
+  - name: "l.gcr.io/google/bazel"
+    args:
+      - "build"
+      - "--platforms=@io_bazel_rules_go//go/toolchain:linux_arm64"
+      - "//container/go/cmd/puller:puller"
+      - "//container/go/cmd/loader:loader"
+    id: "build-linux-arm64"
+    waitFor: ["build-linux-amd64"]
+
+# Step: push the puller release binary for Linux ARM64
+  - name: "gcr.io/cloud-builders/gsutil"
+    args:
+      - "cp"
+      - "-a"
+      - "public-read"
+      - "bazel-bin/container/go/cmd/puller/linux_arm64_pure_stripped/puller"
+      - "gs://rules_docker/$COMMIT_SHA/puller-linux-arm64"
+    waitFor: ["build-linux-arm64"]
+
+# Step: push the loader release binary for Linux ARM64
+  - name: "gcr.io/cloud-builders/gsutil"
+    args:
+      - "cp"
+      - "-a"
+      - "public-read"
+      - "bazel-bin/container/go/cmd/loader/linux_arm64_pure_stripped/loader"
+      - "gs://rules_docker/$COMMIT_SHA/loader-linux-arm64"
+    waitFor: ["build-linux-arm64"]
+
+# Step: build the puller and loader release binaries for Darwin AMD64
   - name: "l.gcr.io/google/bazel"
     args:
       - "build"
       - "--platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64"
       - "//container/go/cmd/puller:puller"
       - "//container/go/cmd/loader:loader"
-    id: "build-darwin"
-    waitFor: ["build-linux"]
+    id: "build-darwin-amd64"
+    waitFor: ["build-linux-arm64"]
 
-# Step: push the puller release binary for Darwin
+# Step: push the puller release binary for Darwin AMD64
   - name: "gcr.io/cloud-builders/gsutil"
     args:
       - "cp"
@@ -77,9 +108,9 @@ steps:
       - "public-read"
       - "bazel-bin/container/go/cmd/puller/darwin_amd64_pure_stripped/puller"
       - "gs://rules_docker/$COMMIT_SHA/puller-darwin-amd64"
-    waitFor: ["build-darwin"]
+    waitFor: ["build-darwin-amd64"]
 
-# Step: push the loader release binary for Darwin
+# Step: push the loader release binary for Darwin AMD64
   - name: "gcr.io/cloud-builders/gsutil"
     args:
       - "cp"
@@ -87,4 +118,4 @@ steps:
       - "public-read"
       - "bazel-bin/container/go/cmd/loader/darwin_amd64_pure_stripped/loader"
       - "gs://rules_docker/$COMMIT_SHA/loader-darwin-amd64"
-    waitFor: ["build-darwin"]
+    waitFor: ["build-darwin-amd64"]


### PR DESCRIPTION
First step towards addressing https://github.com/bazelbuild/rules_docker/issues/1155