### PR TITLE
Fixed load() call for pip_deps in WORKSPACE described in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
 
-load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "io_bazel_rules_docker_pip_deps")
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", container_pip_deps = "pip_deps")
 
-io_bazel_rules_docker_pip_deps()
+container_pip_deps()
 
 load(
     "@io_bazel_rules_docker//container:container.bzl",


### PR DESCRIPTION
After setting up my WORKSPACE as described in README.md, I received the error:
```
Error: file '@io_bazel_rules_docker//repositories:pip_repositories.bzl' does not contain symbol 'io_bazel_rules_docker_pip_deps'
```

This was fixed by changing the requested symbol to `pip_deps`.