### PR TITLE
Add Domino Data Lab to list of adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2371,6 +2371,7 @@ Here's a (non-exhaustive) list of companies that use `rules_docker` in productio
   * [Amaiz](https://github.com/amaizfinance)
   * [Aura Devices](https://auradevices.io/)
   * [Button](https://usebutton.com)
+  * [Domino Data Lab](https://www.dominodatalab.com/)
   * [Canva](https://canva.com)
   * [Etsy](https://www.etsy.com)
   * [Evertz](https://evertz.com/)


### PR DESCRIPTION
At [Domino Data Lab](https://www.dominodatalab.com/), we're using `rules_docker` to build Docker images in our monorepo. Hopefully our usage encourages others to adopt `rules_docker` as well.