### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/container/push.bzl
+++ b/container/push.bzl
@@ -31,7 +31,7 @@ load(
 
 def _get_runfile_path(ctx, f):
     if ctx.attr.windows_paths:
-        return "%RUNFILES%\{}".format(runfile(ctx, f).replace("/", "\\"))
+        return "%RUNFILES%\\{}".format(runfile(ctx, f).replace("/", "\\"))
     else:
         return "${RUNFILES}/%s" % runfile(ctx, f)
 


### PR DESCRIPTION
The backslash used for Windows paths needs to be escaped itself. This was okay because `\{` is an invalid escape sequence which was ignored; but now they'll throw errors due to https://github.com/bazelbuild/bazel/commit/73402fa4aa5b9de46c9a4042b75e6fb332ad4a7f.