### PR TITLE
make downloading and installing quieter

### DIFF
--- a/docker/package_managers/download_pkgs.bzl
+++ b/docker/package_managers/download_pkgs.bzl
@@ -27,19 +27,19 @@ def _generate_add_additional_repo_commands(ctx, additional_repos):
 
 def _generate_download_commands(ctx, packages, additional_repos):
     return """#!/usr/bin/env bash
-set -ex
+set -e
 {add_additional_repo_commands}
 # Remove /var/lib/apt/lists/* in the base image. apt-get update -y command will create them.
 rm -rf /var/lib/apt/lists/*
 # Fetch Index
-apt-get update -y
+apt-get update -y -qq
 # Make partial dir
 mkdir -p /tmp/install/./partial
 # Install command
-apt-get install --no-install-recommends -y -q -o Dir::Cache="/tmp/install" -o Dir::Cache::archives="." {packages} --download-only
+apt-get install --no-install-recommends -y -qq -o Dir::Cache="/tmp/install" -o Dir::Cache::archives="." {packages} --download-only
 
 items=$(ls /tmp/install/*.deb)
-if [ $items = "" ]; then
+if [ -z "$items" ]; then
     echo "Did not find the .deb files for debian packages {packages} in /tmp/install. Did apt-get actually succeed?" && false
 fi
 # Generate csv listing the name & versions of the debian packages.
@@ -47,11 +47,9 @@ fi
 # Name,Version
 # gcc,7.1
 # clang,9.1
-echo "Generating metadata CSV file {installables}_metadata.csv"
 echo Name,Version > {installables}_metadata.csv
 dpkg_deb_path=$(which dpkg-deb)
 for item in $items; do
-    echo "Adding information about $item to metadata CSV"
     pkg_name=$($dpkg_deb_path -f $item Package)
     if [ $pkg_name = "" ]; then
         echo "Failed to get name of the package for $item" && false
@@ -60,7 +58,6 @@ for item in $items; do
     if [ $pkg_version = "" ]; then
         echo "Failed to get the version of the package for $item" && false
     fi
-    echo "Package $pkg_name, Version $pkg_version"
     echo -n "$pkg_name," >> {installables}_metadata.csv
     echo $pkg_version >> {installables}_metadata.csv
 done;

--- a/docker/package_managers/installer.sh.tpl
+++ b/docker/package_managers/installer.sh.tpl
@@ -2,7 +2,7 @@
 # This script installs debs in installables.tar through dpkg and apt-get.
 # It expects to be volume-mounted inside a docker image, in /tmp/pkginstall
 # along with the installables.tar.
-set -ex
+set -e
 pushd /tmp/pkginstall
 %{install_commands}
 popd

--- a/docker/package_managers/run_download.sh.tpl
+++ b/docker/package_managers/run_download.sh.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 function guess_runfiles() {
     if [ -d ${BASH_SOURCE[0]}.runfiles ]; then

--- a/docker/package_managers/run_install.sh.tpl
+++ b/docker/package_managers/run_install.sh.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 # Resolve the docker tool path
 DOCKER="%{docker_tool_path}"

--- a/docker/util/commit_layer.sh.tpl
+++ b/docker/util/commit_layer.sh.tpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 # Load utils
 source %{util_script}

--- a/docker/util/extract.sh.tpl
+++ b/docker/util/extract.sh.tpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 # Resolve the docker tool path
 DOCKER="%{docker_tool_path}"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Using these two rules is very loud and spammy in my terminal. Before my change, you get this:
```
$ bazel test //tests/docker/package_managers:gpg_test
<some stuff from this repo that doesn't affect people who just use this rule>
INFO: From Action external/debian9/builder_output_tar.tar:
++ guess_runfiles
++ '[' -d bazel-out/darwin-fastbuild/bin/external/debian9/builder_script.sh.runfiles ']'
++++ dirname bazel-out/darwin-fastbuild/bin/external/debian9/builder_script.sh
+++ cd bazel-out/darwin-fastbuild/bin/external/debian9
+++ pwd
++ mydir=/private/var/tmp/_bazel_paul.tarjan/6f5fd31832ce262640c512a62fb62896/sandbox/darwin-sandbox/2002/execroot/io_bazel_rules_docker/bazel-out/darwin-fastbuild/bin/external/debian9
++ echo /private/var/tmp/_bazel_paul.tarjan/6f5fd31832ce262640c512a62fb62896/sandbox/darwin-sandbox/2002/execroot/io_bazel_rules_docker/bazel-out/darwin-fastbuild/bin/external/debian9
++ sed -e 's|\(.*\.runfiles\)/.*|\1|'
+ RUNFILES=/private/var/tmp/_bazel_paul.tarjan/6f5fd31832ce262640c512a62fb62896/sandbox/darwin-sandbox/2002/execroot/io_bazel_rules_docker/bazel-out/darwin-fastbuild/bin/external/debian9
+ DOCKER=/usr/local/bin/docker
+ DOCKER_FLAGS=
+ [[ -z /usr/local/bin/docker ]]
++ bazel-out/host/bin/contrib/extract_image_id bazel-out/darwin-fastbuild/bin/external/debian_base/image/image.tar
+ image_id=6786f6a45544215e9e4411db2318c7f561009b38fcf7c88f2f5f656256ba72f8
+ /usr/local/bin/docker load -i bazel-out/darwin-fastbuild/bin/external/debian_base/image/image.tar
++ /usr/local/bin/docker run -w=/ -d --privileged 6786f6a45544215e9e4411db2318c7f561009b38fcf7c88f2f5f656256ba72f8 sh -c '#!/usr/bin/env bash
set -ex
printf "" >> /etc/apt/sources.list.d/builder_repos.list
# Remove /var/lib/apt/lists/* in the base image. apt-get update -y command will create them.
rm -rf /var/lib/apt/lists/*
# Fetch Index
apt-get update -y
# Make partial dir
mkdir -p /tmp/install/./partial
# Install command
apt-get install --no-install-recommends -y -q -o Dir::Cache="/tmp/install" -o Dir::Cache::archives="." debootstrap --download-only

items=$(ls /tmp/install/*.deb)
if [ $items = "" ]; then
    echo "Did not find the .deb files for debian packages debootstrap in /tmp/install. Did apt-get actually succeed?" && false
fi
# Generate csv listing the name & versions of the debian packages.
# Example contents of a metadata CSV with debian packages gcc 8.1 & clang 9.1:
# Name,Version
# gcc,7.1
# clang,9.1
echo "Generating metadata CSV file builder_metadata.csv"
echo Name,Version > builder_metadata.csv
dpkg_deb_path=$(which dpkg-deb)
for item in $items; do
    echo "Adding information about $item to metadata CSV"
    pkg_name=$($dpkg_deb_path -f $item Package)
    if [ $pkg_name = "" ]; then
        echo "Failed to get name of the package for $item" && false
    fi
    pkg_version=$($dpkg_deb_path -f $item Version)
    if [ $pkg_version = "" ]; then
        echo "Failed to get the version of the package for $item" && false
    fi
    echo "Package $pkg_name, Version $pkg_version"
    echo -n "$pkg_name," >> builder_metadata.csv
    echo $pkg_version >> builder_metadata.csv
done;
# Tar command to only include all the *.deb files and ignore other directories placed in the cache dir.
tar -cpf builder_packages.tar --mtime=1970-01-01 --directory /tmp/install/. `cd /tmp/install/. && ls *.deb`'
+ cid=0ceffa0c548af52d82056751c40519454e44432a6db225372471d49bd51b0224
+ /usr/local/bin/docker attach 0ceffa0c548af52d82056751c40519454e44432a6db225372471d49bd51b0224
+ mkdir -p /tmp/install/./partial
+ apt-get install --no-install-recommends -y -q -o Dir::Cache=/tmp/install -o Dir::Cache::archives=. debootstrap --download-only
+ ls /tmp/install/debootstrap_1.0.89_all.deb /tmp/install/libffi6_3.2.1-6_amd64.deb /tmp/install/libgmp10_2%3a6.1.2+dfsg-1_amd64.deb /tmp/install/libgnutls30_3.5.8-5+deb9u5_amd64.deb /tmp/install/libhogweed4_3.3-1+b2_amd64.deb /tmp/install/libidn11_1.33-1+deb9u1_amd64.deb /tmp/install/libidn2-0_0.16-1+deb9u1_amd64.deb /tmp/install/libnettle6_3.3-1+b2_amd64.deb /tmp/install/libp11-kit0_0.23.3-2+deb9u1_amd64.deb /tmp/install/libpsl5_0.17.0-3_amd64.deb /tmp/install/libtasn1-6_4.10-1.1+deb9u1_amd64.deb /tmp/install/libunistring0_0.9.6+really0.9.3-0.1_amd64.deb /tmp/install/wget_1.18-5+deb9u3_amd64.deb
+ items=/tmp/install/debootstrap_1.0.89_all.deb
/tmp/install/libffi6_3.2.1-6_amd64.deb
/tmp/install/libgmp10_2%3a6.1.2+dfsg-1_amd64.deb
/tmp/install/libgnutls30_3.5.8-5+deb9u5_amd64.deb
/tmp/install/libhogweed4_3.3-1+b2_amd64.deb
/tmp/install/libidn11_1.33-1+deb9u1_amd64.deb
/tmp/install/libidn2-0_0.16-1+deb9u1_amd64.deb
/tmp/install/libnettle6_3.3-1+b2_amd64.deb
/tmp/install/libp11-kit0_0.23.3-2+deb9u1_amd64.deb
/tmp/install/libpsl5_0.17.0-3_amd64.deb
/tmp/install/libtasn1-6_4.10-1.1+deb9u1_amd64.deb
/tmp/install/libunistring0_0.9.6+really0.9.3-0.1_amd64.deb
/tmp/install/wget_1.18-5+deb9u3_amd64.deb
+ [ /tmp/install/debootstrap_1.0.89_all.deb /tmp/install/libffi6_3.2.1-6_amd64.deb /tmp/install/libgmp10_2%3a6.1.2+dfsg-1_amd64.deb /tmp/install/libgnutls30_3.5.8-5+deb9u5_amd64.deb /tmp/install/libhogweed4_3.3-1+b2_amd64.deb /tmp/install/libidn11_1.33-1+deb9u1_amd64.deb /tmp/install/libidn2-0_0.16-1+deb9u1_amd64.deb /tmp/install/libnettle6_3.3-1+b2_amd64.deb /tmp/install/libp11-kit0_0.23.3-2+deb9u1_amd64.deb /tmp/install/libpsl5_0.17.0-3_amd64.deb /tmp/install/libtasn1-6_4.10-1.1+deb9u1_amd64.deb /tmp/install/libunistring0_0.9.6+really0.9.3-0.1_amd64.deb /tmp/install/wget_1.18-5+deb9u3_amd64.deb =  ]
sh: 14: [: /tmp/install/debootstrap_1.0.89_all.deb: unexpected operator
+ echo Generating metadata CSV file builder_metadata.csv
+ echo Name,Version
+ which dpkg-deb
+ dpkg_deb_path=/usr/bin/dpkg-deb
+ echo Adding information about /tmp/install/debootstrap_1.0.89_all.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/debootstrap_1.0.89_all.deb Package
+ pkg_name=debootstrap
+ [ debootstrap =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/debootstrap_1.0.89_all.deb Version
+ pkg_version=1.0.89
+ [ 1.0.89 =  ]
+ echo Package debootstrap, Version 1.0.89
+ echo -n debootstrap,
+ echo 1.0.89
+ echo Adding information about /tmp/install/libffi6_3.2.1-6_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/libffi6_3.2.1-6_amd64.deb Package
+ pkg_name=libffi6
+ [ libffi6 =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/libffi6_3.2.1-6_amd64.deb Version
+ pkg_version=3.2.1-6
+ [ 3.2.1-6 =  ]
+ echo Package libffi6, Version 3.2.1-6
+ echo -n libffi6,
+ echo 3.2.1-6
+ echo Adding information about /tmp/install/libgmp10_2%3a6.1.2+dfsg-1_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/libgmp10_2%3a6.1.2+dfsg-1_amd64.deb Package
+ pkg_name=libgmp10
+ [ libgmp10 =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/libgmp10_2%3a6.1.2+dfsg-1_amd64.deb Version
+ pkg_version=2:6.1.2+dfsg-1
+ [ 2:6.1.2+dfsg-1 =  ]
+ echo Package libgmp10, Version 2:6.1.2+dfsg-1
+ echo -n libgmp10,
+ echo 2:6.1.2+dfsg-1
+ echo Adding information about /tmp/install/libgnutls30_3.5.8-5+deb9u5_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/libgnutls30_3.5.8-5+deb9u5_amd64.deb Package
+ pkg_name=libgnutls30
+ [ libgnutls30 =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/libgnutls30_3.5.8-5+deb9u5_amd64.deb Version
+ pkg_version=3.5.8-5+deb9u5
+ [ 3.5.8-5+deb9u5 =  ]
+ echo Package libgnutls30, Version 3.5.8-5+deb9u5
+ echo -n libgnutls30,
+ echo 3.5.8-5+deb9u5
+ echo Adding information about /tmp/install/libhogweed4_3.3-1+b2_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/libhogweed4_3.3-1+b2_amd64.deb Package
+ pkg_name=libhogweed4
+ [ libhogweed4 =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/libhogweed4_3.3-1+b2_amd64.deb Version
+ pkg_version=3.3-1+b2
+ [ 3.3-1+b2 =  ]
+ echo Package libhogweed4, Version 3.3-1+b2
+ echo -n libhogweed4,
+ echo 3.3-1+b2
+ echo Adding information about /tmp/install/libidn11_1.33-1+deb9u1_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/libidn11_1.33-1+deb9u1_amd64.deb Package
+ pkg_name=libidn11
+ [ libidn11 =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/libidn11_1.33-1+deb9u1_amd64.deb Version
+ pkg_version=1.33-1+deb9u1
+ [ 1.33-1+deb9u1 =  ]
+ echo Package libidn11, Version 1.33-1+deb9u1
+ echo -n libidn11,
+ echo 1.33-1+deb9u1
+ echo Adding information about /tmp/install/libidn2-0_0.16-1+deb9u1_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/libidn2-0_0.16-1+deb9u1_amd64.deb Package
+ pkg_name=libidn2-0
+ [ libidn2-0 =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/libidn2-0_0.16-1+deb9u1_amd64.deb Version
+ pkg_version=0.16-1+deb9u1
+ [ 0.16-1+deb9u1 =  ]
+ echo Package libidn2-0, Version 0.16-1+deb9u1
+ echo -n libidn2-0,
+ echo 0.16-1+deb9u1
+ echo Adding information about /tmp/install/libnettle6_3.3-1+b2_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/libnettle6_3.3-1+b2_amd64.deb Package
+ pkg_name=libnettle6
+ [ libnettle6 =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/libnettle6_3.3-1+b2_amd64.deb Version
+ pkg_version=3.3-1+b2
+ [ 3.3-1+b2 =  ]
+ echo Package libnettle6, Version 3.3-1+b2
+ echo -n libnettle6,
+ echo 3.3-1+b2
+ echo Adding information about /tmp/install/libp11-kit0_0.23.3-2+deb9u1_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/libp11-kit0_0.23.3-2+deb9u1_amd64.deb Package
+ pkg_name=libp11-kit0
+ [ libp11-kit0 =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/libp11-kit0_0.23.3-2+deb9u1_amd64.deb Version
+ pkg_version=0.23.3-2+deb9u1
+ [ 0.23.3-2+deb9u1 =  ]
+ echo Package libp11-kit0, Version 0.23.3-2+deb9u1
+ echo -n libp11-kit0,
+ echo 0.23.3-2+deb9u1
+ echo Adding information about /tmp/install/libpsl5_0.17.0-3_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/libpsl5_0.17.0-3_amd64.deb Package
+ pkg_name=libpsl5
+ [ libpsl5 =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/libpsl5_0.17.0-3_amd64.deb Version
+ pkg_version=0.17.0-3
+ [ 0.17.0-3 =  ]
+ echo Package libpsl5, Version 0.17.0-3
+ echo -n libpsl5,
+ echo 0.17.0-3
+ echo Adding information about /tmp/install/libtasn1-6_4.10-1.1+deb9u1_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/libtasn1-6_4.10-1.1+deb9u1_amd64.deb Package
+ pkg_name=libtasn1-6
+ [ libtasn1-6 =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/libtasn1-6_4.10-1.1+deb9u1_amd64.deb Version
+ pkg_version=4.10-1.1+deb9u1
+ [ 4.10-1.1+deb9u1 =  ]
+ echo Package libtasn1-6, Version 4.10-1.1+deb9u1
+ echo -n libtasn1-6,
+ echo 4.10-1.1+deb9u1
+ echo Adding information about /tmp/install/libunistring0_0.9.6+really0.9.3-0.1_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/libunistring0_0.9.6+really0.9.3-0.1_amd64.deb Package
+ pkg_name=libunistring0
+ [ libunistring0 =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/libunistring0_0.9.6+really0.9.3-0.1_amd64.deb Version
+ pkg_version=0.9.6+really0.9.3-0.1
+ [ 0.9.6+really0.9.3-0.1 =  ]
+ echo Package libunistring0, Version 0.9.6+really0.9.3-0.1
+ echo -n libunistring0,
+ echo 0.9.6+really0.9.3-0.1
+ echo Adding information about /tmp/install/wget_1.18-5+deb9u3_amd64.deb to metadata CSV
+ /usr/bin/dpkg-deb -f /tmp/install/wget_1.18-5+deb9u3_amd64.deb Package
+ pkg_name=wget
+ [ wget =  ]
+ /usr/bin/dpkg-deb -f /tmp/install/wget_1.18-5+deb9u3_amd64.deb Version
+ pkg_version=1.18-5+deb9u3
+ [ 1.18-5+deb9u3 =  ]
+ echo Package wget, Version 1.18-5+deb9u3
+ echo -n wget,
+ echo 1.18-5+deb9u3
+ cd /tmp/install/.
+ ls debootstrap_1.0.89_all.deb libffi6_3.2.1-6_amd64.deb libgmp10_2%3a6.1.2+dfsg-1_amd64.deb libgnutls30_3.5.8-5+deb9u5_amd64.deb libhogweed4_3.3-1+b2_amd64.deb libidn11_1.33-1+deb9u1_amd64.deb libidn2-0_0.16-1+deb9u1_amd64.deb libnettle6_3.3-1+b2_amd64.deb libp11-kit0_0.23.3-2+deb9u1_amd64.deb libpsl5_0.17.0-3_amd64.deb libtasn1-6_4.10-1.1+deb9u1_amd64.deb libunistring0_0.9.6+really0.9.3-0.1_amd64.deb wget_1.18-5+deb9u3_amd64.deb
+ tar -cpf builder_packages.tar --mtime=1970-01-01 --directory /tmp/install/. debootstrap_1.0.89_all.deb libffi6_3.2.1-6_amd64.deb libgmp10_2%3a6.1.2+dfsg-1_amd64.deb libgnutls30_3.5.8-5+deb9u5_amd64.deb libhogweed4_3.3-1+b2_amd64.deb libidn11_1.33-1+deb9u1_amd64.deb libidn2-0_0.16-1+deb9u1_amd64.deb libnettle6_3.3-1+b2_amd64.deb libp11-kit0_0.23.3-2+deb9u1_amd64.deb libpsl5_0.17.0-3_amd64.deb libtasn1-6_4.10-1.1+deb9u1_amd64.deb libunistring0_0.9.6+really0.9.3-0.1_amd64.deb wget_1.18-5+deb9u3_amd64.deb
+ /usr/local/bin/docker cp 0ceffa0c548af52d82056751c40519454e44432a6db225372471d49bd51b0224:builder_packages.tar bazel-out/darwin-fastbuild/bin/external/debian9/builder_output_tar.tar
+ /usr/local/bin/docker cp 0ceffa0c548af52d82056751c40519454e44432a6db225372471d49bd51b0224:builder_metadata.csv bazel-out/darwin-fastbuild/bin/external/debian9/builder_metadata.csv
+ /usr/local/bin/docker rm 0ceffa0c548af52d82056751c40519454e44432a6db225372471d49bd51b0224
Loaded image: bazel/image:image
Get:1 http://security.debian.org stretch/updates InRelease [53.0 kB]
Ign:2 http://httpredir.debian.org/debian stretch InRelease
Get:3 http://httpredir.debian.org/debian stretch-updates InRelease [93.6 kB]
Get:4 http://security.debian.org stretch/updates/main amd64 Packages [843 kB]
Get:5 http://httpredir.debian.org/debian stretch Release [118 kB]
Get:6 http://httpredir.debian.org/debian stretch-updates/main amd64 Packages [2711 B]
Get:7 http://httpredir.debian.org/debian stretch Release.gpg [2410 B]
Get:8 http://httpredir.debian.org/debian stretch/main amd64 Packages [9610 kB]
Fetched 10.7 MB in 5s (1940 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libffi6 libgmp10 libgnutls30 libhogweed4 libidn11 libidn2-0 libnettle6
  libp11-kit0 libpsl5 libtasn1-6 libunistring0 wget
Suggested packages:
  gnutls-bin
Recommended packages:
  gnupg publicsuffix
The following NEW packages will be installed:
  debootstrap libffi6 libgmp10 libgnutls30 libhogweed4 libidn11 libidn2-0
  libnettle6 libp11-kit0 libpsl5 libtasn1-6 libunistring0 wget
0 upgraded, 13 newly installed, 0 to remove and 21 not upgraded.
Need to get 3023 kB of archives.
After this operation, 9111 kB of additional disk space will be used.
Get:1 http://security.debian.org stretch/updates/main amd64 libp11-kit0 amd64 0.23.3-2+deb9u1 [112 kB]
Get:2 http://httpredir.debian.org/debian stretch/main amd64 libgmp10 amd64 2:6.1.2+dfsg-1 [253 kB]
Get:3 http://httpredir.debian.org/debian stretch/main amd64 libnettle6 amd64 3.3-1+b2 [192 kB]
Get:4 http://httpredir.debian.org/debian stretch/main amd64 libhogweed4 amd64 3.3-1+b2 [136 kB]
Get:5 http://httpredir.debian.org/debian stretch/main amd64 libidn11 amd64 1.33-1+deb9u1 [115 kB]
Get:6 http://httpredir.debian.org/debian stretch/main amd64 libffi6 amd64 3.2.1-6 [20.4 kB]
Get:7 http://httpredir.debian.org/debian stretch/main amd64 libtasn1-6 amd64 4.10-1.1+deb9u1 [50.6 kB]
Get:8 http://httpredir.debian.org/debian stretch/main amd64 libgnutls30 amd64 3.5.8-5+deb9u5 [896 kB]
Get:9 http://httpredir.debian.org/debian stretch/main amd64 libunistring0 amd64 0.9.6+really0.9.3-0.1 [279 kB]
Get:10 http://httpredir.debian.org/debian stretch/main amd64 libidn2-0 amd64 0.16-1+deb9u1 [60.7 kB]
Get:11 http://httpredir.debian.org/debian stretch/main amd64 libpsl5 amd64 0.17.0-3 [41.8 kB]
Get:12 http://httpredir.debian.org/debian stretch/main amd64 wget amd64 1.18-5+deb9u3 [800 kB]
Get:13 http://httpredir.debian.org/debian stretch/main amd64 debootstrap all 1.0.89 [66.5 kB]
Fetched 3023 kB in 1s (1793 kB/s)
Download complete and in download only mode
Generating metadata CSV file builder_metadata.csv
Adding information about /tmp/install/debootstrap_1.0.89_all.deb to metadata CSV
Package debootstrap, Version 1.0.89
Adding information about /tmp/install/libffi6_3.2.1-6_amd64.deb to metadata CSV
Package libffi6, Version 3.2.1-6
Adding information about /tmp/install/libgmp10_2%3a6.1.2+dfsg-1_amd64.deb to metadata CSV
Package libgmp10, Version 2:6.1.2+dfsg-1
Adding information about /tmp/install/libgnutls30_3.5.8-5+deb9u5_amd64.deb to metadata CSV
Package libgnutls30, Version 3.5.8-5+deb9u5
Adding information about /tmp/install/libhogweed4_3.3-1+b2_amd64.deb to metadata CSV
Package libhogweed4, Version 3.3-1+b2
Adding information about /tmp/install/libidn11_1.33-1+deb9u1_amd64.deb to metadata CSV
Package libidn11, Version 1.33-1+deb9u1
Adding information about /tmp/install/libidn2-0_0.16-1+deb9u1_amd64.deb to metadata CSV
Package libidn2-0, Version 0.16-1+deb9u1
Adding information about /tmp/install/libnettle6_3.3-1+b2_amd64.deb to metadata CSV
Package libnettle6, Version 3.3-1+b2
Adding information about /tmp/install/libp11-kit0_0.23.3-2+deb9u1_amd64.deb to metadata CSV
Package libp11-kit0, Version 0.23.3-2+deb9u1
Adding information about /tmp/install/libpsl5_0.17.0-3_amd64.deb to metadata CSV
Package libpsl5, Version 0.17.0-3
Adding information about /tmp/install/libtasn1-6_4.10-1.1+deb9u1_amd64.deb to metadata CSV
Package libtasn1-6, Version 4.10-1.1+deb9u1
Adding information about /tmp/install/libunistring0_0.9.6+really0.9.3-0.1_amd64.deb to metadata CSV
Package libunistring0, Version 0.9.6+really0.9.3-0.1
Adding information about /tmp/install/wget_1.18-5+deb9u3_amd64.deb to metadata CSV
Package wget, Version 1.18-5+deb9u3
0ceffa0c548af52d82056751c40519454e44432a6db225372471d49bd51b0224
INFO: From Action external/debian9/builder-with-packages.tar.unstripped:
+ DOCKER=/usr/local/bin/docker
+ DOCKER_FLAGS=
+ [[ -z /usr/local/bin/docker ]]
+ TO_JSON_TOOL=bazel-out/host/bin/docker/util/to_json
+ source bazel-out/darwin-fastbuild/bin/external/debian9/image_util.sh
++ bazel-out/host/bin/contrib/extract_image_id bazel-out/darwin-fastbuild/bin/external/debian_base/image/image.tar
+ image_id=6786f6a45544215e9e4411db2318c7f561009b38fcf7c88f2f5f656256ba72f8
+ /usr/local/bin/docker load -i bazel-out/darwin-fastbuild/bin/external/debian_base/image/image.tar
++ mktemp -d
+ tmpdir=/var/folders/w7/tz80jp8n52zb9h3ltr6x2pyc0000gn/T/tmp.GSiuSENP
+ trap 'rm -rf /var/folders/w7/tz80jp8n52zb9h3ltr6x2pyc0000gn/T/tmp.GSiuSENP' EXIT
++ dirname /var/folders/w7/tz80jp8n52zb9h3ltr6x2pyc0000gn/T/tmp.GSiuSENP/bazel-out/darwin-fastbuild/bin/external/debian9/builder-packages.tar
+ mkdir -p /var/folders/w7/tz80jp8n52zb9h3ltr6x2pyc0000gn/T/tmp.GSiuSENP/bazel-out/darwin-fastbuild/bin/external/debian9
++ pwd
+ cp -L /private/var/tmp/_bazel_paul.tarjan/6f5fd31832ce262640c512a62fb62896/sandbox/darwin-sandbox/2003/execroot/io_bazel_rules_docker/bazel-out/darwin-fastbuild/bin/external/debian9/builder-packages.tar /var/folders/w7/tz80jp8n52zb9h3ltr6x2pyc0000gn/T/tmp.GSiuSENP/bazel-out/darwin-fastbuild/bin/external/debian9/builder-packages.tar
++ pwd
+ cp -L /private/var/tmp/_bazel_paul.tarjan/6f5fd31832ce262640c512a62fb62896/sandbox/darwin-sandbox/2003/execroot/io_bazel_rules_docker/bazel-out/darwin-fastbuild/bin/external/debian9/builder.install /var/folders/w7/tz80jp8n52zb9h3ltr6x2pyc0000gn/T/tmp.GSiuSENP/installer.sh
++ /usr/local/bin/docker volume create
+ vid=a2614ea550ac7516dc1ed0fff5545a7af19845e3bd44c81a05c8573690f8d6f1
++ /usr/local/bin/docker create -v a2614ea550ac7516dc1ed0fff5545a7af19845e3bd44c81a05c8573690f8d6f1:/tmp/pkginstall 6786f6a45544215e9e4411db2318c7f561009b38fcf7c88f2f5f656256ba72f8 /bin/true
+ cid=3afb2a9204ce79ab753c1db2e8f7724e12604a847e0c65b12a0a3ea835c45991
+ for f in $tmpdir/*
+ /usr/local/bin/docker cp /var/folders/w7/tz80jp8n52zb9h3ltr6x2pyc0000gn/T/tmp.GSiuSENP/bazel-out 3afb2a9204ce79ab753c1db2e8f7724e12604a847e0c65b12a0a3ea835c45991:/tmp/pkginstall
+ for f in $tmpdir/*
+ /usr/local/bin/docker cp /var/folders/w7/tz80jp8n52zb9h3ltr6x2pyc0000gn/T/tmp.GSiuSENP/installer.sh 3afb2a9204ce79ab753c1db2e8f7724e12604a847e0c65b12a0a3ea835c45991:/tmp/pkginstall
+ /usr/local/bin/docker rm 3afb2a9204ce79ab753c1db2e8f7724e12604a847e0c65b12a0a3ea835c45991
++ /usr/local/bin/docker run -d -v a2614ea550ac7516dc1ed0fff5545a7af19845e3bd44c81a05c8573690f8d6f1:/tmp/pkginstall --privileged 6786f6a45544215e9e4411db2318c7f561009b38fcf7c88f2f5f656256ba72f8 /tmp/pkginstall/installer.sh
+ cid=55be14cc878283fbba33371344ab4f3e05127223a9a1b415b0b130cf7e90b7c6
+ /usr/local/bin/docker attach 55be14cc878283fbba33371344ab4f3e05127223a9a1b415b0b130cf7e90b7c6
You cannot attach to a stopped container, start it first
+ true
+ reset_cmd 6786f6a45544215e9e4411db2318c7f561009b38fcf7c88f2f5f656256ba72f8 55be14cc878283fbba33371344ab4f3e05127223a9a1b415b0b130cf7e90b7c6 builder-with-packages
+ local original_image_name=6786f6a45544215e9e4411db2318c7f561009b38fcf7c88f2f5f656256ba72f8
+ local container_id=55be14cc878283fbba33371344ab4f3e05127223a9a1b415b0b130cf7e90b7c6
+ local output_image_name=builder-with-packages
+ DOCKER=/usr/local/bin/docker
+ DOCKER_FLAGS=
+ local old_cmd
++ /usr/local/bin/docker inspect -f '{{range .Config.Cmd}}{{.}} {{end}}' 6786f6a45544215e9e4411db2318c7f561009b38fcf7c88f2f5f656256ba72f8
+ old_cmd='/bin/sh -c /bin/bash '
++ echo '/bin/sh -c /bin/bash '
++ bazel-out/host/bin/docker/util/to_json
+ fmt_cmd='["/bin/sh", "-c", "/bin/bash"]'
+ '[' '["/bin/sh", "-c", "/bin/bash"]' == '' ']'
+ '[' '["/bin/sh", "-c", "/bin/bash"]' == '[]' ']'
+ /usr/local/bin/docker commit -c 'CMD ["/bin/sh", "-c", "/bin/bash"]' 55be14cc878283fbba33371344ab4f3e05127223a9a1b415b0b130cf7e90b7c6 builder-with-packages
+ /usr/local/bin/docker save builder-with-packages
+ /usr/local/bin/docker rm 55be14cc878283fbba33371344ab4f3e05127223a9a1b415b0b130cf7e90b7c6
+ /usr/local/bin/docker volume rm a2614ea550ac7516dc1ed0fff5545a7af19845e3bd44c81a05c8573690f8d6f1
+ rm -rf /var/folders/w7/tz80jp8n52zb9h3ltr6x2pyc0000gn/T/tmp.GSiuSENP
Loaded image: bazel/image:image
3afb2a9204ce79ab753c1db2e8f7724e12604a847e0c65b12a0a3ea835c45991
sha256:6e3ccbcaa4d4afd82247199dc733f293de1bc22de3989ea32963ea02fef6b36e
55be14cc878283fbba33371344ab4f3e05127223a9a1b415b0b130cf7e90b7c6
a2614ea550ac7516dc1ed0fff5545a7af19845e3bd44c81a05c8573690f8d6f1
INFO: From Action tests/docker/package_managers/gpg_image-trusted.gpg:
+ DOCKER=/usr/local/bin/docker
+ DOCKER_FLAGS=
+ [[ -z /usr/local/bin/docker ]]
++ bazel-out/host/bin/contrib/extract_image_id bazel-out/darwin-fastbuild/bin/tests/docker/package_managers/gpg_image.key.tar
+ image_id=80120fd8be53a0132f093eb1a4f4fb054bbd018b897e8813943c9d08f9ede853
+ /usr/local/bin/docker load -i bazel-out/darwin-fastbuild/bin/tests/docker/package_managers/gpg_image.key.tar
++ /usr/local/bin/docker run -d 80120fd8be53a0132f093eb1a4f4fb054bbd018b897e8813943c9d08f9ede853 sh -c 'apt-get update && apt-get install -y -q gnupg && for file in /gpg/*; do apt-key add $file; done'
+ id=4b91a6debaba35fb515611fb48305f3cc095aa2b6c8ae2a6bf5f40844cb87469
++ /usr/local/bin/docker wait 4b91a6debaba35fb515611fb48305f3cc095aa2b6c8ae2a6bf5f40844cb87469
+ retcode=0
+ '[' 0 '!=' 0 ']'
+ /usr/local/bin/docker cp 4b91a6debaba35fb515611fb48305f3cc095aa2b6c8ae2a6bf5f40844cb87469:/etc/apt/trusted.gpg bazel-out/darwin-fastbuild/bin/tests/docker/package_managers/gpg_image-trusted.gpg
+ /usr/local/bin/docker rm 4b91a6debaba35fb515611fb48305f3cc095aa2b6c8ae2a6bf5f40844cb87469
The image bazel/tests/docker/package_managers:gpg_image.key already exists, renaming the old one with ID sha256:c006dbf46bdb64c561b3b15bc2e3c7f0b976a44bcadb6a2dbbd11ca02a33bdd3 to empty string
Loaded image: bazel/tests/docker/package_managers:gpg_image.key
4b91a6debaba35fb515611fb48305f3cc095aa2b6c8ae2a6bf5f40844cb87469
Target //tests/docker/package_managers:gpg_test up-to-date:
  bazel-bin/tests/docker/package_managers/gpg_test
INFO: Elapsed time: 79.021s, Critical Path: 76.88s
INFO: 18 processes: 3 internal, 15 darwin-sandbox.
INFO: Build completed successfully, 18 total actions
//tests/docker/package_managers:gpg_test                                 PASSED in 18.6s

Executed 1 out of 1 test: 1 test passes.
INFO: Build completed successfully, 18 total actions
```
Issue Number: N/A


## What is the new behavior?
After my change you have this:
```
$ bazel test //tests/docker/package_managers:gpg_test
<some stuff from this repo that doesn't affect people who just use this rule>
Loaded image: bazel/image:image
8a1b2ead70b44cd1efbb3716b9ca1233fb67a9f64ac0fdd9bfb5a08839f42cec
Target //tests/docker/package_managers:gpg_test up-to-date:
  bazel-bin/tests/docker/package_managers/gpg_test
INFO: Elapsed time: 17.613s, Critical Path: 14.02s
INFO: 3 processes: 2 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 3 total actions
//tests/docker/package_managers:gpg_test                                  PASSED in 26.1s
```

I'm going to keep working on trying to figure out who is emitting those 2 extra lines but it is much better in this shape.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

