### PR TITLE
Switch to non-api fetch URLs

### DIFF
--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -37,11 +37,10 @@ def go_deps():
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(
             name = "com_github_google_go_containerregistry",
-            urls = ["https://api.github.com/repos/google/go-containerregistry/tarball/c061b3f39cff652d18f95ee23ebfd39cb3f5ee89"],  # v0.5.1
-            sha256 = "742b8a99f43800ec2e7e6d6c5bf04b7ac3887af597ac85986c84aed37b160ebf",
+            urls = ["https://github.com/google/go-containerregistry/archive/v0.5.1.tar.gz"],
+            sha256 = "c3e28d8820056e7cc870dbb5f18b4f7f7cbd4e1b14633a6317cef895fdb35203",
             importpath = "github.com/google/go-containerregistry",
-            strip_prefix = "google-go-containerregistry-c061b3f",
-            type = "tar.gz",
+            strip_prefix = "go-containerregistry-0.5.1",
             build_directives = [
                 # Silence Go module warnings about unused modules.
                 "gazelle:exclude pkg/authn/k8schain",
@@ -50,36 +49,32 @@ def go_deps():
     if "com_github_pkg_errors" not in excludes:
         go_repository(
             name = "com_github_pkg_errors",
-            urls = ["https://api.github.com/repos/pkg/errors/tarball/614d223910a179a466c1767a985424175c39b465"],  # v0.9.1
-            sha256 = "208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6",
+            urls = ["https://github.com/pkg/errors/archive/v0.9.1.tar.gz"],
+            sha256 = "56bfd893023daa498508bfe161de1be83299fcf15376035e7df79cbd7d6fa608",
             importpath = "github.com/pkg/errors",
-            strip_prefix = "pkg-errors-614d223",
-            type = "tar.gz",
+            strip_prefix = "errors-0.9.1",
         )
     if "in_gopkg_yaml_v2" not in excludes:
         go_repository(
             name = "in_gopkg_yaml_v2",
-            urls = ["https://api.github.com/repos/go-yaml/yaml/tarball/53403b58ad1b561927d19068c655246f2db79d48"],  # v2.2.8
-            sha256 = "7c8b9e36fac643f1b4a5fc1dc578fb569fc3a1d611c02c3338f4efa84de729fa",
+            urls = ["https://github.com/go-yaml/yaml/archive/v2.2.8.tar.gz"],
+            sha256 = "9632d0760e9a07c414f2b2b6cd453d6225e42ecea77906883b23f1f1d0546045",
             importpath = "gopkg.in/yaml.v2",
-            strip_prefix = "go-yaml-yaml-53403b5",
-            type = "tar.gz",
+            strip_prefix = "yaml-2.2.8",
         )
     if "com_github_kylelemons_godebug" not in excludes:
         go_repository(
             name = "com_github_kylelemons_godebug",
-            urls = ["https://api.github.com/repos/kylelemons/godebug/tarball/9ff306d4fbead574800b66369df5b6144732d58e"],  # v1.1.0
-            sha256 = "6151c487936ab72cffbf804626228083c9b3abfc908a2bb41b1160e1e5780aaf",
+            urls = ["https://github.com/kylelemons/godebug/archive/v1.1.0.tar.gz"],
+            sha256 = "72cc6f274fbd165b7674280f836a6b400e80dbae055919e101920dedf50e79db",
             importpath = "github.com/kylelemons/godebug",
-            strip_prefix = "kylelemons-godebug-9ff306d",
-            type = "tar.gz",
+            strip_prefix = "godebug-1.1.0",
         )
     if "com_github_ghodss_yaml" not in excludes:
         go_repository(
             name = "com_github_ghodss_yaml",
-            urls = ["https://api.github.com/repos/ghodss/yaml/tarball/0ca9ea5df5451ffdf184b4428c902747c2c11cd7"],  # v1.0.0
-            sha256 = "d4bd43ce9348fc1b52af3b7de7a8e62a30d5a02d9137319f312cd95380014f6e",
+            urls = ["https://github.com/ghodss/yaml/archive/v1.0.0.tar.gz"],
+            sha256 = "8a76b47cd171944612aae1cfa08bbb971b63fec16794c839252808392097de44",
             importpath = "github.com/ghodss/yaml",
-            strip_prefix = "ghodss-yaml-0ca9ea5",
-            type = "tar.gz",
+            strip_prefix = "yaml-1.0.0",
         )


### PR DESCRIPTION
This is a no-op change.

These URLs have a few advantages:
* GitHub is less aggressive at rate-limiting these URLs, and these URLs
  are easier to set up pass-through proxies for in an enterprise
  setting.
* The URLs self-document which tag is being fetched, rather than
  requiring separate comments to track tags (but the sha256 ensures
  re-pointed tags will still halt builds). That said, there are
  sha1-equivalent URLs if we'd prefer to keep them.
* The URLs have file extensions, so don't need a separate `type`
  attribute