### PR TITLE
Add option to push images sequentially in push-all

### DIFF
--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -68,10 +68,15 @@ def _impl(ctx):
     ctx.actions.expand_template(
         template = ctx.file._all_tpl,
         substitutions = {
-            "%{push_statements}": "\n".join([
+            "%{async_push_statements}": "\n".join([
                 "async \"%s\"" % _get_runfile_path(ctx, command)
                 for command in scripts
             ]),
+            "%{push_statements}": "\n".join([
+                "\"%s\"" % _get_runfile_path(ctx, command)
+                for command in scripts
+            ]),
+            "%{sequential}": "true" if ctx.attr.sequential else "",
         },
         output = ctx.outputs.executable,
         is_executable = True,
@@ -99,6 +104,10 @@ container_push = rule(
                 "Docker",
             ],
             doc = "The form to push: Docker or OCI.",
+        ),
+        "sequential": attr.bool(
+            default = False,
+            doc = "If true, push images sequentially.",
         ),
         "_all_tpl": attr.label(
             default = Label("//contrib:push-all.sh.tpl"),

--- a/contrib/push-all.sh.tpl
+++ b/contrib/push-all.sh.tpl
@@ -34,11 +34,17 @@ function async() {
     PIDS+=($!)
 }
 
-%{push_statements}
-
-# Wait for all of the subprocesses, failing the script if any of them failed.
-if [ "${#PIDS[@]}" != 0 ]; then
+SEQUENTIAL="%{sequential}"
+if [ -z "${SEQUENTIAL}" ]; then
+  %{async_push_statements}
+  # Wait for all of the subprocesses, failing the script if any of them failed.
+  if [ "${#PIDS[@]}" != 0 ]; then
     for pid in ${PIDS[@]}; do
-        wait ${pid}
+      wait ${pid}
     done
+  fi
+else
+  %{push_statements}
 fi
+
+


### PR DESCRIPTION
There seems to be a bug with pushing many images (50+) related to the
async+wait behavior previously used, and this new option will give users
who have lots of images to push a safer option.

Fixes https://github.com/bazelbuild/rules_docker/issues/525