### PR TITLE
Allow passing command line arguments during `bazel run`

### DIFF
--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -264,7 +264,7 @@ def incremental_load(
         if run:
             # Args are embedded into the image, so omitted here.
             run_statements.append(
-                "\"${DOCKER}\" ${DOCKER_FLAGS} run %s %s" % (run_flags, tag_reference),
+                "\"${DOCKER}\" ${DOCKER_FLAGS} run %s %s \"$@\"" % (run_flags, tag_reference),
             )
 
     ctx.actions.expand_template(

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -40,6 +40,7 @@ load(
 )
 load("//d:image.bzl", "d_image")
 load("//docker:docker.bzl", "docker_push")
+load("//go:image.bzl", "go_image")
 load("//groovy:image.bzl", "groovy_image")
 load(
     "//java:image.bzl",
@@ -954,6 +955,14 @@ container_image(
     launcher = ":launcher",
     launcher_args = ["-env-append=CUSTOM_MESSAGE=Launched via launcher!"],
     legacy_run_behavior = False,
+)
+
+go_image(
+    name = "flag_image",
+    srcs = ["flag_main.go"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
 )
 
 d_image(

--- a/testdata/flag_main.go
+++ b/testdata/flag_main.go
@@ -1,0 +1,27 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main tells the linter to shut up.
+package main
+
+import (
+    "flag"
+    "fmt"
+)
+
+func main() {
+    arg := flag.String("arg", "", "Command line argument to print")
+    flag.Parse()
+    fmt.Println(*arg)
+}

--- a/testing/e2e/flag.sh
+++ b/testing/e2e/flag.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -ex
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+source ./testing/e2e/util.sh
+
+# Tests that the flags are passed correctly.
+
+# Must be invoked from the root of the repo.
+ROOT=$PWD
+
+function test_flag() {
+  cd "${ROOT}"
+  clear_docker
+  EXPECT_CONTAINS "$(bazel run testdata:flag_image -- -arg='Hello World!')" "Hello World!"
+}
+
+# Call function above
+test_flag

--- a/testing/e2e/test_flag.yaml
+++ b/testing/e2e/test_flag.yaml
@@ -1,0 +1,22 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests that verify flag passing
+
+steps:
+- name: "l.gcr.io/google/bazel"
+  entrypoint: "bash"
+  args:
+  - -c
+  - ./testing/e2e/flag.sh


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Closing issues: #1486 and #1441.

Currently any command-line arguments (except for `--norun`) to `bazel run` are ignored.

## What is the new behavior?
To maximize compatibility between `<lang>_binary` and `<lang>_image`, this PR allows passing command line arguments after `--` to `bazel run`.
For example, now `bazel run //path/to:my_image -- --arg1="hello world" --arg2="how are you?"`, will pass `--arg1` and `--arg2` to the end of the `docker run` command, which will in turn pass them to the binary.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

