### PR TITLE
update to latest buildifier

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,6 @@
 ---
 buildifier:
-  version: 0.22.0
+  version: 4.0.1
   # Check for issues with the format of our bazel config files.
   # All warnings from https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md
   # are enabled except:

--- a/container/bundle.bzl
+++ b/container/bundle.bzl
@@ -54,12 +54,12 @@ def _container_bundle_impl(ctx):
 
         layer = _get_layers(ctx, ctx.label.name, image_target_dict[target])
         images[tag] = layer
-        runfiles += [layer.get("config")]
-        runfiles += [layer.get("config_digest")]
+        runfiles.append(layer.get("config"))
+        runfiles.append(layer.get("config_digest"))
         runfiles += layer.get("unzipped_layer", [])
         runfiles += layer.get("diff_id", [])
         if layer.get("legacy"):
-            runfiles += [layer.get("legacy")]
+            runfiles.append(layer.get("legacy"))
 
     _incr_load(
         ctx,

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -164,11 +164,11 @@ def _add_create_image_config_args(
 
     if base_config:
         args.add("-baseConfig", base_config)
-        inputs += [base_config]
+        inputs.append(base_config)
 
     if base_manifest:
         args.add("-baseManifest", base_manifest)
-        inputs += [base_manifest]
+        inputs.append(base_manifest)
 
     if architecture:
         args.add("-architecture", architecture)

--- a/container/import.bzl
+++ b/container/import.bzl
@@ -76,10 +76,10 @@ def _container_import_impl(ctx):
     diff_ids = []
     for layer in ctx.files.layers:
         zipped, unzipped = _layer_pair(ctx, layer)
-        zipped_layers += [zipped]
-        unzipped_layers += [unzipped]
-        blobsums += [_sha256(ctx, zipped)]
-        diff_ids += [_sha256(ctx, unzipped)]
+        zipped_layers.append(zipped)
+        unzipped_layers.append(unzipped)
+        blobsums.append(_sha256(ctx, zipped))
+        diff_ids.append(_sha256(ctx, unzipped))
 
     manifest = None
     manifest_digest = None

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -95,7 +95,7 @@ def _impl(ctx):
     ))
 
     if ctx.attr.skip_unchanged_digest:
-        pusher_args += ["-skip-unchanged-digest"]
+        pusher_args.append("-skip-unchanged-digest")
     digester_args += ["--dst", str(ctx.outputs.digest.path), "--format", str(ctx.attr.format)]
     ctx.actions.run(
         inputs = digester_input,

--- a/contrib/compare_ids_test.bzl
+++ b/contrib/compare_ids_test.bzl
@@ -43,7 +43,7 @@ def _compare_ids_test_impl(ctx):
     tar_files = []
     for file in ctx.files.images:
         if file.short_path.endswith("tar"):
-            tar_files += [file]
+            tar_files.append(file)
 
     if (len(tar_files) == 0):
         fail("No images provided for test.")

--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -61,8 +61,8 @@ def _impl(ctx):
             is_executable = True,
         )
 
-        scripts += [out]
-        runfiles += [out]
+        scripts.append(out)
+        runfiles.append(out)
         runfiles += pusher_inputs
 
     ctx.actions.expand_template(

--- a/skylib/path.bzl
+++ b/skylib/path.bzl
@@ -59,7 +59,7 @@ def canonicalize(path):
 
     # Strip ./ from the beginning if specified.
     # There is no way to handle .// correctly (no function that would make
-    # that possible and Skylark is not turing complete) so just consider it
+    # that possible and Starlark is not turing complete) so just consider it
     # as an absolute path. A path of / should preserve the entire
     # path up to the repository root.
 

--- a/tests/contrib/automatic_container_release/BUILD
+++ b/tests/contrib/automatic_container_release/BUILD
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])  # Apache 2.0
-
 load(
     "@bazel_tools//tools/build_rules:test_rules.bzl",
     "file_test",
@@ -24,6 +22,8 @@ load(
 )
 load("//contrib/automatic_container_release:metadata_merge.bzl", "metadata_merge")
 load("//contrib/automatic_container_release:packages_metadata.bzl", "packages_metadata")
+
+licenses(["notice"])  # Apache 2.0
 
 configs_test(
     name = "configs_test",

--- a/tests/docker/package_managers/BUILD
+++ b/tests/docker/package_managers/BUILD
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
-
 load(
     "@bazel_tools//tools/build_rules:test_rules.bzl",
     "file_test",
@@ -24,6 +22,8 @@ load("//contrib:test.bzl", "container_test")
 load("//docker/package_managers:apt_key.bzl", "add_apt_key")
 load("//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("//docker/package_managers:install_pkgs.bzl", "install_pkgs")
+
+package(default_visibility = ["//visibility:public"])
 
 download_pkgs(
     name = "test_download_pkgs",


### PR DESCRIPTION
0.22.0 is too old to run under the arguments passed by Bazel CI as of https://github.com/bazelbuild/continuous-integration/commit/15fbac414e5065bff3b46e2ace5e119c4704a72c