### PR TITLE
Add arm64 support to load puller and loader binaries

### DIFF
--- a/container/load.bzl
+++ b/container/load.bzl
@@ -38,7 +38,7 @@ container_import(
         loader = repository_ctx.attr._loader_darwin
     elif repository_ctx.os.name.lower().startswith("linux"):
         arch = repository_ctx.execute(["uname", "-m"]).stdout.strip()
-        if arch == "arm64" or arch == "aarch64" :
+        if arch == "arm64" or arch == "aarch64":
             loader = repository_ctx.attr._loader_linux_arm64
         elif arch == "s390x":
             loader = repository_ctx.attr._loader_linux_s390x

--- a/container/load.bzl
+++ b/container/load.bzl
@@ -38,7 +38,9 @@ container_import(
         loader = repository_ctx.attr._loader_darwin
     elif repository_ctx.os.name.lower().startswith("linux"):
         arch = repository_ctx.execute(["uname", "-m"]).stdout.strip()
-        if arch == "s390x":
+        if arch == "arm64" or arch == "aarch64" :
+            loader = repository_ctx.attr._loader_linux_arm64
+        elif arch == "s390x":
             loader = repository_ctx.attr._loader_linux_s390x
 
     result = repository_ctx.execute([
@@ -66,6 +68,11 @@ container_load = repository_rule(
         "_loader_linux_amd64": attr.label(
             executable = True,
             default = Label("@loader_linux_amd64//file:downloaded"),
+            cfg = "host",
+        ),
+        "_loader_linux_arm64": attr.label(
+            executable = True,
+            default = Label("@loader_linux_arm64//file:downloaded"),
             cfg = "host",
         ),
         "_loader_linux_s390x": attr.label(

--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -71,6 +71,12 @@ _container_pull_attrs = {
         cfg = "host",
         doc = "(optional) Exposed to provide a way to test other pullers on Linux",
     ),
+    "puller_linux_arm64": attr.label(
+        executable = True,
+        default = Label("@go_puller_linux_arm64//file:downloaded"),
+        cfg = "host",
+        doc = "(optional) Exposed to provide a way to test other pullers on Linux",
+    ),
     "puller_linux_s390x": attr.label(
         executable = True,
         default = Label("@go_puller_linux_s390x//file:downloaded"),
@@ -108,7 +114,9 @@ def _impl(repository_ctx):
         puller = repository_ctx.attr.puller_darwin
     elif repository_ctx.os.name.lower().startswith("linux"):
         arch = repository_ctx.execute(["uname", "-m"]).stdout.strip()
-        if arch == "s390x":
+        if arch == "arm64" or arch == "aarch64":
+            puller = repository_ctx.attr.puller_linux_arm64
+        elif arch == "s390x":
             puller = repository_ctx.attr.puller_linux_s390x
 
     args = [

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -39,7 +39,7 @@ def repositories():
             sha256 = "08b8963cce9234f57055bafc7cadd1624cdce3c5990048cea1df453d7d288bc6",
             urls = [("https://storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-linux-amd64")],
         )
-        
+
     if "go_puller_linux_arm64" not in excludes:
         http_file(
             name = "go_puller_linux_arm64",

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -39,6 +39,14 @@ def repositories():
             sha256 = "08b8963cce9234f57055bafc7cadd1624cdce3c5990048cea1df453d7d288bc6",
             urls = [("https://storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-linux-amd64")],
         )
+        
+    if "go_puller_linux_arm64" not in excludes:
+        http_file(
+            name = "go_puller_linux_arm64",
+            executable = True,
+            sha256 = "912ee7c469b3e4bf15ba5d1f0ee500e7ec6724518862703fa8b09e4d58ce3ee6",
+            urls = [("https://storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-linux-arm64")],
+        )
 
     if "go_puller_linux_s390x" not in excludes:
         http_file(
@@ -62,6 +70,14 @@ def repositories():
             executable = True,
             sha256 = "5e5ada66beff07f9188bdc1f99c3fa37c407fc0048cd78b9c2047e9c5516f20b",
             urls = [("https://storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/loader-linux-amd64")],
+        )
+
+    if "loader_linux_arm64" not in excludes:
+        http_file(
+            name = "loader_linux_arm64",
+            executable = True,
+            sha256 = "a80966d17b25dbc9313e9fc1cae74ded5916fa64dba0d33438c8adad338b44d3",
+            urls = [("https://storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/loader-linux-arm64")],
         )
 
     if "loader_linux_s390x" not in excludes:


### PR DESCRIPTION
Similar to what https://github.com/bazelbuild/rules_docker/pull/1661 does for s390x.