### PR TITLE
chore(base_images): update base images to latest

### DIFF
--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:7c31f56955cc66134efb3e8282c68f7c92ae3dddcfd99ebf0e7e3dcd9b686e4f",
-    # "gcr.io/distroless/cc:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:c4014bdecaede16f767f8cfc496f968736bc08632bf54a37c004820e85cd8209",
+    # "gcr.io/distroless/cc:debug" circa 2021-01-26 09:59 +0000
+    "debug": "sha256:a75883862308503d14e58e1576f507f52d630f7d92f61a72d6bed129ad6d8209",
+    # "gcr.io/distroless/cc:latest" circa 2021-01-26 09:59 +0000
+    "latest": "sha256:012611229b0d67639b91bc3bef3e8a47841d22396ef5156fd24ee0d13f03f9c2",
 }

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:799b6c346ef976683d93259aa335501a4aaa1bb2156d68444ff149d2e5d5c155",
-    # "gcr.io/distroless/base:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:8d58596f5181f95d908d7f8318f8e27bc394164491bd0aa53c2f284480fd8f8b",
+    # "gcr.io/distroless/base:debug" circa 2021-01-26 09:59 +0000
+    "debug": "sha256:6e633a1081d24e4ab5bd83ae4699069c3e16a0dbd0944eb861502128295c22d4",
+    # "gcr.io/distroless/base:latest" circa 2021-01-26 09:59 +0000
+    "latest": "sha256:f65536ce108fcc41cdcd5cb101006fcb82b9a1527409263feb9e34032f00bda0",
 }

--- a/go/static.bzl
+++ b/go/static.bzl
@@ -19,8 +19,10 @@
 # git repository.
 
 DIGESTS = {
+    # TODO: this image tag is no longer published on gcr.io.
+    # See https://github.com/GoogleContainerTools/distroless/issues/571
     # "gcr.io/distroless/static:debug" circa 2019-10-11 13:46 -0400
     "debug": "sha256:9b60270ec0991bc4f14bda475e8cae75594d8197d0ae58576ace84694aa75d7a",
-    # "gcr.io/distroless/static:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:9b60270ec0991bc4f14bda475e8cae75594d8197d0ae58576ace84694aa75d7a",
+    # "gcr.io/distroless/static:latest" circa 2021-01-26 10:09 +0000
+    "latest": "sha256:bea8d5bd05952cf913f33b22d26540e2a25389be781b357e8b1a132672d6fe24",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:79ed7ab74f05f73f84ac4217d61e2951a0bf1a8c4de5c8ceb398c9521df76c54",
-    # "gcr.io/distroless/java:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:e7f4f67846dde93d59e537c03b596e18b181e50bf63af4fafa5d41ec0a5fd0fc",
+    # "gcr.io/distroless/java:debug" circa 2021-01-26 09:59 +0000
+    "debug": "sha256:d695d472434c5aeeec83196d6692ffcc8f28e73efe7b2fdfbeb38578510b4e0d",
+    # "gcr.io/distroless/java:latest" circa 2021-01-26 09:59 +0000
+    "latest": "sha256:22b552ce46f8b7acda6ecaa2840df565aa845d76fcdfaec1e451181089a68cf8",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:4fd6982c6f9dec3dbba18a5724b523fdcab937fc223f91887cc514b4505f7fbb",
-    # "gcr.io/distroless/java/jetty:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:e8d9fca6dbee84cbff3b2c7979e13178e7951991d1a8370d5d582e92f138aab6",
+    # "gcr.io/distroless/java/jetty:debug" circa 2021-01-26 09:59 +0000
+    "debug": "sha256:8c34dec2d892ec9c26d30f9d63673f1fe454ecabd74787e05836b5b125ec379a",
+    # "gcr.io/distroless/java/jetty:latest" circa 2021-01-26 09:59 +0000
+    "latest": "sha256:cf69113c7341ab590fb0f23403b75487ee0a6a0a5325fd39e755941be56241ee",
 }

--- a/nodejs/nodejs.bzl
+++ b/nodejs/nodejs.bzl
@@ -19,8 +19,9 @@
 # git repository.
 
 DIGESTS = {
+    # TODO: this image tag is no longer published on gcr.io.
     # "gcr.io/google-appengine/debian9:debug" circa 2019-10-11 13:46 -0400
     "debug": "sha256:c05b781371f75d1bd7a199bc83de177173cc80c98dbfb6c1ef7075757addece4",
-    # "gcr.io/google-appengine/debian9:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:c05b781371f75d1bd7a199bc83de177173cc80c98dbfb6c1ef7075757addece4",
+    # "gcr.io/google-appengine/debian9:latest" circa 2021-01-26 10:09 +0000
+    "latest": "sha256:f2aac845f5cc5659bd101580f77862a5f5501b3a539b9805ba4dd8ceb31ac0e6",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:f8e2df9c00e2211013deb1c7297662e80ea90c484496b1ee772eedfef2ef53cc",
-    # "gcr.io/distroless/python2.7:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:6d3895c4a1629ac99e73c7dc9cbe0ad8cb213d6cdebf3e835c2c388fc5aab1b2",
+    # "gcr.io/distroless/python2.7:debug" circa 2021-01-26 09:59 +0000
+    "debug": "sha256:0705f82a4ad051f0044c097612dd659c2a93989f062fe832ec88ae7e8ff4de90",
+    # "gcr.io/distroless/python2.7:latest" circa 2021-01-26 09:59 +0000
+    "latest": "sha256:a190b769c94793fa88949c5d810b2972c2db8b8391adbd174edbc18065976817",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:a1025877bc8bc6d7fb0c482fbf2c709d10a437ffd3a9a1ed19c62f94f5c7704c",
-    # "gcr.io/distroless/python3:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:8e74b6697d0a741a5d1bb7366260f48721783f71e01d800c13cd2392586639f3",
+    # "gcr.io/distroless/python3:debug" circa 2021-01-26 09:59 +0000
+    "debug": "sha256:78191e03663e24c8fafde0ed5d4c0338148737e126ab0c82a8a3eac7aa10930a",
+    # "gcr.io/distroless/python3:latest" circa 2021-01-26 09:59 +0000
+    "latest": "sha256:bbbaf33dea2a4c3c5bc69fc75c47e4d4182aa1cbc46257059b859cb6b7cd9cc6",
 }


### PR DESCRIPTION
The following image updates failed so didn't get updated:

```console
❯ bazel run //container/go/cmd/update_deps -- --repository=gcr.io/distroless/static --output=$PWD/go/static.bzl
2021/01/26 10:03:12 Computing digest for gcr.io/distroless/static:debug: GET https://gcr.io/v2/distroless/static/manifests/debug: 
MANIFEST_UNKNOWN: Failed to fetch "debug" from request "/v2/distroless/static/manifests/debug".

❯ bazel run //container/go/cmd/update_deps -- --repository=gcr.io/google-appengine/debian9 --output=$PWD/nodejs/nodejs.bzl
2021/01/26 10:03:14 Computing digest for gcr.io/google-appengine/debian9:debug: GET https://gcr.io/v2/google-appengine/debian9/manifests/debug: 
MANIFEST_UNKNOWN: Failed to fetch "debug" from request "/v2/google-appengine/debian9/manifests/debug".
```

I checked the web view and there are indeed no debug images for these
two (any more?):
- https://console.cloud.google.com/gcr/images/distroless/GLOBAL/static
- https://console.cloud.google.com/gcr/images/google-appengine/GLOBAL/debian9

Refs: https://github.com/GoogleContainerTools/distroless/issues/571