### PR TITLE
Less verbose package managers

### DIFF
--- a/docker/package_managers/download_pkgs.bzl
+++ b/docker/package_managers/download_pkgs.bzl
@@ -27,7 +27,7 @@ def _generate_add_additional_repo_commands(ctx, additional_repos):
 
 def _generate_download_commands(ctx, packages, additional_repos):
     return """#!/usr/bin/env bash
-set -ex
+set -e
 {add_additional_repo_commands}
 # Remove /var/lib/apt/lists/* in the base image. apt-get update -y command will create them.
 rm -rf /var/lib/apt/lists/*

--- a/docker/package_managers/installer.sh.tpl
+++ b/docker/package_managers/installer.sh.tpl
@@ -2,7 +2,7 @@
 # This script installs debs in installables.tar through dpkg and apt-get.
 # It expects to be volume-mounted inside a docker image, in /tmp/pkginstall
 # along with the installables.tar.
-set -ex
+set -e
 pushd /tmp/pkginstall
 %{install_commands}
 popd

--- a/docker/package_managers/run_download.sh.tpl
+++ b/docker/package_managers/run_download.sh.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 function guess_runfiles() {
     if [ -d ${BASH_SOURCE[0]}.runfiles ]; then

--- a/docker/package_managers/run_install.sh.tpl
+++ b/docker/package_managers/run_install.sh.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 # Resolve the docker tool path
 DOCKER="%{docker_tool_path}"


### PR DESCRIPTION
## What?
Removes `set -x` from the scripts in the package managers

## Why?
Because they are very verbose