### PR TITLE
Support authentication in contrib/push-all.bzl

### DIFF
--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -50,6 +50,13 @@ def _impl(ctx):
         pusher_args += ["--stamp-info-file=%s" % _get_runfile_path(ctx, f) for f in stamp_inputs]
         pusher_args.append("--dst={}".format(tag))
         pusher_args.append("--format={}".format(ctx.attr.format))
+
+        # If the docker toolchain is configured to use a custom client config
+        # directory, use that instead
+        toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
+        if toolchain_info.client_config != "":
+            pusher_args += ["-client-config-dir", str(toolchain_info.client_config)]
+
         out = ctx.actions.declare_file("%s.%d.push" % (ctx.label.name, index))
         ctx.actions.expand_template(
             template = ctx.file._tag_tpl,
@@ -125,6 +132,7 @@ container_push = rule(
         ),
     },
     executable = True,
+    toolchains = ["@io_bazel_rules_docker//toolchains/docker:toolchain_type"],
     implementation = _impl,
 )
 


### PR DESCRIPTION
This adds support for authentication to `contrib/push-all.bzl` via credentials defined in a Docker client config defined using [`docker_toolchain_configure`](https://github.com/bazelbuild/rules_docker#container_push-custom-client-configuration). The implementation follows the example of [`container_push`](https://github.com/bazelbuild/rules_docker/blob/e15c9ebf203b7fa708e69ff5f1cdcf427d7edf6f/container/push.bzl#L109-L113).

I'm not sure how to add a test-case for this. Any pointers?