### PR TITLE
Update distroless dependencies

### DIFF
--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -20,7 +20,7 @@
 
 DIGESTS = {
     # "gcr.io/distroless/cc:debug" circa 2020-10-30 12:48 -0700
-    "debug": "sha256:820bc028e4957cc24bbe8a8975fdee106c7d2d8fedac1d1ad605e9d942a2bb3e",
+    "debug": "sha256:7c31f56955cc66134efb3e8282c68f7c92ae3dddcfd99ebf0e7e3dcd9b686e4f",
     # "gcr.io/distroless/cc:latest" circa 2020-10-30 12:48 -0700
-    "latest": "sha256:ac75dbf0b249e5e3758134458d447bfd6a85d74c262ecb7cd88df68a3f53c6e3",
+    "latest": "sha256:c4014bdecaede16f767f8cfc496f968736bc08632bf54a37c004820e85cd8209",
 }

--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:c3c3041dd6af49c2435baabbe4303bd2ab171c0a1e24bdfa1167a74814a222a6",
-    # "gcr.io/distroless/cc:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:86f16733f25964c40dcd34edf14339ddbb2287af2f7c9dfad88f0366723c00d7",
+    # "gcr.io/distroless/cc:debug" circa 2020-10-19 11:55 -0700
+    "debug": "sha256:4711e8de819a276a9e38911afd73ee24cb6e0fd5c473534756bb84bbdf6af509",
+    # "gcr.io/distroless/cc:latest" circa 2020-10-19 11:55 -0700
+    "latest": "sha256:ac75dbf0b249e5e3758134458d447bfd6a85d74c262ecb7cd88df68a3f53c6e3",
 }

