### PR TITLE
remove redundant condition in container_test

### DIFF
--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -62,7 +62,7 @@ py_binary(
 alias(
     name = "structure_test_executable",
     actual = select({
-        "@bazel_tools//src/conditions:darwin": "@structure_test_darwin//file",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@structure_test_darwin//file",
         "@bazel_tools//src/conditions:linux_aarch64": "@structure_test_linux_aarch64//file",
         "//conditions:default": "@structure_test_linux//file",
     }),


### PR DESCRIPTION
On bazel 4.0.0, this causes an error (I confirmed that it works under 3.7.2 so it must be due to one of the 4.0 breaking changes):

```
ERROR: Analysis of target '//trumpet:image_test' failed; build aborted: /private/var/tmp/_bazel_alex.eagle/03c50bd9f989d25b88a1be300d53820c/external/io_bazel_rules_docker/contrib/BUILD:62:6: Illegal ambiguous match on configurable attribute actual in @io_bazel_rules_docker//contrib:structure_test_executable:
@bazel_tools//src/conditions:darwin
@bazel_tools//src/conditions:darwin_x86_64
Multiple matches are not allowed unless one is unambiguously more specialized.
```