### PR TITLE
Update puller and loader locations and sequencing in cloudbuild

### DIFF
--- a/container/go/cloudbuild.yaml
+++ b/container/go/cloudbuild.yaml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This cloudbuild.yaml file is used to release the go puller binary.
+# This cloudbuild.yaml file is used to release the go puller and pusher
+# binaries.
 
 timeout: 3600s
 options:
@@ -29,62 +30,66 @@ steps:
 # TODO(xingao): Once we have tests for the go binary, run the tests before
 # pushing the binaries to GCS.
 
-# Step: build the puller release binary for Linux
+# Step: build the puller and pusher release binary for Linux AMD64
   - name: "l.gcr.io/google/bazel"
     args:
       - "build"
       - "--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64"
       - "//container/go/cmd/puller:puller"
       - "//container/go/cmd/loader:loader"
-    id: "build-linux"
+    id: "build-linux-amd64"
     waitFor: ["version"]
 
-# Step: push the puller release binary for Linux
+# Step: push the puller release binary for Linux AMD64
   - name: "gcr.io/cloud-builders/gsutil"
     args:
       - "cp"
       - "-a"
       - "public-read"
-      - "bazel-bin/container/go/cmd/puller/linux_amd64_pure_stripped/puller"
+      - "bazel-bin/container/go/cmd/puller/puller_/puller"
       - "gs://rules_docker/$COMMIT_SHA/puller-linux-amd64"
-    waitFor: ["build-linux"]
+    id: "push-puller-linux-amd64"
+    waitFor: ["build-linux-amd64"]
 
-# Step: push the loader release binary for Linux
+# Step: push the loader release binary for Linux AMD64
   - name: "gcr.io/cloud-builders/gsutil"
     args:
       - "cp"
       - "-a"
       - "public-read"
-      - "bazel-bin/container/go/cmd/loader/linux_amd64_pure_stripped/loader"
+      - "bazel-bin/container/go/cmd/loader/loader_/loader"
       - "gs://rules_docker/$COMMIT_SHA/loader-linux-amd64"
-    waitFor: ["build-linux"]
+    id: "push-loader-linux-amd64"
+    waitFor: ["build-linux-amd64"]
 
-# Step: build the puller release binary for Darwin
+# Step: build the puller and loader release binaries for Darwin AMD64
   - name: "l.gcr.io/google/bazel"
     args:
       - "build"
       - "--platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64"
       - "//container/go/cmd/puller:puller"
       - "//container/go/cmd/loader:loader"
-    id: "build-darwin"
-    waitFor: ["build-linux"]
+    id: "build-darwin-amd64"
+    waitFor: ["push-puller-linux-amd64", "push-loader-linux-amd64"]
 
-# Step: push the puller release binary for Darwin
+# Step: push the puller release binary for Darwin AMD64
   - name: "gcr.io/cloud-builders/gsutil"
     args:
       - "cp"
       - "-a"
       - "public-read"
-      - "bazel-bin/container/go/cmd/puller/darwin_amd64_pure_stripped/puller"
+      - "bazel-bin/container/go/cmd/puller/puller_/puller"
       - "gs://rules_docker/$COMMIT_SHA/puller-darwin-amd64"
-    waitFor: ["build-darwin"]
+    id: "push-puller-darwin-amd64"
+    waitFor: ["build-darwin-amd64"]
 
-# Step: push the loader release binary for Darwin
+# Step: push the loader release binary for Darwin AMD64
   - name: "gcr.io/cloud-builders/gsutil"
     args:
       - "cp"
       - "-a"
       - "public-read"
-      - "bazel-bin/container/go/cmd/loader/darwin_amd64_pure_stripped/loader"
+      - "bazel-bin/container/go/cmd/loader/loader_/loader"
       - "gs://rules_docker/$COMMIT_SHA/loader-darwin-amd64"
-    waitFor: ["build-darwin"]
+    id: "push-loader-darwin-amd64"
+    waitFor: ["build-darwin-amd64"]


### PR DESCRIPTION
The location and naming of go binary artifacts changed when rules_go was updated in https://github.com/bazelbuild/rules_docker/commit/db48e7c187f42a0a4fcaaa9ce90c2748fff11b68. This is likely due to the changes in https://github.com/bazelbuild/rules_go/commit/695da5906684ab96e558c3159f7d88a20a6a1703 and https://github.com/bazelbuild/rules_go/commit/7a2ed944ae81f5c896e876e0c0975e9900832334.

Since builds on all platforms now place the artifacts in the same location, the darwin build can only begin once the linux uploads are complete.