### PR TITLE
python3: Respect tags field

### DIFF
--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -103,12 +103,12 @@ def py3_image(name, base = None, deps = [], layers = [], **kwargs):
     # TODO(mattmoor): Consider making the directory into which the app
     # is placed configurable.
     base = base or DEFAULT_BASE
+    tags = kwargs.get("tags", None)
     for index, dep in enumerate(layers):
-        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary_name)
+        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep, tags = tags)
+        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, tags = tags, binary = binary_name)
 
     visibility = kwargs.get("visibility", None)
-    tags = kwargs.get("tags", None)
     app_layer(
         name = name,
         base = base,


### PR DESCRIPTION
'tags' fields are not applied to layer rules.
Fixes #523 for python3.