### PR TITLE
Fix Stamp param propagation from base image

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -75,6 +75,7 @@ TEST_TARGETS = [
     ":with_rfc_3339_creation_time",
     ":with_stamped_creation_time",
     ":with_default_stamped_creation_time",
+    ":with_base_stamped_image",
     ":with_env",
     ":layers_with_env",
     ":with_double_env",

--- a/container/providers.bzl
+++ b/container/providers.bzl
@@ -27,6 +27,7 @@ ImageInfo = provider(fields = [
     "container_parts",
     "legacy_run_behavior",
     "docker_run_flags",
+    "stamp",
 ])
 
 # A provider containing information exposed by container_import rules

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -338,6 +338,11 @@ container_image(
 )
 
 container_image(
+    name = "with_base_stamped_image",
+    base = ":with_stamped_creation_time",
+)
+
+container_image(
     name = "with_default_stamped_creation_time",
     base = ":base_with_volume",
     stamp = True,


### PR DESCRIPTION
The Stamp attribute is now properly prorivded from the base image to the
child image which ensures that target image will be created with default
timestamp value.

```starlark
container_image(
    name = "with_stamped_creation_time",
    base = ":base_with_volume",
    stamp = True,
)

container_image(
    name = "with_base_stamped_image",
    base = ":with_stamped_creation_time",
)
```

Related to #155