### PR TITLE
Add experimental_tarball_format to container_image

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -117,6 +117,7 @@ TEST_TARGETS = [
     ":flat",
     ":flatten_with_tarball_base",
     ":nodejs_image",
+    ":compressed_experiment",
 ]
 
 TEST_DATA = [

--- a/container/bundle.bzl
+++ b/container/bundle.bzl
@@ -71,6 +71,10 @@ def _container_bundle_impl(ctx):
         ctx,
         images,
         ctx.outputs.tar_output,
+        # Experiment: currently only support experimental_tarball_format in
+        # container_image for testing optimization.
+        # TODO(#1695): Update this.
+        "legacy",
         stamp = stamp,
     )
 

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -583,6 +583,15 @@ _attrs = dicts.add(_layer.attrs, {
     "cmd": attr.string_list(),
     "compression": attr.string(default = "gzip"),
     "compression_options": attr.string_list(),
+    "create_image_config": attr.label(
+        default = Label("//container/go/cmd/create_image_config:create_image_config"),
+        cfg = "host",
+        executable = True,
+        allow_files = True,
+    ),
+    "creation_time": attr.string(),
+    "docker_run_flags": attr.string(),
+    "entrypoint": attr.string_list(),
     "experimental_tarball_format": attr.string(
         values = [
             "legacy",
@@ -596,15 +605,6 @@ _attrs = dicts.add(_layer.attrs, {
                "docker. This is an experimental attribute, which is subject " +
                "to change or removal: do not depend on its exact behavior."),
     ),
-    "create_image_config": attr.label(
-        default = Label("//container/go/cmd/create_image_config:create_image_config"),
-        cfg = "host",
-        executable = True,
-        allow_files = True,
-    ),
-    "creation_time": attr.string(),
-    "docker_run_flags": attr.string(),
-    "entrypoint": attr.string_list(),
     "label_file_strings": attr.string_list(),
     # Implicit/Undocumented dependencies.
     "label_files": attr.label_list(

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -309,6 +309,7 @@ def _impl(
         layers = None,
         compression = None,
         compression_options = None,
+        experimental_tarball_format = None,
         debs = None,
         tars = None,
         architecture = None,
@@ -342,6 +343,7 @@ def _impl(
     layers: label List, overrides ctx.attr.layers
     compression: str, overrides ctx.attr.compression
     compression_options: str list, overrides ctx.attr.compression_options
+    experimental_tarball_format: str, overrides ctx.attr.experimental_tarball_format
     debs: File list, overrides ctx.files.debs
     tars: File list, overrides ctx.files.tars
     architecture: str, overrides ctx.attr.architecture
@@ -363,6 +365,7 @@ def _impl(
     architecture = architecture or ctx.attr.architecture
     compression = compression or ctx.attr.compression
     compression_options = compression_options or ctx.attr.compression_options
+    experimental_tarball_format = experimental_tarball_format or ctx.attr.experimental_tarball_format
     operating_system = operating_system or ctx.attr.operating_system
     os_version = os_version or ctx.attr.os_version
     creation_time = creation_time or ctx.attr.creation_time
@@ -516,6 +519,7 @@ def _impl(
         ctx,
         images,
         output_tarball,
+        experimental_tarball_format,
     )
     _assemble_image_digest(ctx, name, container_parts, output_tarball, output_digest)
 
@@ -579,6 +583,19 @@ _attrs = dicts.add(_layer.attrs, {
     "cmd": attr.string_list(),
     "compression": attr.string(default = "gzip"),
     "compression_options": attr.string_list(),
+    "experimental_tarball_format": attr.string(
+        values = [
+            "legacy",
+            "compressed",
+        ],
+        default = "legacy",
+        doc = ("The tarball format to use when producing an image .tar file. " +
+               "Defaults to \"legacy\", which contains uncompressed layers. " +
+               "If set to \"compressed\", the resulting tarball will contain " +
+               "compressed layers, but is only loadable by newer versions of " +
+               "docker. This is an experimental attribute, which is subject " +
+               "to change or removal: do not depend on its exact behavior."),
+    ),
     "create_image_config": attr.label(
         default = Label("//container/go/cmd/create_image_config:create_image_config"),
         cfg = "host",
@@ -775,6 +792,7 @@ def _validate_command(name, argument, operating_system):
 #      # Compression method and command-line options.
 #      compression = "gzip",
 #      compression_options = ["--fast"],
+#      experimental_tarball_format = "compressed",
 #   )
 
 def container_image(**kwargs):

--- a/container/import.bzl
+++ b/container/import.bzl
@@ -125,6 +125,10 @@ def _container_import_impl(ctx):
         ctx,
         images,
         ctx.outputs.out,
+        # Experiment: currently only support experimental_tarball_format in
+        # container_image for testing optimization.
+        # TODO(#1695): Update this.
+        "legacy",
     )
 
     runfiles = ctx.runfiles(

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -158,6 +158,7 @@ def assemble(
         ctx,
         images,
         output,
+        experimental_tarball_format,
         stamp = False):
     """Create the full image from the list of layers.
 
@@ -169,6 +170,7 @@ def assemble(
     """
     args = ctx.actions.args()
     args.add(output, format = "--output=%s")
+    args.add(experimental_tarball_format, format = "--experimental-tarball-format=%s")
     inputs = []
     if stamp:
         args.add_all([ctx.info_file, ctx.version_file], format_each = "--stamp-info-file=%s")

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -166,6 +166,7 @@ def assemble(
        ctx: The context
        images: List of images/layers to assemple
        output: The output path for the image tar
+       experimental_tarball_format: The format of the image tarball: "legacy" | "compressed"
        stamp: Whether to stamp the produced image
     """
     args = ctx.actions.args()

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -1060,8 +1060,8 @@ container_image(
 
 container_image(
     name = "compressed_experiment",
-    files = [":foo"],
     experimental_tarball_format = "compressed",
+    files = [":foo"],
 )
 
 # push_compression* are built but not executed. This is because building a

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -1058,6 +1058,12 @@ container_image(
     files = [":foo"],
 )
 
+container_image(
+    name = "compressed_experiment",
+    files = [":foo"],
+    experimental_tarball_format = "compressed",
+)
+
 # push_compression* are built but not executed. This is because building a
 # `container_push` appears to be the only way to generated the compressed
 # tarball.


### PR DESCRIPTION
This adds an attribute that controls the format of the image tarball
produced when building container_image as "${name}.tar".

The current behavior is a legacy, uncompressed format that is compatible
with older versions of docker but suboptimal for most use cases. I have
retained the default behavior by setting the default value to "legacy",
but callers can opt into a newer format by setting this to "compressed".

In the future, we may want to add support for an OCI Image Layout as
well.

See: https://github.com/bazelbuild/rules_docker/issues/1695