### PR TITLE
Propagate tags to the container image test bundle

### DIFF
--- a/contrib/test.bzl
+++ b/contrib/test.bzl
@@ -164,6 +164,8 @@ def container_test(name, image, configs, driver = None, verbose = None, **kwargs
         loaded_name = "%s:intermediate" % sanitized_name
         restricted_to = kwargs.get("restricted_to", None)
         compatible_with = kwargs.get("compatible_with", None)
+        tags = kwargs.get("tags", [])
+
         container_bundle(
             name = image_loader,
             images = {
@@ -171,6 +173,7 @@ def container_test(name, image, configs, driver = None, verbose = None, **kwargs
             },
             restricted_to = restricted_to,
             compatible_with = compatible_with,
+            tags = tags,
         )
 
     _container_test(


### PR DESCRIPTION
Fixes #1729

<img width="1017" alt="Screen Shot 2021-02-08 at 12 36 08 PM" src="https://user-images.githubusercontent.com/50580/107271987-44b71b00-6a0a-11eb-8cb2-a1a5e2edf003.png">
