### PR TITLE
update_deps: Correctly check if manifest pull failed

### DIFF
--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:7c31f56955cc66134efb3e8282c68f7c92ae3dddcfd99ebf0e7e3dcd9b686e4f",
-    # "gcr.io/distroless/cc:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:c4014bdecaede16f767f8cfc496f968736bc08632bf54a37c004820e85cd8209",
+    # "gcr.io/distroless/cc:debug" circa 2021-03-14 11:14 -0400
+    "debug": "sha256:2b083aa36dbfe76eff429ee21596d53a6ca5ab69ec48aef375264c267e3da5a0",
+    # "gcr.io/distroless/cc:latest" circa 2021-03-14 11:14 -0400
+    "latest": "sha256:937aa8c7edd91618d8ed4510a0fd06a9dd97db3a786b23e953213cdcf88ccfde",
 }

--- a/container/go/cmd/update_deps/update_deps.go
+++ b/container/go/cmd/update_deps/update_deps.go
@@ -86,7 +86,7 @@ func main() {
 	debug := *repository + ":debug"
 	debugDigest, err := crane.Digest(debug, options...)
 	if err != nil {
-		if !strings.HasPrefix(err.Error(), "MANIFEST_UNKNOWN") {
+		if !strings.Contains(err.Error(), "MANIFEST_UNKNOWN: Failed to fetch") {
 			log.Fatalf("Computing digest for %s: %v", debug, err)
 		}
 		debugDigest = latestDigest

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:799b6c346ef976683d93259aa335501a4aaa1bb2156d68444ff149d2e5d5c155",
-    # "gcr.io/distroless/base:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:8d58596f5181f95d908d7f8318f8e27bc394164491bd0aa53c2f284480fd8f8b",
+    # "gcr.io/distroless/base:debug" circa 2021-03-14 11:14 -0400
+    "debug": "sha256:2ff953dd529274b500358650d00ad73aa73de4c84ebe331381ae4d4186ad9c36",
+    # "gcr.io/distroless/base:latest" circa 2021-03-14 11:14 -0400
+    "latest": "sha256:3275e0193422021d412891b791f183b82bba943015aff9b7056758b7dd023fb4",
 }

--- a/go/static.bzl
+++ b/go/static.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/static:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:9b60270ec0991bc4f14bda475e8cae75594d8197d0ae58576ace84694aa75d7a",
-    # "gcr.io/distroless/static:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:9b60270ec0991bc4f14bda475e8cae75594d8197d0ae58576ace84694aa75d7a",
+    # "gcr.io/distroless/static:debug" circa 2021-03-14 11:14 -0400
+    "debug": "sha256:359e0c5c9a1364d82f567db01e1419dead4dfc04d33271248f9c713007d0c22e",
+    # "gcr.io/distroless/static:latest" circa 2021-03-14 11:14 -0400
+    "latest": "sha256:359e0c5c9a1364d82f567db01e1419dead4dfc04d33271248f9c713007d0c22e",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:79ed7ab74f05f73f84ac4217d61e2951a0bf1a8c4de5c8ceb398c9521df76c54",
-    # "gcr.io/distroless/java:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:e7f4f67846dde93d59e537c03b596e18b181e50bf63af4fafa5d41ec0a5fd0fc",
+    # "gcr.io/distroless/java:debug" circa 2021-03-14 11:14 -0400
+    "debug": "sha256:40ebcde63488757cfcb4451465f17fec7955cfad960d63fbb5d5a9b3c7ad04ec",
+    # "gcr.io/distroless/java:latest" circa 2021-03-14 11:14 -0400
+    "latest": "sha256:1e569cb980bcb1b8fc9db5d887240fe5b7d1cc722e601c0b3e68cdc65d66f1a9",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:4fd6982c6f9dec3dbba18a5724b523fdcab937fc223f91887cc514b4505f7fbb",
-    # "gcr.io/distroless/java/jetty:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:e8d9fca6dbee84cbff3b2c7979e13178e7951991d1a8370d5d582e92f138aab6",
+    # "gcr.io/distroless/java/jetty:debug" circa 2021-03-14 11:14 -0400
+    "debug": "sha256:32d8a92f2f4c59b5440221b627d94d6d7cc33e3702b67a9e542cda3d5e76dd49",
+    # "gcr.io/distroless/java/jetty:latest" circa 2021-03-14 11:14 -0400
+    "latest": "sha256:9696f0882ac318904348f2204ccae11232e1978f7f66bf083dd0b8206f59d5da",
 }

--- a/nodejs/nodejs.bzl
+++ b/nodejs/nodejs.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/google-appengine/debian9:debug" circa 2019-10-11 13:46 -0400
-    "debug": "sha256:c05b781371f75d1bd7a199bc83de177173cc80c98dbfb6c1ef7075757addece4",
-    # "gcr.io/google-appengine/debian9:latest" circa 2019-10-11 13:46 -0400
-    "latest": "sha256:c05b781371f75d1bd7a199bc83de177173cc80c98dbfb6c1ef7075757addece4",
+    # "gcr.io/google-appengine/debian9:debug" circa 2021-03-14 11:14 -0400
+    "debug": "sha256:18fffa1540afe7784c23384479e161c7e86c9c4b24726bb90857bb62897bda93",
+    # "gcr.io/google-appengine/debian9:latest" circa 2021-03-14 11:14 -0400
+    "latest": "sha256:18fffa1540afe7784c23384479e161c7e86c9c4b24726bb90857bb62897bda93",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:f8e2df9c00e2211013deb1c7297662e80ea90c484496b1ee772eedfef2ef53cc",
-    # "gcr.io/distroless/python2.7:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:6d3895c4a1629ac99e73c7dc9cbe0ad8cb213d6cdebf3e835c2c388fc5aab1b2",
+    # "gcr.io/distroless/python2.7:debug" circa 2021-03-14 11:14 -0400
+    "debug": "sha256:0243d3b0fae19c4cddf55a43018c617793e61c5ef79ee40852f144b1d70f356a",
+    # "gcr.io/distroless/python2.7:latest" circa 2021-03-14 11:14 -0400
+    "latest": "sha256:14e6b999bd473c5b08cdb260432e6d01b7111325133341af54a68b4e1ba6d6c1",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2020-10-30 14:07 -0700
-    "debug": "sha256:a1025877bc8bc6d7fb0c482fbf2c709d10a437ffd3a9a1ed19c62f94f5c7704c",
-    # "gcr.io/distroless/python3:latest" circa 2020-10-30 14:07 -0700
-    "latest": "sha256:8e74b6697d0a741a5d1bb7366260f48721783f71e01d800c13cd2392586639f3",
+    # "gcr.io/distroless/python3:debug" circa 2021-03-14 11:14 -0400
+    "debug": "sha256:0951be19d51e7db0706299b3d08bea13ddedf62435d68e98a001e4c73775bea4",
+    # "gcr.io/distroless/python3:latest" circa 2021-03-14 11:14 -0400
+    "latest": "sha256:daaeda88192f299fd430a5278657b2322b24de6514bf94086083ef7c367c21ba",
 }


### PR DESCRIPTION
This script finds reproducable hashes for pulling containers from
distroless. Since the last time this was run it seems that they
have stopped pushing a :debug tag for some images (static). This
makes sense as static is just an image with some standard openssl
and user file deps that do not have debug versions.

The code that implements update_deps is written to recover from
this situation (seemingly anticipating it) but it looks like the
author copied a Fatalf which os.Exit(1)s after printing. I've
changed this ti a Printf() so that the existing recovery logic
can take over.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

