### PR TITLE
For gzip operations, use a new Go helper by default instead of which(gzip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,8 @@ docker_toolchain_configure(
   # Should be set explcitly for remote execution.
   docker_path="<enter absolute path to the docker binary (in the remote exec env) here>",
   # OPTIONAL: Path to the gzip binary.
-  # Either gzip_path or gzip_target should be set explcitly for remote execution.
   gzip_path="<enter absolute path to the gzip binary (in the remote exec env) here>",
   # OPTIONAL: Bazel target for the gzip tool.
-  # Either gzip_path or gzip_target should be set explcitly for remote execution.
   gzip_target="<enter absolute path (i.e., must start with repo name @...//:...) to an executable gzip target>",
   # OPTIONAL: Path to the xz binary.
   # Should be set explcitly for remote execution.

--- a/container/BUILD
+++ b/container/BUILD
@@ -179,7 +179,6 @@ bzl_library(
         "//skylib:filetype",
         "//skylib:label",
         "//skylib:path",
-        "//skylib:zip",
         "@bazel_tools//tools/build_defs/hash:hash.bzl",
     ],
 )

--- a/container/go/cmd/zipper/BUILD
+++ b/container/go/cmd/zipper/BUILD
@@ -1,0 +1,34 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ###
+# Build file for zipper binary.
+
+load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+# gazelle:prefix github.com/bazelbuild/rules_docker
+gazelle(name = "gazelle")
+
+go_binary(
+    name = "zipper",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["zipper.go"],
+    importpath = "github.com/bazelbuild/rules_docker",
+    visibility = ["//visibility:private"],
+)

--- a/container/go/cmd/zipper/zipper.go
+++ b/container/go/cmd/zipper/zipper.go
@@ -1,0 +1,81 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+////////////////////////////////////////////////
+// This package performs gzip operations.
+
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+var (
+	src        = flag.String("src", "", "The source location of the file to zip/unzip.")
+	dst        = flag.String("dst", "", "The destination location of the file, after zip/unzip.")
+	decompress = flag.Bool("decompress", false, "If true, perform gunzip. If false, gzip.")
+	fast       = flag.Bool("fast", false, "If true, use the fastest compression level.")
+)
+
+func main() {
+	flag.Parse()
+
+	if *src == "" {
+		log.Fatalln("Required option -src was not specified.")
+	}
+
+	if *dst == "" {
+		log.Fatalln("Required option -dst was not specified.")
+	}
+
+	dat, err := ioutil.ReadFile(*src)
+	if err != nil {
+		log.Fatalf("Unable to read input file: %v", err)
+	}
+	var buf bytes.Buffer
+	if *decompress {
+		zr, err := gzip.NewReader(bytes.NewReader(dat))
+		if err != nil {
+			log.Fatalf("Unable to read: %v", err)
+		}
+		if _, err := buf.ReadFrom(zr); err != nil {
+			log.Fatalf("Unable to decompress: %v", err)
+		}
+		if err := zr.Close(); err != nil {
+			log.Fatalf("Unable to close gzip reader: %v", err)
+		}
+	} else {
+		level := gzip.DefaultCompression
+		if *fast {
+			level = gzip.BestSpeed
+		}
+		zw, err := gzip.NewWriterLevel(&buf, level)
+		if err != nil {
+			log.Fatalf("Unable to create gzip writer: %v", err)
+		}
+		if _, err := zw.Write(dat); err != nil {
+			log.Fatalf("Unable to compress: %v", err)
+		}
+		if err := zw.Close(); err != nil {
+			log.Fatalf("Unable to close gzip writer: %s", err)
+		}
+	}
+	if err := ioutil.WriteFile(*dst, buf.Bytes(), os.ModePerm); err != nil {
+		log.Fatalf("Unable to write to %q: %v", *dst, err)
+	}
+}

--- a/container/import.bzl
+++ b/container/import.bzl
@@ -39,6 +39,7 @@ load(
     "//skylib:zip.bzl",
     _gunzip = "gunzip",
     _gzip = "gzip",
+    _zip_tools = "tools",
 )
 
 def _is_filetype(filename, extensions):
@@ -178,7 +179,7 @@ container_import = rule(
             mandatory = False,
         ),
         "repository": attr.string(default = "bazel"),
-    }, _hash_tools, _layer_tools),
+    }, _hash_tools, _layer_tools, _zip_tools),
     executable = True,
     outputs = {
         "out": "%{name}.tar",

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -39,6 +39,7 @@ load(
 load(
     "//skylib:zip.bzl",
     _gzip = "gzip",
+    _zip_tools = "tools",
 )
 
 _DEFAULT_MTIME = -1
@@ -288,7 +289,7 @@ _layer_attrs = dicts.add({
     "portable_mtime": attr.bool(default = False),
     "symlinks": attr.string_dict(),
     "tars": attr.label_list(allow_files = tar_filetype),
-}, _hash_tools, _layer_tools)
+}, _hash_tools, _layer_tools, _zip_tools)
 
 _layer_outputs = {
     "layer": "%{name}-layer.tar",

--- a/testing/default_toolchain/WORKSPACE
+++ b/testing/default_toolchain/WORKSPACE
@@ -22,22 +22,12 @@ local_repository(
 )
 
 load(
-    "//:local_tool.bzl",
-    "local_tool",
-)
-
-local_tool(
-    name = "gzip",
-)
-
-load(
     "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
     docker_toolchain_configure = "toolchain_configure",
 )
 
 docker_toolchain_configure(
     name = "docker_config",
-    gzip_target = "@gzip//:gzip",
 )
 
 load(

--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -24,7 +24,7 @@ DockerToolchainInfo = provider(
                          "will be used. DOCKER_CONFIG is not defined, the " +
                          "home directory will be used.",
         "docker_flags": "Additional flags to the docker command",
-        "gzip_path": "Optional path to the gzip binary. If not set found via which.",
+        "gzip_path": "Optional path to the gzip binary.",
         "gzip_target": "Optional Bazel target for the gzip tool. " +
                        "Should only be set if gzip_path is unset.",
         "tool_path": "Path to the docker executable",
@@ -104,8 +104,6 @@ def _toolchain_configure_impl(repository_ctx):
         gzip_attr = "gzip_target = \"%s\"," % repository_ctx.attr.gzip_target
     elif repository_ctx.attr.gzip_path:
         gzip_attr = "gzip_path = \"%s\"," % repository_ctx.attr.gzip_path
-    elif repository_ctx.which("gzip"):
-        gzip_attr = "gzip_path = \"%s\"," % repository_ctx.which("gzip")
     docker_flags = []
     docker_flags += repository_ctx.attr.docker_flags
 
@@ -161,9 +159,8 @@ toolchain_configure = repository_rule(
         ),
         "gzip_path": attr.string(
             mandatory = False,
-            doc = "The full path to the gzip binary. If not specified, it will " +
-                  "be searched for in the path. If not available, running commands " +
-                  "that use gzip will fail.",
+            doc = "The full path to the gzip binary. If not specified, a tool will " +
+                  "be compiled and used.",
         ),
         "gzip_target": attr.label(
             executable = True,


### PR DESCRIPTION
This is mostly for consistency across platforms, and to remove an external dependency.