### PR TITLE
Pass custom Docker client config to push-all

### DIFF
--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -50,6 +50,13 @@ def _impl(ctx):
         pusher_args += ["--stamp-info-file=%s" % _get_runfile_path(ctx, f) for f in stamp_inputs]
         pusher_args.append("--dst={}".format(tag))
         pusher_args.append("--format={}".format(ctx.attr.format))
+
+        # If the docker toolchain is configured to use a custom client config
+        # directory, use that instead
+        toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
+        if toolchain_info.client_config != "":
+            pusher_args += [" --client-config-dir {}".format(toolchain_info.client_config)]
+
         out = ctx.actions.declare_file("%s.%d.push" % (ctx.label.name, index))
         ctx.actions.expand_template(
             template = ctx.file._tag_tpl,
@@ -125,6 +132,7 @@ container_push = rule(
         ),
     },
     executable = True,
+    toolchains = ["@io_bazel_rules_docker//toolchains/docker:toolchain_type"],
     implementation = _impl,
 )
 


### PR DESCRIPTION
Adds support for custom Docker client configs by applying the changes made to `container/push.bzl` from #594 to `contrib/push-all.bzl`.