### PR TITLE
Introduce output_group for pusher executable

### DIFF
--- a/container/push.bzl
+++ b/container/push.bzl
@@ -132,6 +132,9 @@ def _impl(ctx):
             executable = exe,
             runfiles = runfiles,
         ),
+        OutputGroupInfo(
+            exe = [exe],
+        ),
         PushInfo(
             registry = registry,
             repository = repository,
@@ -224,10 +227,10 @@ def container_push(name, format, image, registry, repository, **kwargs):
         image = image,
         registry = registry,
         repository = repository,
-        extension = select({
+        extension = kwargs.pop("extension", select({
             "@bazel_tools//src/conditions:host_windows": ".bat",
             "//conditions:default": "",
-        }),
+        })),
         tag_tpl = select({
             "@bazel_tools//src/conditions:host_windows": Label("//container:push-tag.bat.tpl"),
             "//conditions:default": Label("//container:push-tag.sh.tpl"),


### PR DESCRIPTION
This allows the pusher to be referenced as a label without including all the default outputs including the .digest file

Fixes #1684

Also use the user-provided value for the (undocumented) "extension" parameter if one is set.

Fixes #1683