### PR TITLE
container_test pass tags to container_bundle

### DIFF
--- a/contrib/test.bzl
+++ b/contrib/test.bzl
@@ -164,6 +164,7 @@ def container_test(name, image, configs, driver = None, verbose = None, **kwargs
         loaded_name = "%s:intermediate" % sanitized_name
         restricted_to = kwargs.get("restricted_to", None)
         compatible_with = kwargs.get("compatible_with", None)
+        tags = kwargs.get("tags", None)
         container_bundle(
             name = image_loader,
             images = {
@@ -171,6 +172,7 @@ def container_test(name, image, configs, driver = None, verbose = None, **kwargs
             },
             restricted_to = restricted_to,
             compatible_with = compatible_with,
+            tags = tags,
         )
 
     _container_test(


### PR DESCRIPTION
Calling `container_test` with tags is creating a `container_bundle` that is not tagged. This change passes the tags to the container_bundle. The change is inspired by the passing of `restricted_to` and `compatible_with`.

Question: Why aren't we passing `**kwargs` instead of calling out specific keys?