### PR TITLE
Modify the timeout and enable the real-time logs of the docker build process.

### DIFF
--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -121,10 +121,11 @@ dockerfile_image = repository_rule(
             mandatory = True,
             doc = "The label for the Dockerfile to build the image from.",
         ),
+        # @unsorted-dict-items
         "timeout": attr.int(
             default = 3600,
-            doc = "Maximum duration of the build image.",
             mandatory = False,
+            doc = "Maximum duration of the build image.",
         ),
         "quiet": attr.bool(
             default = False,

--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -77,8 +77,8 @@ def _impl(repository_ctx):
 
     build_result = repository_ctx.execute(
         command,
-        timeout = repository_ctx.attr.timeout,
         quiet = repository_ctx.attr.quiet,
+        timeout = repository_ctx.attr.timeout,
     )
     if build_result.return_code:
         fail("docker build command failed: {} ({})".format(
@@ -121,16 +121,15 @@ dockerfile_image = repository_rule(
             mandatory = True,
             doc = "The label for the Dockerfile to build the image from.",
         ),
-        # @unsorted-dict-items
-        "timeout": attr.int(
-            default = 3600,
-            mandatory = False,
-            doc = "Maximum duration of the build image.",
-        ),
         "quiet": attr.bool(
             default = False,
             doc = "Print the stdout of the client docker when building the image.",
             mandatory = False,
+        ),
+        "timeout": attr.int(
+            default = 3600,
+            mandatory = False,
+            doc = "Maximum duration of the build image.",
         ),
         "vars": attr.string_list(
             doc = "List of environment vars to include in the build.",

--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -78,7 +78,7 @@ def _impl(repository_ctx):
     build_result = repository_ctx.execute(
         command,
         timeout = repository_ctx.attr.timeout,
-        quiet = repository_ctx.attr.quiet
+        quiet = repository_ctx.attr.quiet,
     )
     if build_result.return_code:
         fail("docker build command failed: {} ({})".format(
@@ -121,15 +121,15 @@ dockerfile_image = repository_rule(
             mandatory = True,
             doc = "The label for the Dockerfile to build the image from.",
         ),
-        "quiet": attr.bool(
-            mandatory = False,
-            default = False,
-            doc = "Print the stdout of the client docker when building the image."
-        ),
         "timeout": attr.int(
             mandatory = False,
             default = 3600,
             doc = "Maximum duration of the build image.",
+        ),
+        "quiet": attr.bool(
+            mandatory = False,
+            default = False,
+            doc = "Print the stdout of the client docker when building the image.",
         ),
         "vars": attr.string_list(
             doc = "List of environment vars to include in the build.",

--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -128,8 +128,8 @@ dockerfile_image = repository_rule(
         ),
         "timeout": attr.int(
             default = 3600,
-            doc = "Maximum duration of the build image.",
             mandatory = False,
+            doc = "Maximum duration of the build image.",
         ),
         "vars": attr.string_list(
             doc = "List of environment vars to include in the build.",

--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -122,14 +122,14 @@ dockerfile_image = repository_rule(
             doc = "The label for the Dockerfile to build the image from.",
         ),
         "timeout": attr.int(
-            mandatory = False,
             default = 3600,
             doc = "Maximum duration of the build image.",
+            mandatory = False,
         ),
         "quiet": attr.bool(
-            mandatory = False,
             default = False,
             doc = "Print the stdout of the client docker when building the image.",
+            mandatory = False,
         ),
         "vars": attr.string_list(
             doc = "List of environment vars to include in the build.",

--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -75,7 +75,11 @@ def _impl(repository_ctx):
         str(dockerfile_path.dirname),
     ])
 
-    build_result = repository_ctx.execute(command)
+    build_result = repository_ctx.execute(
+        command,
+        timeout = repository_ctx.attr.timeout,
+        quiet = repository_ctx.attr.quiet
+    )
     if build_result.return_code:
         fail("docker build command failed: {} ({})".format(
             build_result.stderr,
@@ -116,6 +120,16 @@ dockerfile_image = repository_rule(
             allow_single_file = True,
             mandatory = True,
             doc = "The label for the Dockerfile to build the image from.",
+        ),
+        "quiet": attr.bool(
+            mandatory = False,
+            default = False,
+            doc = "Print the stdout of the client docker when building the image."
+        ),
+        "timeout": attr.int(
+            mandatory = False,
+            default = 3600,
+            doc = "Maximum duration of the build image.",
         ),
         "vars": attr.string_list(
             doc = "List of environment vars to include in the build.",

--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -128,8 +128,8 @@ dockerfile_image = repository_rule(
         ),
         "timeout": attr.int(
             default = 3600,
-            mandatory = False,
             doc = "Maximum duration of the build image.",
+            mandatory = False,
         ),
         "vars": attr.string_list(
             doc = "List of environment vars to include in the build.",


### PR DESCRIPTION
The purpose of this pull request is to make it possible to modify the timeout of the image build process, since the default value (600 seconds) may not be sufficient.
This process can be terminated by external factors, such as a very large base image or slow internet.
For debugging purposes, also enabling real-time logs of the build process is a good strategy.