### PR TITLE
Fix the root directory when building for Linux on Windows.

### DIFF
--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -125,6 +125,9 @@ def build_layer(
     if (operating_system == "windows"):
         args.add("--root_directory=Files")
         empty_root_dirs = ["Files", "Hives"]
+    elif build_layer_exec.path.endswith(".exe"):
+        # Building on Windows, but not for Windows. Do not use the default root directory.
+        args.add("--root_directory=")
 
     all_files = [struct(src = f.path, dst = _magic_path(ctx, f, layer)) for f in files]
     all_files += [struct(src = f.path, dst = path) for (path, f) in file_map.items()]


### PR DESCRIPTION
Otherwise, the .tar file gets a weird structure that is not well interpreted in Linux; e.g. files get names like ".\a\b\c\file" (that is a filename, not a path).