### PR TITLE
replace "tar A" with more portable command

### DIFF
--- a/docker/toolchain_container/toolchain_container.bzl
+++ b/docker/toolchain_container/toolchain_container.bzl
@@ -145,8 +145,7 @@ def _language_tool_layer_impl(
         ctx.actions.run_shell(
             inputs = installables_tars,
             outputs = [final_installables_tar],
-            command = "tar cvf {output_tar} --files-from /dev/null && \
-        for i in {input_tars}; do tar A --file={output_tar} $i; done".format(
+            command = "cat {input_tars} > {output_tar}".format(
                 output_tar = final_installables_tar.path,
                 input_tars = " ".join(installables_tars_paths),
             ),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Tests fail on OSX with this message:
```
Usage:
  List:    tar -tf <archive-filename>
  Extract: tar -xf <archive-filename>
  Create:  tar -cf <archive-filename> [filenames...]
  Help:    tar --help
```

BSD `tar` doesn't seem to have `-A`. But `tar` archives are just concatenatable, so I think `cat` is enough here

Issue Number: N/A


## What is the new behavior?
```
bazel test tests/docker/package_managers/...
```
now passes on my laptop

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

