### PR TITLE
Revert "Invite maintainers from community (#1750)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @smukherj1 @alexeagle @pcj @gravypod

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @smukherj1 @hicksjoseph

--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
 # Bazel Container Image Rules
 
-## Are you interested in helping maintain `rules_docker`?
-
-Given the maturity of `rules_docker` and its importance to so many Bazel users,
-we believe that it's time to give the community more ownership in maintaining
-these rules. If you are interested in helping to shape the growth of
-`rules_docker`, ensuring that pull requests get processed in a timely manner,
-and creating new tagged releases, please reach out to
-rules-docker-users@googlegroups.com.
-
-
 Travis CI | Bazel CI
 :---: | :---:
 [![Build Status](https://travis-ci.org/bazelbuild/rules_docker.svg?branch=master)](https://travis-ci.org/bazelbuild/rules_docker) | [![Build status](https://badge.buildkite.com/693d7892250cfd44beea3cd95573388200935906a28cd3146d.svg)](https://buildkite.com/bazel/docker-rules-docker-postsubmit)


### PR DESCRIPTION
We got the new maintainers here now, and don't need to advertise this way.

We'll surely add more maintainers from the community over time, but can bootstrap that the normal way by promoting ppl who are active and helpful in the repo.

This reverts commit a4d580ee357b3e40e80becb311ea88214b70e0db
and moves the config file to .github/ folder to improve tidiness in the root