### PR TITLE
Fix update_deps to grab correct platform digest, rerun

### DIFF
--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:c3c3041dd6af49c2435baabbe4303bd2ab171c0a1e24bdfa1167a74814a222a6",
-    # "gcr.io/distroless/cc:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:86f16733f25964c40dcd34edf14339ddbb2287af2f7c9dfad88f0366723c00d7",
+    # "gcr.io/distroless/cc:debug" circa 2020-10-30 14:07 -0700
+    "debug": "sha256:7c31f56955cc66134efb3e8282c68f7c92ae3dddcfd99ebf0e7e3dcd9b686e4f",
+    # "gcr.io/distroless/cc:latest" circa 2020-10-30 14:07 -0700
+    "latest": "sha256:c4014bdecaede16f767f8cfc496f968736bc08632bf54a37c004820e85cd8209",
 }

--- a/container/go/cmd/update_deps/BUILD
+++ b/container/go/cmd/update_deps/BUILD
@@ -30,6 +30,7 @@ go_library(
     deps = [
         "//container/go/pkg/compat:go_default_library",
         "@com_github_google_go_containerregistry//pkg/crane:go_default_library",
+        "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
     ],
 )

--- a/container/go/cmd/update_deps/update_deps.go
+++ b/container/go/cmd/update_deps/update_deps.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/v1"
 )
 
 const digestTemplate = `# Copyright 2017 The Bazel Authors. All rights reserved.
@@ -74,6 +75,7 @@ func main() {
 		log.Fatalln("Required option -output was not specified.")
 	}
 	options := []crane.Option{}
+	options = append(options, crane.WithPlatform(&v1.Platform{Architecture: "amd64", OS: "linux"}))
 
 	latest := *repository + ":latest"
 	latestDigest, err := crane.Digest(latest, options...)

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2020-09-28 19:06 -0400
-    "debug": "sha256:67ad904b14d60c0a0188ffd9fc52b3cf380ef76a72f8774208f51814ba4bb0d4",
-    # "gcr.io/distroless/base:latest" circa 2020-09-28 19:06 -0400
-    "latest": "sha256:ece03c2478ad03dd5968c0fc55fc1ba5c6b9c642bde71cf11dba8293ae588a8c",
+    # "gcr.io/distroless/base:debug" circa 2020-10-30 14:07 -0700
+    "debug": "sha256:799b6c346ef976683d93259aa335501a4aaa1bb2156d68444ff149d2e5d5c155",
+    # "gcr.io/distroless/base:latest" circa 2020-10-30 14:07 -0700
+    "latest": "sha256:8d58596f5181f95d908d7f8318f8e27bc394164491bd0aa53c2f284480fd8f8b",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:d5e1e6c9378f7eb7b9f0c2a131cf31ab94030f187da4faaefd6fde2a3b875336",
-    # "gcr.io/distroless/java:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:ae0eb3d54fb9172fe0f0c2158ef21501c090333c336ccaefa816bbe326c8716e",
+    # "gcr.io/distroless/java:debug" circa 2020-10-30 14:07 -0700
+    "debug": "sha256:79ed7ab74f05f73f84ac4217d61e2951a0bf1a8c4de5c8ceb398c9521df76c54",
+    # "gcr.io/distroless/java:latest" circa 2020-10-30 14:07 -0700
+    "latest": "sha256:e7f4f67846dde93d59e537c03b596e18b181e50bf63af4fafa5d41ec0a5fd0fc",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:db1f47a599afc4e942f8f6c7f416ccdd0c27ef4b99c0eaa21f11b5f1511c2070",
-    # "gcr.io/distroless/java/jetty:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:0068460e6a226f3eb583c4deb02c79b6bb5aca494d3f1996690d7189b5aa4cec",
+    # "gcr.io/distroless/java/jetty:debug" circa 2020-10-30 14:07 -0700
+    "debug": "sha256:4fd6982c6f9dec3dbba18a5724b523fdcab937fc223f91887cc514b4505f7fbb",
+    # "gcr.io/distroless/java/jetty:latest" circa 2020-10-30 14:07 -0700
+    "latest": "sha256:e8d9fca6dbee84cbff3b2c7979e13178e7951991d1a8370d5d582e92f138aab6",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:7a935652f1ce58b8c8044adccb61a67f47609dc04bb001ada6dd4db88957323d",
-    # "gcr.io/distroless/python2.7:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:ebe778d426d1d78a3954bf61deacc4371a430200a1f1c88b16e913bc5192aebf",
+    # "gcr.io/distroless/python2.7:debug" circa 2020-10-30 14:07 -0700
+    "debug": "sha256:f8e2df9c00e2211013deb1c7297662e80ea90c484496b1ee772eedfef2ef53cc",
+    # "gcr.io/distroless/python2.7:latest" circa 2020-10-30 14:07 -0700
+    "latest": "sha256:6d3895c4a1629ac99e73c7dc9cbe0ad8cb213d6cdebf3e835c2c388fc5aab1b2",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:44b13e14537accc5784b475bd756bba289135d4554e204d204f1455eb0c0d7da",
-    # "gcr.io/distroless/python3:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:de110a5eb0edb950dc4653ae0288f530b8c2af77e44d9bebab117ed0b74d5426",
+    # "gcr.io/distroless/python3:debug" circa 2020-10-30 14:07 -0700
+    "debug": "sha256:a1025877bc8bc6d7fb0c482fbf2c709d10a437ffd3a9a1ed19c62f94f5c7704c",
+    # "gcr.io/distroless/python3:latest" circa 2020-10-30 14:07 -0700
+    "latest": "sha256:8e74b6697d0a741a5d1bb7366260f48721783f71e01d800c13cd2392586639f3",
 }

--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -37,9 +37,9 @@ def go_deps():
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(
             name = "com_github_google_go_containerregistry",
-            urls = ["https://api.github.com/repos/google/go-containerregistry/tarball/e5f4efd48dbff3ab3165a944d6777f8db28f0ccb"],  # v0.1.2
-            strip_prefix = "google-go-containerregistry-e5f4efd",
-            sha256 = "3a5f9ff61b48b928ce37e9d227a581571957b3b3ad5d45d148bce5433f9c9a6c",
+            urls = ["https://api.github.com/repos/google/go-containerregistry/tarball/8a2841911ffee4f6892ca0083e89752fb46c48dd"],  # v0.1.4
+            strip_prefix = "google-go-containerregistry-8a28419",
+            sha256 = "60b9a600affa5667bd444019a4e218b7752d8500cfa923c1ac54ce2f88f773e2",
             importpath = "github.com/google/go-containerregistry",
             type = "tar.gz",
         )


### PR DESCRIPTION
Suggest reviewing commit by commit.

In #1655, I ran into issues where `update_deps.sh` provided invalid digests. My belief is that
distroless started shipping multi-platform images (`linux/amd64` and `linux/arm64`), so `crane`
was grabbing the multi-platform manifest instead of the `linux/amd64` digest. In the first two
commits, I

1. upgrade external repos to latest version of `crane`
2. add `linux/amd64` platform as default to `update_deps` binary

Then I

3. ran the new `update_deps.sh`, and it produced valid digests.

~Open Q: presumably, rules_docker will want to support arm images at some point? Future work?~ Answered my question here: https://github.com/bazelbuild/rules_docker/issues/1155#issuecomment-571149145

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bazelbuild/rules_docker/1666)
<!-- Reviewable:end -->