--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2020-10-19 11:55 -0700
-    "debug": "sha256:4711e8de819a276a9e38911afd73ee24cb6e0fd5c473534756bb84bbdf6af509",
-    # "gcr.io/distroless/cc:latest" circa 2020-10-19 11:55 -0700
+    # "gcr.io/distroless/cc:debug" circa 2020-10-30 12:48 -0700
+    "debug": "sha256:820bc028e4957cc24bbe8a8975fdee106c7d2d8fedac1d1ad605e9d942a2bb3e",
+    # "gcr.io/distroless/cc:latest" circa 2020-10-30 12:48 -0700
     "latest": "sha256:ac75dbf0b249e5e3758134458d447bfd6a85d74c262ecb7cd88df68a3f53c6e3",
 }

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -20,7 +20,7 @@
 
 DIGESTS = {
     # "gcr.io/distroless/base:debug" circa 2020-10-30 12:48 -0700
-    "debug": "sha256:a0e0bf20125b75729b760763575e6d596db21358ad6afa1be8abbb6491d2347c",
+    "debug": "sha256:799b6c346ef976683d93259aa335501a4aaa1bb2156d68444ff149d2e5d5c155",
     # "gcr.io/distroless/base:latest" circa 2020-10-30 12:48 -0700
-    "latest": "sha256:249859465bcde1cb15128ff0d9eb2bb54de67f72a834a7576e6649cfe0a27698",
+    "latest": "sha256:8d58596f5181f95d908d7f8318f8e27bc394164491bd0aa53c2f284480fd8f8b",
 }

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2020-09-28 19:06 -0400
-    "debug": "sha256:67ad904b14d60c0a0188ffd9fc52b3cf380ef76a72f8774208f51814ba4bb0d4",
-    # "gcr.io/distroless/base:latest" circa 2020-09-28 19:06 -0400
-    "latest": "sha256:ece03c2478ad03dd5968c0fc55fc1ba5c6b9c642bde71cf11dba8293ae588a8c",
+    # "gcr.io/distroless/base:debug" circa 2020-10-19 11:55 -0700
+    "debug": "sha256:72a0093a0214e414527a97d359313992534f94a689449615875d922097f0ba62",
+    # "gcr.io/distroless/base:latest" circa 2020-10-19 11:55 -0700
+    "latest": "sha256:08b50837bd6afc1ad5e55e5b997422b57206dd497e538b2cdee6762add07b5ac",
 }

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2020-10-19 11:55 -0700
-    "debug": "sha256:72a0093a0214e414527a97d359313992534f94a689449615875d922097f0ba62",
-    # "gcr.io/distroless/base:latest" circa 2020-10-19 11:55 -0700
-    "latest": "sha256:08b50837bd6afc1ad5e55e5b997422b57206dd497e538b2cdee6762add07b5ac",
+    # "gcr.io/distroless/base:debug" circa 2020-10-30 12:48 -0700
+    "debug": "sha256:a0e0bf20125b75729b760763575e6d596db21358ad6afa1be8abbb6491d2347c",
+    # "gcr.io/distroless/base:latest" circa 2020-10-30 12:48 -0700
+    "latest": "sha256:249859465bcde1cb15128ff0d9eb2bb54de67f72a834a7576e6649cfe0a27698",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:d5e1e6c9378f7eb7b9f0c2a131cf31ab94030f187da4faaefd6fde2a3b875336",
-    # "gcr.io/distroless/java:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:ae0eb3d54fb9172fe0f0c2158ef21501c090333c336ccaefa816bbe326c8716e",
+    # "gcr.io/distroless/java:debug" circa 2020-10-19 11:56 -0700
+    "debug": "sha256:0bc1714349309f3f61765ca8e1ce81f3efb0db071bf4f07b137ae068569a12d1",
+    # "gcr.io/distroless/java:latest" circa 2020-10-19 11:56 -0700
+    "latest": "sha256:8dd4606ead0960f90b733d945ae050fc283c3d798bca95e5801de19d32913db0",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2020-10-19 11:56 -0700
-    "debug": "sha256:0bc1714349309f3f61765ca8e1ce81f3efb0db071bf4f07b137ae068569a12d1",
-    # "gcr.io/distroless/java:latest" circa 2020-10-19 11:56 -0700
-    "latest": "sha256:8dd4606ead0960f90b733d945ae050fc283c3d798bca95e5801de19d32913db0",
+    # "gcr.io/distroless/java:debug" circa 2020-10-30 12:48 -0700
+    "debug": "sha256:79ed7ab74f05f73f84ac4217d61e2951a0bf1a8c4de5c8ceb398c9521df76c54",
+    # "gcr.io/distroless/java:latest" circa 2020-10-30 12:48 -0700
+    "latest": "sha256:e7f4f67846dde93d59e537c03b596e18b181e50bf63af4fafa5d41ec0a5fd0fc",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:db1f47a599afc4e942f8f6c7f416ccdd0c27ef4b99c0eaa21f11b5f1511c2070",
-    # "gcr.io/distroless/java/jetty:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:0068460e6a226f3eb583c4deb02c79b6bb5aca494d3f1996690d7189b5aa4cec",
+    # "gcr.io/distroless/java/jetty:debug" circa 2020-10-19 11:56 -0700
+    "debug": "sha256:8882e189d4ac6eb11d8e015681b95b9f671c4e0781218c1af6bba4b8a8a3f4b5",
+    # "gcr.io/distroless/java/jetty:latest" circa 2020-10-19 11:56 -0700
+    "latest": "sha256:f842c0f77339433e59562a9b2dd41640f2dd0f15c4e359981d8256c0fe92b095",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2020-10-19 11:56 -0700
-    "debug": "sha256:8882e189d4ac6eb11d8e015681b95b9f671c4e0781218c1af6bba4b8a8a3f4b5",
-    # "gcr.io/distroless/java/jetty:latest" circa 2020-10-19 11:56 -0700
-    "latest": "sha256:f842c0f77339433e59562a9b2dd41640f2dd0f15c4e359981d8256c0fe92b095",
+    # "gcr.io/distroless/java/jetty:debug" circa 2020-10-30 12:48 -0700
+    "debug": "sha256:4fd6982c6f9dec3dbba18a5724b523fdcab937fc223f91887cc514b4505f7fbb",
+    # "gcr.io/distroless/java/jetty:latest" circa 2020-10-30 12:48 -0700
+    "latest": "sha256:e8d9fca6dbee84cbff3b2c7979e13178e7951991d1a8370d5d582e92f138aab6",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2020-10-19 11:55 -0700
-    "debug": "sha256:195ddc8b89407d4ae8a3d952ee08395411d28520b667ee83ac8562db36b68da3",
-    # "gcr.io/distroless/python2.7:latest" circa 2020-10-19 11:55 -0700
+    # "gcr.io/distroless/python2.7:debug" circa 2020-10-30 12:48 -0700
+    "debug": "sha256:6e9ae83d0958191b84e1d8de9d688361cccae4a766c7ef2397397c695c641ce5",
+    # "gcr.io/distroless/python2.7:latest" circa 2020-10-30 12:48 -0700
     "latest": "sha256:c83217b59e577039cd3fe4eb6cbe9bb2bf806ef15205afaee1a573f4a96411ed",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:7a935652f1ce58b8c8044adccb61a67f47609dc04bb001ada6dd4db88957323d",
