### PR TITLE
Reduce build verbosity of container_run_and_commit

### DIFF
--- a/docker/util/commit.sh.tpl
+++ b/docker/util/commit.sh.tpl
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 # Setup tools and load utils
 TO_JSON_TOOL="%{to_json_tool}"


### PR DESCRIPTION
The shell expansion prints many unnecessary verbose debug lines into the bazel build log. Let's stop doing that.