### PR TITLE
Use bash from the environment instead of absolute path

### DIFF
--- a/contrib/cmp_images.sh.tpl
+++ b/contrib/cmp_images.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/docker/package_managers/download_pkgs.bzl
+++ b/docker/package_managers/download_pkgs.bzl
@@ -26,7 +26,7 @@ def _generate_add_additional_repo_commands(ctx, additional_repos):
     )
 
 def _generate_download_commands(ctx, packages, additional_repos):
-    return """#!/bin/bash
+    return """#!/usr/bin/env bash
 set -ex
 {add_additional_repo_commands}
 # Remove /var/lib/apt/lists/* in the base image. apt-get update -y command will create them.

--- a/docker/package_managers/installer.sh.tpl
+++ b/docker/package_managers/installer.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script installs debs in installables.tar through dpkg and apt-get.
 # It expects to be volume-mounted inside a docker image, in /tmp/pkginstall
 # along with the installables.tar.

--- a/docker/package_managers/run_download.sh.tpl
+++ b/docker/package_managers/run_download.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 function guess_runfiles() {

--- a/docker/package_managers/run_install.sh.tpl
+++ b/docker/package_managers/run_install.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 # Resolve the docker tool path

--- a/docker/util/commit.sh.tpl
+++ b/docker/util/commit.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/docker/util/commit_layer.sh.tpl
+++ b/docker/util/commit_layer.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/docker/util/extract.sh.tpl
+++ b/docker/util/extract.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/docker/util/image_util.sh.tpl
+++ b/docker/util/image_util.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 reset_cmd() {
     local original_image_name=$1

--- a/testdata/cc_image_wrapper.sh
+++ b/testdata/cc_image_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 "$1" || { echo "FAIL!"; exit 1; }

--- a/testing/download_pkgs_at_root/download_pkgs_at_root_run_test.sh
+++ b/testing/download_pkgs_at_root/download_pkgs_at_root_run_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 BASEDIR=$(dirname "$0")

--- a/tests/container/architecture_test.sh
+++ b/tests/container/architecture_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BASEDIR=$(dirname "$0")
 

--- a/tests/container/pull_info_validation_test.bzl
+++ b/tests/container/pull_info_validation_test.bzl
@@ -5,7 +5,7 @@ load("//container:providers.bzl", "PullInfo")
 def _pull_info_validation_test_impl(ctx):
     pull_info = ctx.attr.target[PullInfo]
     compare_script_file = ctx.actions.declare_file("compare.sh")
-    compare_script = """#!/bin/bash
+    compare_script = """#!/usr/bin/env bash
 function assert_equals(){
     if [ "$2" != "$3" ]; then
       echo "Expected $1 to be '$2' but was '$3'"

--- a/tests/contrib/compare_ids_fail_test.sh.tpl
+++ b/tests/contrib/compare_ids_fail_test.sh.tpl
@@ -16,7 +16,7 @@
 # This creates a new workspace and copies all required files into it, then runs the test
 # which is expected to fail, and passes only if it fails.
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux
 

--- a/tests/contrib/mv_project_root.sh
+++ b/tests/contrib/mv_project_root.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/tests/contrib/rename_image_test.sh
+++ b/tests/contrib/rename_image_test.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 function extract_image_name () {
     # Extracts the image name (repo:tag) from the tarball without running it

--- a/tests/docker/package_managers/download_pkgs_run_test.sh
+++ b/tests/docker/package_managers/download_pkgs_run_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 BASEDIR=$(dirname "$0")

--- a/tests/docker/package_managers/download_pkgs_with_additional_repos_run_test.sh
+++ b/tests/docker/package_managers/download_pkgs_with_additional_repos_run_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 BASEDIR=$(dirname "$0")

--- a/tests/docker/package_managers/test_complex_packages.sh
+++ b/tests/docker/package_managers/test_complex_packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 TEST_BUILD_FILE="tests/docker/package_managers/BUILD.bazel"


### PR DESCRIPTION
Not all operating systems ship with bash located at `/bin/bash`. Change the interpreter to `/usr/bin/env bash` to request bash from the environment.

For instance, I use [NixOS](https://nixos.org) as my daily driver and this operating system does not follow [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard); In fact it does not have a `/bin` and the only thing in `/usr/bin` is `env`.

Related to https://github.com/bazelbuild/rules_go/pull/2295