### PR TITLE
Remove --privileged flag in package_manager rules

### DIFF
--- a/docker/package_managers/run_download.sh.tpl
+++ b/docker/package_managers/run_download.sh.tpl
@@ -28,7 +28,7 @@ image_id=$(%{image_id_extractor_path} %{image_tar})
 $DOCKER $DOCKER_FLAGS load -i %{image_tar}
 
 # Run the builder image.
-cid=$($DOCKER $DOCKER_FLAGS run -w="/" -d --privileged $image_id sh -c $'%{download_commands}')
+cid=$($DOCKER $DOCKER_FLAGS run -w="/" -d $image_id sh -c $'%{download_commands}')
 $DOCKER $DOCKER_FLAGS attach $cid
 $DOCKER $DOCKER_FLAGS cp $cid:%{installables}_packages.tar %{output}
 $DOCKER $DOCKER_FLAGS cp $cid:%{installables}_metadata.csv %{output_metadata}

--- a/docker/package_managers/run_install.sh.tpl
+++ b/docker/package_managers/run_install.sh.tpl
@@ -48,7 +48,7 @@ for f in $tmpdir/*; do
 done
 $DOCKER $DOCKER_FLAGS rm $cid
 
-cid=$($DOCKER $DOCKER_FLAGS run -d -v $vid:/tmp/pkginstall --privileged $image_id /tmp/pkginstall/installer.sh)
+cid=$($DOCKER $DOCKER_FLAGS run -d -v $vid:/tmp/pkginstall $image_id /tmp/pkginstall/installer.sh)
 
 $DOCKER $DOCKER_FLAGS attach $cid || true
 


### PR DESCRIPTION
This shouldn't be needed, is a security risk, and conflicts with userns remapping.

I'd like to test compatibility with userns remapping, but it requires restarting the docker daemon with a different configuration and it's unclear to me the best way to do that