### PR TITLE
Support computing the digest when caller can only specify --tarball.

### DIFF
--- a/container/go/cmd/digester/digester.go
+++ b/container/go/cmd/digester/digester.go
@@ -42,8 +42,8 @@ func main() {
 	if *dst == "" {
 		log.Fatalln("Required option -dst was not specified.")
 	}
-	if *imgConfig == "" {
-		log.Fatalln("Option --config is required.")
+	if *imgTarball == "" && *imgConfig == "" {
+		log.Fatalln("Neither --tarball nor --config was specified.")
 	}
 	imgParts, err := compat.ImagePartsFromArgs(*imgConfig, *baseManifest, *imgTarball, layers)
 	if err != nil {


### PR DESCRIPTION
This was supported before, but was removed as part of https://github.com/bazelbuild/rules_docker/pull/1123, a performance optimization/refactoring change. I am proposing to add back the support without changing the code path if the other inputs are available, so current users are not affected.