### PR TITLE
Renamed `io_bazel_rules_rust` to `rules_rust`

### DIFF
--- a/README.md
+++ b/README.md
@@ -949,7 +949,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # You *must* import the Rust rules before setting up the rust_image rules.
 http_archive(
-    name = "io_bazel_rules_rust",
+    name = "rules_rust",
     # Replace with a real SHA256 checksum
     sha256 = "{SHA256}"
     # Replace with a real commit SHA
@@ -957,7 +957,7 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_rust/archive/{HEAD}.tar.gz"],
 )
 
-load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
+load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
 rust_repositories()
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -317,21 +317,18 @@ _go_image_repos()
 
 # For our rust_image test
 http_archive(
-    name = "io_bazel_rules_rust",
-    sha256 = "3d3faa85e49ebf4d26c40075549a17739d636360064b94a9d481b37ace0add82",
-    strip_prefix = "rules_rust-6e87304c834c30b9c9f585cad19f30e7045281d7",
-    urls = ["https://github.com/bazelbuild/rules_rust/archive/6e87304c834c30b9c9f585cad19f30e7045281d7.tar.gz"],
+    name = "rules_rust",
+    sha256 = "42e60f81e2b269d28334b73b70d02fb516c8de0c16242f5d376bfe6d94a3509f",
+    strip_prefix = "rules_rust-58f709ffec90da93c4e622d8d94f0cd55cd2ef54",
+    urls = [
+        # Master branch as of 2021-02-04
+        "https://github.com/bazelbuild/rules_rust/archive/58f709ffec90da93c4e622d8d94f0cd55cd2ef54.tar.gz",
+    ],
 )
 
-load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
+load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
 rust_repositories()
-
-# The following is required by rules_rust, remove once
-# https://github.com/bazelbuild/rules_rust/issues/167 is fixed
-load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
-
-bazel_version(name = "bazel_version")
 
 # For our d_image test
 http_archive(

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -16,7 +16,7 @@
 The signature of this rule is compatible with rust_binary.
 """
 
-load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:rust.bzl", "rust_binary")
 load(
     "//cc:image.bzl",
     "DEFAULT_BASE",
@@ -35,16 +35,16 @@ def repositories():
 def rust_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
     """Constructs a container image wrapping a rust_binary target.
 
-  Args:
-    name: Name of the rust_image target.
-    base: Base image to use for the rust_image.
-    deps: Dependencies of the rust_image target.
-    binary: An alternative binary target to use instead of generating one.
-    layers: Augments "deps" with dependencies that should be put into
-           their own layers.
-    **kwargs: See rust_binary.
+    Args:
+        name: Name of the rust_image target.
+        base: Base image to use for the rust_image.
+        deps: Dependencies of the rust_image target.
+        layers: Augments "deps" with dependencies that should be put into their own layers.
+        binary: An alternative binary target to use instead of generating one.
+        **kwargs: See rust_binary.
   """
     if layers:
+        # buildifier: disable=print
         print("rust_image does not benefit from layers=[], got: %s" % layers)
 
     if not binary:


### PR DESCRIPTION
As of https://github.com/bazelbuild/rules_rust/commit/1fe23158e5316c17b2ee2a252ee7165c5d83cc93 the workspace name for the Bazel Rust rules is `rules_rust`. This PR is to reflect that change in the docker rules.