### PR TITLE
go_register_toolchains: set default version

### DIFF
--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -34,7 +34,13 @@ def go_deps(version = GO_VERSION):
     already.
     """
     go_rules_dependencies()
-    go_register_toolchains(version)
+    sdk_kinds = ("_go_download_sdk", "_go_host_sdk", "_go_local_sdk", "_go_wrap_sdk")
+    existing_rules = native.existing_rules()
+    sdk_rules = [r for r in existing_rules.values() if r["kind"] in sdk_kinds]
+    if len(sdk_rules) > 0 or "go_sdk" in existing_rules:
+        go_register_toolchains()
+    else:
+        go_register_toolchains(version)
     gazelle_dependencies()
     excludes = native.existing_rules().keys()
     if "com_github_google_go_containerregistry" not in excludes:

--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -34,7 +34,7 @@ def go_deps(version = GO_VERSION):
     already.
     """
     go_rules_dependencies()
-    go_register_toolchains(go_version)
+    go_register_toolchains(version)
     gazelle_dependencies()
     excludes = native.existing_rules().keys()
     if "com_github_google_go_containerregistry" not in excludes:

--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -22,7 +22,10 @@ repository.
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
-def go_deps():
+# go version for rules_go
+GO_VERSION = "1.15.5"
+
+def go_deps(version = GO_VERSION):
     """Pull in external Go packages needed by Go binaries in this repo.
 
     Pull in all dependencies needed to build the Go binaries in this
@@ -31,7 +34,7 @@ def go_deps():
     already.
     """
     go_rules_dependencies()
-    go_register_toolchains()
+    go_register_toolchains(go_version)
     gazelle_dependencies()
     excludes = native.existing_rules().keys()
     if "com_github_google_go_containerregistry" not in excludes:


### PR DESCRIPTION
The support for a default version in go_register_toolchains is gone, so
we need to pass an explicit version.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>