### PR TITLE
Fix tests resulting from pip dropping support for legacy Python

### DIFF
--- a/testing/examples/run_instruction_arbitrary/BUILD
+++ b/testing/examples/run_instruction_arbitrary/BUILD
@@ -45,10 +45,10 @@ container_run_and_commit(
         "echo 'source /google-cloud-sdk/path.bash.inc' >> ~/.bashrc",
         # Install kubernetes as a component of gcloud
         "/google-cloud-sdk/bin/gcloud components install --quiet kubectl",
-        "apt-get update",
-        "apt-get install -y --no-install-recommends python3-pip",
-        "apt-get clean",
-        "python3 -m pip install --upgrade pip setuptools wheel",
+        # Install Python tools
+        "wget https://bootstrap.pypa.io/3.5/get-pip.py",
+        "python3 get-pip.py",
+        "python3 -m pip install --upgrade setuptools wheel",
     ],
     image = ":gcloud_installer.tar",
 )

--- a/testing/examples/run_instruction_arbitrary/Dockerfile
+++ b/testing/examples/run_instruction_arbitrary/Dockerfile
@@ -14,6 +14,6 @@ RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/google-cloud-sdk/bin
 
 # Install python tools
-RUN apt-get update && apt-get install -y --no-install-recommends python3-pip \
-    && apt-get clean \
-    && python3 -m pip install --upgrade pip setuptools wheel
+
+RUN wget https://bootstrap.pypa.io/3.5/get-pip.py && python3 get-pip.py \
+    && python3 -m pip install --upgrade setuptools wheel


### PR DESCRIPTION
The tests are using a base image that only has python3.5.
Currently the `//testing/examples/run_instruction_arbitrary:all` tests are failing with

```
stderr: Traceback (most recent call last):
  File "/usr/local/bin/pip", line 7, in <module>
    from pip._internal.cli.main import main
  File "/usr/local/lib/python3.5/dist-packages/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
```

This was fixed upstream in https://github.com/pyenv/pyenv/pull/1793 but it is not clear to me how/when we can expect to see that as part of launcher.gcr.io/google/bazel:latest.