### PR TITLE
Add the ability to add healthcheck definition for containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2201,9 +2201,12 @@ container_image(name, base, data_path, directory, files, legacy_repository_namin
         <code>List of strings, optional</code>
         <p><a href="https://docs.docker.com/engine/reference/builder/#healthcheck">
         The test to perform to check that the container is healthy.</a></p>
-        <p>An empty list means to inherit the default.</p>
+        <p>
+        An empty list means to inherit the default. If <code>healthcheck_test</code> wasn't defined
+        <code>HEALTHCHECK</code> will be inherited from an upper layers.
+        </p>
         <p>Possible definition options are:</p>
-        <p><code>[]</code> : inherit healthcheck</p>
+        <p><code>None</code>/<code>[]</code> : inherit healthcheck</p>
         <p><code>["NONE"]</code> : disable healthcheck</p>
         <p><code>["CMD", "test", "-f", "file"]</code> : exec arguments directly</p>
         <p><code>["CMD-SHELL", "curl -q localhost:8080"]</code> : run command with system's default shell</p>

--- a/README.md
+++ b/README.md
@@ -2195,6 +2195,82 @@ container_image(name, base, data_path, directory, files, legacy_repository_namin
         </p>
       </td>
     </tr>
+    <tr>
+      <td><code>healthcheck_test</code></td>
+      <td>
+        <code>List of strings, optional</code>
+        <p><a href="https://docs.docker.com/engine/reference/builder/#healthcheck">
+        The test to perform to check that the container is healthy.</a></p>
+        <p>An empty list means to inherit the default.</p>
+        <p>Possible definition options are:</p>
+        <p><code>[]</code> : inherit healthcheck</p>
+        <p><code>["NONE"]</code> : disable healthcheck</p>
+        <p><code>["CMD", "test", "-f", "file"]</code> : exec arguments directly</p>
+        <p><code>["CMD-SHELL", "curl -q localhost:8080"]</code> : run command with system's default shell</p>
+        <p>
+          <code>
+          healthcheck_test = ["CMD", "test", "-f", "file"],
+          </code>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>healthcheck_interval</code></td>
+      <td>
+        <code>strings, optional</code>
+        <p>Interval is the time to wait between health checks.</p>
+        <p>
+          Should be in the duration format. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+        </p>
+        <p>
+          <code>
+          healthcheck_interval = "30s",
+          </code>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>healthcheck_timeout</code></td>
+      <td>
+        <code>strings, optional</code>
+        <p>Health check timeout is the time to wait before considering the check to have hung.</p>
+        <p>
+          Should be in the duration format. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+        </p>
+        <p>
+          <code>
+          healthcheck_timeout = "30s",
+          </code>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>healthcheck_start_period</code></td>
+      <td>
+        <code>strings, optional</code>
+        <p>The health check start period for the container to initialize before the retries starts to count down.</p>
+        <p>
+          Should be in the duration format. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+        </p>
+        <p>
+          <code>
+          healthcheck_start_period = "10s",
+          </code>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>healthcheck_retries</code></td>
+      <td>
+        <code>integer, optional</code>
+        <p>Health check retries is the number of consecutive failures needed to consider a container as unhealthy.</p>
+        <p>
+          <code>
+          healthcheck_retries = 2,
+          </code>
+        </p>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/container/go/cmd/create_image_config/create_image_config.go
+++ b/container/go/cmd/create_image_config/create_image_config.go
@@ -30,27 +30,32 @@ import (
 )
 
 var (
-	baseConfig         = flag.String("baseConfig", "", "The base image config.")
-	baseManifest       = flag.String("baseManifest", "", "The base image manifest.")
-	outputConfig       = flag.String("outputConfig", "", "The output image config file to generate.")
-	outputManifest     = flag.String("outputManifest", "", "The output manifest file to generate.")
-	creationTimeString = flag.String("creationTime", "", "The creation timestamp. Acceptable formats: Integer or floating point seconds since Unix Epoch, RFC 3339 date/time.")
-	user               = flag.String("user", "", "The username to run the commands under.")
-	workdir            = flag.String("workdir", "", "Set the working directory of the layer.")
-	nullEntryPoint     = flag.Bool("nullEntryPoint", false, "If true, Entrypoint will be set to null.")
-	nullCmd            = flag.Bool("nullCmd", false, "If true, Cmd will be set to null.")
-	architecture       = flag.String("architecture", "amd64", "The architecture of the docker image.")
-	operatingSystem    = flag.String("operatingSystem", "linux", "Operating system to create docker image for, eg. linux.")
-	osVersion          = flag.String("osVersion", "", "Operating system version to create docker image for (primarily for windows).")
-	labelsArray        utils.ArrayStringFlags
-	ports              utils.ArrayStringFlags
-	volumes            utils.ArrayStringFlags
-	entrypointPrefix   utils.ArrayStringFlags
-	env                utils.ArrayStringFlags
-	command            utils.ArrayStringFlags
-	entrypoint         utils.ArrayStringFlags
-	layerDigestFile    utils.ArrayStringFlags
-	stampInfoFile      utils.ArrayStringFlags
+	baseConfig             = flag.String("baseConfig", "", "The base image config.")
+	baseManifest           = flag.String("baseManifest", "", "The base image manifest.")
+	outputConfig           = flag.String("outputConfig", "", "The output image config file to generate.")
+	outputManifest         = flag.String("outputManifest", "", "The output manifest file to generate.")
+	creationTimeString     = flag.String("creationTime", "", "The creation timestamp. Acceptable formats: Integer or floating point seconds since Unix Epoch, RFC 3339 date/time.")
+	user                   = flag.String("user", "", "The username to run the commands under.")
+	workdir                = flag.String("workdir", "", "Set the working directory of the layer.")
+	nullEntryPoint         = flag.Bool("nullEntryPoint", false, "If true, Entrypoint will be set to null.")
+	nullCmd                = flag.Bool("nullCmd", false, "If true, Cmd will be set to null.")
+	architecture           = flag.String("architecture", "amd64", "The architecture of the docker image.")
+	operatingSystem        = flag.String("operatingSystem", "linux", "Operating system to create docker image for, eg. linux.")
+	osVersion              = flag.String("osVersion", "", "Operating system version to create docker image for (primarily for windows).")
+	healthcheckInterval    = flag.String("healthcheckInterval", "", "Health check interval is the time to wait between checks.")
+	healthcheckTimeout     = flag.String("healthcheckTimeout", "", "Health check timeout is the time to wait before considering the check to have hung.")
+	healthcheckStartPeriod = flag.String("healthcheckStartPeriod", "", "Health check start period for the container to initialize before the retries starts to count down.")
+	healthcheckRetries     = flag.Int("healthcheckRetries", 0, "Health check retries is the number of consecutive failures needed to consider a container as unhealthy. Zero means inherit.")
+	labelsArray            utils.ArrayStringFlags
+	ports                  utils.ArrayStringFlags
+	volumes                utils.ArrayStringFlags
+	entrypointPrefix       utils.ArrayStringFlags
+	env                    utils.ArrayStringFlags
+	command                utils.ArrayStringFlags
+	entrypoint             utils.ArrayStringFlags
+	layerDigestFile        utils.ArrayStringFlags
+	stampInfoFile          utils.ArrayStringFlags
+	healthcheckTest        utils.ArrayStringFlags
 )
 
 func main() {
@@ -63,6 +68,7 @@ func main() {
 	flag.Var(&entrypoint, "entrypoint", "Override the Entrypoint of the previous layer.")
 	flag.Var(&layerDigestFile, "layerDigestFile", "Layer sha256 hashes that make up this image. The order that these layers are specified matters.")
 	flag.Var(&stampInfoFile, "stampInfoFile", "A list of files from which to read substitutions to make in the provided fields.")
+	flag.Var(&healthcheckTest, "healthcheckTest", "Override the HealthCheck command of the previous layer.")
 
 	flag.Parse()
 
@@ -89,27 +95,32 @@ func main() {
 	}
 
 	opts := compat.OverrideConfigOpts{
-		ConfigFile:         configFile,
-		OutputConfig:       *outputConfig,
-		CreationTimeString: *creationTimeString,
-		User:               *user,
-		Workdir:            *workdir,
-		NullEntryPoint:     *nullEntryPoint,
-		NullCmd:            *nullCmd,
-		Architecture:       *architecture,
-		OperatingSystem:    *operatingSystem,
-		OSVersion:          *osVersion,
-		CreatedBy:          "bazel build ...",
-		Author:             "Bazel",
-		LabelsArray:        labelsArray,
-		Ports:              ports,
-		Volumes:            volumes,
-		EntrypointPrefix:   entrypointPrefix,
-		Env:                env,
-		Command:            command,
-		Entrypoint:         entrypoint,
-		Layer:              layerDigestFile,
-		Stamper:            stamper,
+		ConfigFile:             configFile,
+		OutputConfig:           *outputConfig,
+		CreationTimeString:     *creationTimeString,
+		User:                   *user,
+		Workdir:                *workdir,
+		NullEntryPoint:         *nullEntryPoint,
+		NullCmd:                *nullCmd,
+		Architecture:           *architecture,
+		OperatingSystem:        *operatingSystem,
+		OSVersion:              *osVersion,
+		CreatedBy:              "bazel build ...",
+		Author:                 "Bazel",
+		LabelsArray:            labelsArray,
+		Ports:                  ports,
+		Volumes:                volumes,
+		EntrypointPrefix:       entrypointPrefix,
+		Env:                    env,
+		Command:                command,
+		Entrypoint:             entrypoint,
+		Layer:                  layerDigestFile,
+		HealthcheckInterval:    *healthcheckInterval,
+		HealthcheckTimeout:     *healthcheckTimeout,
+		HealthcheckStartPeriod: *healthcheckStartPeriod,
+		HealthcheckRetries:     *healthcheckRetries,
+		HealthcheckTest:        healthcheckTest,
+		Stamper:                stamper,
 	}
 
 	// write out the updated config after overriding config content.

--- a/container/go/pkg/compat/config.go
+++ b/container/go/pkg/compat/config.go
@@ -43,24 +43,24 @@ const (
 )
 
 var (
-	validHealcheckTypes = map[string]func([]string) error{
+	validHealthcheckTypes = map[string]func([]string) error{
 		"NONE": func(args []string) error {
-			if len(args) == 1 {
-				return nil
+			if len(args) != 1 {
+				return errors.New("NONE doesn't accept any extra args")
 			}
-			return errors.New("NONE doesn't accept any extra args")
+			return nil
 		},
 		"CMD": func(args []string) error {
-			if len(args) > 1 {
-				return nil
+			if len(args) < 2 {
+				return errors.New("CMD accepts at least 1 arg")
 			}
-			return errors.New("CMD accepts at least 1 arg")
+			return nil
 		},
 		"CMD-SHELL": func(args []string) error {
-			if len(args) == 2 {
-				return nil
+			if len(args) != 2 {
+				return errors.New("CMD-SHELL accepts only 1 arg")
 			}
-			return errors.New("CMD-SHELL accepts only 1 arg")
+			return nil
 		},
 	}
 )
@@ -448,7 +448,7 @@ func updateHealthCheck(overrideInfo *OverrideConfigOpts) error {
 
 	if len(overrideInfo.HealthcheckTest) > 0 {
 		checkType := overrideInfo.HealthcheckTest[0]
-		if check, ok := validHealcheckTypes[checkType]; !ok {
+		if check, ok := validHealthcheckTypes[checkType]; !ok {
 			return fmt.Errorf("HealthcheckTest first argument should be one of: 'NONE', 'CMD', 'CMD-SHELL' was '%s'", checkType)
 		} else if err := check(overrideInfo.HealthcheckTest); err != nil {
 			return errors.Wrap(err, "failed to validate check check command")

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -97,6 +97,11 @@ def _add_create_image_config_args(
         config,
         labels,
         entrypoint,
+        healthcheck_test,
+        healthcheck_interval,
+        healthcheck_timeout,
+        healthcheck_start_period,
+        healthcheck_retries,
         cmd,
         null_cmd,
         null_entrypoint,
@@ -190,6 +195,17 @@ def _add_create_image_config_args(
         args.add("-entrypointPrefix", ctx.file.launcher.basename, format = "/%s")
         args.add_all(ctx.attr.launcher_args, before_each = "-entrypointPrefix")
 
+    if healthcheck_test:
+        args.add_all(healthcheck_test, before_each = "-healthcheckTest")
+        if healthcheck_interval:
+            args.add("-healthcheckInterval", healthcheck_interval)
+        if healthcheck_timeout:
+            args.add("-healthcheckTimeout", healthcheck_timeout)
+        if healthcheck_start_period:
+            args.add("-healthcheckStartPeriod", healthcheck_start_period)
+        if healthcheck_retries:
+            args.add("-healthcheckRetries", healthcheck_retries)
+
 def _format_legacy_label(t):
     return ("--labels=%s=%s" % (t[0], t[1]))
 
@@ -198,6 +214,11 @@ def _image_config(
         name,
         layer_names,
         entrypoint = None,
+        healthcheck_test = None,
+        healthcheck_interval = None,
+        healthcheck_timeout = None,
+        healthcheck_start_period = None,
+        healthcheck_retries = None,
         cmd = None,
         creation_time = None,
         env = None,
@@ -239,6 +260,11 @@ def _image_config(
         config,
         labels,
         entrypoint,
+        healthcheck_test,
+        healthcheck_interval,
+        healthcheck_timeout,
+        healthcheck_start_period,
+        healthcheck_retries,
         cmd,
         null_cmd,
         null_entrypoint,
@@ -302,6 +328,11 @@ def _impl(
         empty_dirs = None,
         directory = None,
         entrypoint = None,
+        healthcheck_test = None,
+        healthcheck_interval = None,
+        healthcheck_timeout = None,
+        healthcheck_start_period = None,
+        healthcheck_retries = None,
         cmd = None,
         creation_time = None,
         symlinks = None,
@@ -336,6 +367,11 @@ def _impl(
     empty_dirs: Dict[str, str], overrides ctx.attr.empty_dirs
     directory: str, overrides ctx.attr.directory
     entrypoint: str List, overrides ctx.attr.entrypoint
+    healthcheck_test: str, overrides ctx.attr.healthcheck_test
+    healthcheck_interval: str, overrides ctx.attr.healthcheck_interval
+    healthcheck_timeout: str, overrides ctx.attr.healthcheck_timeout
+    healthcheck_start_period: str, overrides ctx.attr.healthcheck_start_period
+    healthcheck_retries: int, overrides ctx.attr.healthcheck_retries
     cmd: str List, overrides ctx.attr.cmd
     creation_time: str, overrides ctx.attr.creation_time
     symlinks: str Dict, overrides ctx.attr.symlinks
@@ -361,6 +397,11 @@ def _impl(
   """
     name = name or ctx.label.name
     entrypoint = entrypoint or ctx.attr.entrypoint
+    healthcheck_test = healthcheck_test or ctx.attr.healthcheck_test
+    healthcheck_interval = healthcheck_interval or ctx.attr.healthcheck_interval
+    healthcheck_timeout = healthcheck_timeout or ctx.attr.healthcheck_timeout
+    healthcheck_start_period = healthcheck_start_period or ctx.attr.healthcheck_start_period
+    healthcheck_retries = healthcheck_retries or ctx.attr.healthcheck_retries
     cmd = cmd or ctx.attr.cmd
     architecture = architecture or ctx.attr.architecture
     compression = compression or ctx.attr.compression
@@ -453,6 +494,11 @@ def _impl(
             layer_names = [layer_diff_ids[i]],
             entrypoint = entrypoint,
             cmd = cmd,
+            healthcheck_test = healthcheck_test,
+            healthcheck_interval = healthcheck_interval,
+            healthcheck_timeout = healthcheck_timeout,
+            healthcheck_start_period = healthcheck_start_period,
+            healthcheck_retries = healthcheck_retries,
             creation_time = creation_time,
             env = layer.env,
             base_config = config_file,
@@ -581,6 +627,11 @@ _attrs = dicts.add(_layer.attrs, {
     "architecture": attr.string(default = "amd64"),
     "base": attr.label(allow_files = container_filetype),
     "cmd": attr.string_list(),
+    "healthcheck_test": attr.string_list(),
+    "healthcheck_interval": attr.string(),
+    "healthcheck_timeout": attr.string(),
+    "healthcheck_start_period": attr.string(),
+    "healthcheck_retries": attr.int(),
     "compression": attr.string(default = "gzip"),
     "compression_options": attr.string_list(),
     "create_image_config": attr.label(

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -627,11 +627,6 @@ _attrs = dicts.add(_layer.attrs, {
     "architecture": attr.string(default = "amd64"),
     "base": attr.label(allow_files = container_filetype),
     "cmd": attr.string_list(),
-    "healthcheck_test": attr.string_list(),
-    "healthcheck_interval": attr.string(),
-    "healthcheck_timeout": attr.string(),
-    "healthcheck_start_period": attr.string(),
-    "healthcheck_retries": attr.int(),
     "compression": attr.string(default = "gzip"),
     "compression_options": attr.string_list(),
     "create_image_config": attr.label(
@@ -656,6 +651,11 @@ _attrs = dicts.add(_layer.attrs, {
                "docker. This is an experimental attribute, which is subject " +
                "to change or removal: do not depend on its exact behavior."),
     ),
+    "healthcheck_interval": attr.string(),
+    "healthcheck_retries": attr.int(),
+    "healthcheck_start_period": attr.string(),
+    "healthcheck_test": attr.string_list(),
+    "healthcheck_timeout": attr.string(),
     "label_file_strings": attr.string_list(),
     # Implicit/Undocumented dependencies.
     "label_files": attr.label_list(


### PR DESCRIPTION
Original issue: https://github.com/bazelbuild/rules_docker/issues/770

Adds follow options for container_image:
- healthcheck_test
- healthcheck_interval
- healthcheck_timeout
- healthcheck_start_period
- healthcheck_retries