### PR TITLE
Remove warning about go_image on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,6 @@ registry interactions.
 
 ## Language Rules
 
-Note: Some of these rules are not supported on Mac. Specifically `go_image`
-cannot be used from Bazel running on a Mac. Other rules may also fail
-arbitrarily on Mac due to unforeseen toolchain issues that need to be resolved in
-Bazel and upstream rules repos. Please see [#943](https://github.com/bazelbuild/rules_docker/issues/943)
-for more details.
-
 * [py_image](#py_image) ([signature](
 https://docs.bazel.build/versions/master/be/python.html#py_binary))
 * [py3_image](#py3_image) ([signature](


### PR DESCRIPTION
It was fixed over a year ago according to https://github.com/bazelbuild/rules_go/issues/2089

I've had some users confused by this message since we tell them to use this rule on Mac