-    # "gcr.io/distroless/python2.7:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:ebe778d426d1d78a3954bf61deacc4371a430200a1f1c88b16e913bc5192aebf",
+    # "gcr.io/distroless/python2.7:debug" circa 2020-10-19 11:55 -0700
+    "debug": "sha256:195ddc8b89407d4ae8a3d952ee08395411d28520b667ee83ac8562db36b68da3",
+    # "gcr.io/distroless/python2.7:latest" circa 2020-10-19 11:55 -0700
+    "latest": "sha256:c83217b59e577039cd3fe4eb6cbe9bb2bf806ef15205afaee1a573f4a96411ed",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:44b13e14537accc5784b475bd756bba289135d4554e204d204f1455eb0c0d7da",
-    # "gcr.io/distroless/python3:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:de110a5eb0edb950dc4653ae0288f530b8c2af77e44d9bebab117ed0b74d5426",
+    # "gcr.io/distroless/python3:debug" circa 2020-10-19 11:55 -0700
+    "debug": "sha256:1d992aa6631cacd44746d5d2915b21ad93869cfb2519f90bd516a244b528b6fe",
+    # "gcr.io/distroless/python3:latest" circa 2020-10-19 11:55 -0700
+    "latest": "sha256:151195cef265bd9b7281d2819f7f3d539dc72e8f503a731ff71d4a6e2d90c1b3",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -20,7 +20,7 @@
 
 DIGESTS = {
     # "gcr.io/distroless/python3:debug" circa 2020-10-30 12:48 -0700
-    "debug": "sha256:baec30346d1cff97075a75bf09de2f0bc320ef0cdf29207c648373ae899c4f73",
+    "debug": "sha256:a1025877bc8bc6d7fb0c482fbf2c709d10a437ffd3a9a1ed19c62f94f5c7704c",
     # "gcr.io/distroless/python3:latest" circa 2020-10-30 12:48 -0700
-    "latest": "sha256:151195cef265bd9b7281d2819f7f3d539dc72e8f503a731ff71d4a6e2d90c1b3",
+    "latest": "sha256:8e74b6697d0a741a5d1bb7366260f48721783f71e01d800c13cd2392586639f3",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2020-10-19 11:55 -0700
-    "debug": "sha256:1d992aa6631cacd44746d5d2915b21ad93869cfb2519f90bd516a244b528b6fe",
-    # "gcr.io/distroless/python3:latest" circa 2020-10-19 11:55 -0700
+    # "gcr.io/distroless/python3:debug" circa 2020-10-30 12:48 -0700
+    "debug": "sha256:baec30346d1cff97075a75bf09de2f0bc320ef0cdf29207c648373ae899c4f73",
+    # "gcr.io/distroless/python3:latest" circa 2020-10-30 12:48 -0700
     "latest": "sha256:151195cef265bd9b7281d2819f7f3d539dc72e8f503a731ff71d4a6e2d90c1b3",
 }


### PR DESCRIPTION
It's been over a year since they were updated. For Java at least, many security updates in that time.

I had to manually skip static and debian9 in the update_deps.sh script, as they
failed on https://gcr.io/v2/distroless/static/manifests/debug

    {
      errors: [
        {
          code: "MANIFEST_UNKNOWN",
          message: "Failed to fetch "debug" from request "/v2/distroless/static/manifests/debug"."
        }
      ]
    }

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bazelbuild/rules_docker/1655)
<!-- Reviewable:end -->
