### PR TITLE
Repository names must be lowercase

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -263,7 +263,7 @@ def _repository_name(ctx):
     # Newer Docker clients support multi-level names, which are a part of
     # the v2 registry specification.
 
-    return _join_path(ctx.attr.repository, ctx.label.package)
+    return _join_path(ctx.attr.repository, ctx.label.package).lower()
 
 def _assemble_image_digest(ctx, name, image, image_tarball, output_digest):
     img_args, inputs = _gen_img_args(ctx, image)


### PR DESCRIPTION
See the Repository section in https://github.com/moby/moby/blob/8e610b2b55bfd1bfa9436ab110d311f5e8a74dcb/image/spec/v1.2.md

If the package name contains a uppercase letter, the image can be loaded. It fails with such kind of message:
```
Error parsing reference: "bazel/MyImage:tag" is not a valid repository/tag: invalid reference format: repository name must be lowercase
```