### PR TITLE
container_push: add skip_unchanged_digest attribute

### DIFF
--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -48,6 +48,8 @@ def _impl(ctx):
 
         pusher_args, pusher_inputs = _gen_img_args(ctx, image, _get_runfile_path)
         pusher_args += ["--stamp-info-file=%s" % _get_runfile_path(ctx, f) for f in stamp_inputs]
+        if ctx.attr.skip_unchanged_digest:
+            pusher_args.append("--skip-unchanged-digest")
         pusher_args.append("--dst={}".format(tag))
         pusher_args.append("--format={}".format(ctx.attr.format))
         out = ctx.actions.declare_file("%s.%d.push" % (ctx.label.name, index))
@@ -108,6 +110,10 @@ container_push = rule(
         "sequential": attr.bool(
             default = False,
             doc = "If true, push images sequentially.",
+        ),
+        "skip_unchanged_digest": attr.bool(
+            default = False,
+            doc = "Only push images if the digest has changed, default to False",
         ),
         "_all_tpl": attr.label(
             default = Label("//contrib:push-all.sh.tpl"),


### PR DESCRIPTION
# Bring push-all on par with container_push in term of feature parity.

Generally `--skip-unchanged-digest` is a very useful flag to have. One can simply setup a release pipeline upon successful CI to just do `bazel run <push-all-target>` to push all container images (wrapped in a container bundle) at once.

By checking against upstream registry whether an existing digest already existed, we will only push images which were updated as the result of recent changes introduced to the repo.

The alternative solution is to calculate the SCM diff (git-diff) of the repo to deduce which bazel target were affected, query for container_push targets and `bazel run` each target 1-by-1, which is complicated to setup (especially when handling deleted code).

---

This PR added the ability to verify unchanged digest to bundle push (contrib/push-all) rule for convenience.

Without this, the ability to skip unchanged digest is exclusive to container_push and one would need something like https://github.com/atlassian/bazel-tools/tree/master/multirun to achieve the equivalent.

Caveats: when push-all with a container bundle that has duplicated images and push-all is set to run in parallel, the final result might be random. Use sequential push option if you think this is an issue.

Closes https://github.com/bazelbuild/rules_docker/issues/1741