### PR TITLE
Fix select with condition on darwin.

### DIFF
--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -63,7 +63,6 @@ alias(
     name = "structure_test_executable",
     actual = select({
         "@bazel_tools//src/conditions:darwin": "@structure_test_darwin//file",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@structure_test_darwin//file",
         "@bazel_tools//src/conditions:linux_aarch64": "@structure_test_linux_aarch64//file",
         "//conditions:default": "@structure_test_linux//file",
     }),


### PR DESCRIPTION
Bazel is changing how @bazel_tools/conditions:darwin is implemented.
With old implementation based on flags, it was ok to have darwin and
darwin_x86_64 in a select. This was based on flag --cpu=darwin and
--cpu=dawin_x86_64.

New implementation is based on constraints, where "darwin" means OS (and
any CPU), while "darwin_x86_64" mean only specific CPU. As such they
cannot be used in the same select, because the selection would be
ambiguous.