### PR TITLE
Revert "Remove google cloud build integration (#1767)"

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,23 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  # Test the case where the test target is located at the root of the
+  # workspace, which makes the Bazel package empty.
+  - name: "l.gcr.io/google/bazel"
+    args:
+      - "test"
+      - "--test_output=errors"
+      - "--verbose_failures"
+      - "//:structure_test_at_workspace_root"


### PR DESCRIPTION
This reverts commit 1df35d946009b659306a8274b235bab83cf5c439.

We need to do more work to determine whether there was some coverage here.