### PR TITLE
Allow configuring a http proxy exclusively for the image puller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1318,6 +1318,11 @@ variable. The caching feature hasn't been thoroughly tested and may be thread
 unsafe. If you notice flakiness after enabling it, see the warning below on how
 to workaround it.
 
+**NOTE** Set `CONTAINER_PULL_HTTP_PROXY` and `CONTAINER_PULL_HTTPS_PROXY` to
+use a http proxy exclusively for the image puller. If the `CONTAINER_PULL`
+variables are not set, the default proxy handling from bazel (automatically
+picking up variables like `HTTP_PROXY`) applies.
+
 **NOTE:** `container_pull` is suspected to have thread safety issues. To
 ensure multiple `container_pull`(s) don't execute concurrently, please use the
 bazel startup flag `--loading_phase_threads=1` in your bazel invocation.

--- a/container/go/cmd/puller/puller.go
+++ b/container/go/cmd/puller/puller.go
@@ -134,6 +134,20 @@ func main() {
 		Features:     strings.Fields(*features),
 	}
 
+	// check if http proxy solely for container pulls is defined
+	if httpPullProxy := ospkg.Getenv("CONTAINER_PULL_HTTP_PROXY"); httpPullProxy != "" {
+		err := ospkg.Setenv("HTTP_PROXY", httpPullProxy)
+		if err != nil {
+			log.Fatalf("Could not set HTTP_PROXY environment variable: %v", err)
+		}
+	}
+	if httpsPullProxy := ospkg.Getenv("CONTAINER_PULL_HTTPS_PROXY"); httpsPullProxy != "" {
+		err := ospkg.Setenv("HTTPS_PROXY", httpsPullProxy)
+		if err != nil {
+			log.Fatalf("Could not set HTTPS_PROXY environment variable: %v", err)
+		}
+	}
+
 	dur := time.Duration(*timeout) * time.Second
 	t := &http.Transport{
 		Dial: func(network, addr string) (net.Conn, error) {

--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -244,6 +244,8 @@ container_pull = repository_rule(
     attrs = _container_pull_attrs,
     implementation = _impl,
     environ = [
+        "CONTAINER_PULL_HTTP_PROXY",
+        "CONTAINER_PULL_HTTPS_PROXY",
         "DOCKER_REPO_CACHE",
         "HOME",
         "PULLER_TIMEOUT",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: related to #1664

In order to support proxy-mirrors for various container registries, one can configure http proxies for various container runtimes like docker or cri-o by simply exporting `HTTP_PROXY` and `HTTPS_PROXY`. This is for instance more powerful than explicitly defining mirror repositories for the docker runtime, like described in #1664 and allows the usage of mirrors like https://github.com/rpardini/docker-registry-proxy. We use this in kubevirt as a general precaution to protect our CI system from outages and disappearing images from various registries.

The puller right now already picks up `HTTP_PROXY` and `HTTPS_PROXY`, but this is now a all-or-nothing knob for bazel. One can't tell bazel to use the proxy only for image pulls and ignore it for the rest.

## What is the new behavior?

Add `CONTAINER_PULL_HTTP_PROXY` and `CONTAINER_PULL_HTTPS_PROXY` env variables which can be set in a bazelrc file via action envs, without interfering with the rest of bazel.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

