### PR TITLE
Support container_push on Windows.

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -18,7 +18,12 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-exports_files(["push-tag.sh.tpl"])
+
+exports_files([
+    "push-tag.bat.tpl",
+    "push-tag.sh.tpl",
+])
+
 
 filegroup(
     name = "incremental_load_template",

--- a/container/BUILD
+++ b/container/BUILD
@@ -18,12 +18,10 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-
 exports_files([
     "push-tag.bat.tpl",
     "push-tag.sh.tpl",
 ])
-
 
 filegroup(
     name = "incremental_load_template",

--- a/container/push-tag.bat.tpl
+++ b/container/push-tag.bat.tpl
@@ -1,0 +1,18 @@
+@REM !\usr\bin\env bash
+@REM  Copyright 2017 The Bazel Authors. All rights reserved.
+@REM 
+@REM  Licensed under the Apache License, Version 2.0 (the "License");
+@REM  you may not use this file except in compliance with the License.
+@REM  You may obtain a copy of the License at
+@REM 
+@REM     http:\\www.apache.org\licenses\LICENSE-2.0
+@REM 
+@REM  Unless required by applicable law or agreed to in writing, software
+@REM  distributed under the License is distributed on an "AS IS" BASIS,
+@REM  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM  See the License for the specific language governing permissions and
+@REM  limitations under the License.
+ 
+SET RUNFILES=..
+ 
+%{container_pusher} %{args} "$@"

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -222,16 +222,16 @@ def container_push(name, format, image, registry, repository, **kwargs):
         registry = registry,
         repository = repository,
         extension = select({
-                "@bazel_tools//src/conditions:host_windows": ".bat",
-                "//conditions:default": "",
-            }),
+            "@bazel_tools//src/conditions:host_windows": ".bat",
+            "//conditions:default": "",
+        }),
         tag_tpl = select({
-                "@bazel_tools//src/conditions:host_windows": Label("//container:push-tag.bat.tpl"),
-                "//conditions:default": Label("//container:push-tag.sh.tpl"),
-            }),
+            "@bazel_tools//src/conditions:host_windows": Label("//container:push-tag.bat.tpl"),
+            "//conditions:default": Label("//container:push-tag.sh.tpl"),
+        }),
         windows_paths = select({
-                "@bazel_tools//src/conditions:host_windows": True,
-                "//conditions:default": False,
-            }),
+            "@bazel_tools//src/conditions:host_windows": True,
+            "//conditions:default": False,
+        }),
         **kwargs
     )

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -144,6 +144,9 @@ def _impl(ctx):
 
 _container_push = rule(
     attrs = dicts.add({
+        "extension": attr.string(
+            doc = "(optional) The file extension for the push script.",
+        ),
         "format": attr.string(
             mandatory = True,
             values = [
@@ -185,6 +188,14 @@ _container_push = rule(
             allow_single_file = True,
             doc = "(optional) The label of the file with tag value. Overrides 'tag'.",
         ),
+        "tag_tpl": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = "The script template to use.",
+        ),
+        "windows_paths": attr.bool(
+            mandatory = True,
+        ),
         "_digester": attr.label(
             default = "//container/go/cmd/digester",
             cfg = "host",
@@ -195,14 +206,6 @@ _container_push = rule(
             cfg = "host",
             executable = True,
             allow_files = True,
-        ),
-        "extension": attr.string(),
-        "tag_tpl": attr.label(
-            mandatory = True,
-            allow_single_file = True,
-        ),
-        "windows_paths": attr.bool(
-            mandatory = True,
         ),
     }, _layer_tools),
     executable = True,

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -142,7 +142,6 @@ def _impl(ctx):
         ),
     ]
 
-# Pushes a container image to a registry.
 _container_push = rule(
     attrs = dicts.add({
         "format": attr.string(
@@ -213,6 +212,7 @@ _container_push = rule(
         "digest": "%{name}.digest",
     },
 )
+
 # Pushes a container image to a registry.
 def container_push(name, format, image, registry, repository, **kwargs):
     _container_push(


### PR DESCRIPTION
- Use a batch file instead of a shell script.
- Fix paths by using backslashes.