### PR TITLE
Fixed broken `//tests/docker/util:all` tests

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -205,10 +205,6 @@ platforms:
     - "..."
     # tests/docker/security require gcloud setup to access asci-toolchains images
     - "-//tests/docker/security/..."
-    # Failing with
-    # Unable to load docker image from bazel-out/k8-fastbuild/bin/tests/docker/util/test_container_commit.build: archive/tar: invalid tar header
-    # TODO(alexeagle): re-enable after investigating
-    - "-//tests/docker/util:all"
     # contrib targets are not compatible with remote exec
     - "-//tests/contrib:derivative_with_volume_repro_test"
     - "-//tests/contrib:random_file_img_non_repro_test"
@@ -231,10 +227,6 @@ platforms:
     - "//tests/..."
     # tests/docker/security require gcloud setup to access asci-toolchains images
     - "-//tests/docker/security/..."
-    # Failing with
-    # Unable to load docker image from bazel-out/k8-fastbuild/bin/tests/docker/util/test_container_commit.build: archive/tar: invalid tar header
-    # TODO(alexeagle): re-enable after investigating
-    - "-//tests/docker/util:all"
     # contrib tests are not compatible with remote exec
     - "-//tests/contrib:derivative_with_volume_repro_test"
     - "-//tests/contrib:random_file_img_non_repro_test"

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -120,10 +120,8 @@ def get_from_target(ctx, name, attr_target, file_target = None):
     else:
         if not hasattr(attr_target, "files"):
             return {}
-        tar_files = [file for file in attr_target.files.to_list() if file.extension == "tar"]
-        if len(tar_files) != 1:
-            fail("Expected a list of 1 `.tar` file, got: {}".format(tar_files))
-        return _extract_layers(ctx, name, tar_files[0])
+        target = attr_target.files.to_list()[0]
+        return _extract_layers(ctx, name, target)
 
 def _add_join_layers_args(args, inputs, images):
     """Add args & inputs needed to call the Go join_layers for the given images

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -120,8 +120,10 @@ def get_from_target(ctx, name, attr_target, file_target = None):
     else:
         if not hasattr(attr_target, "files"):
             return {}
-        target = attr_target.files.to_list()[0]
-        return _extract_layers(ctx, name, target)
+        tar_files = [file for file in attr_target.files.to_list() if file.extension == "tar"]
+        if len(tar_files) != 1:
+            fail("Expected a list of 1 `.tar` file, got: {}".format(tar_files))
+        return _extract_layers(ctx, name, tar_files[0])
 
 def _add_join_layers_args(args, inputs, images):
     """Add args & inputs needed to call the Go join_layers for the given images

--- a/docker/util/run.bzl
+++ b/docker/util/run.bzl
@@ -266,9 +266,11 @@ _commit_attrs = {
         allow_files = True,
     ),
 }
+
+# @unsorted-dict-items
 _commit_outputs = {
-    "build": "%{name}.build",
     "out": "%{name}_commit.tar",
+    "build": "%{name}.build",
 }
 
 container_run_and_commit = rule(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

[RBE](https://buildkite.com/bazel/rules-docker-docker/builds/5287#2e3a558e-5267-4540-93b5-bf2f19ae14ab) builds are currently failing when testing `//tests/docker/util:all` with the following error
```
(20:05:17) ERROR: /workdir/tests/docker/util/BUILD:89:16: ExtractConfig tests/docker/util/test_container_commit_image.test_container_commit.build.config failed: (Exit 1): extract_config failed: error executing command
  (cd /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/execroot/io_bazel_rules_docker && \
  exec env - \
  bazel-out/host/bin/container/go/cmd/extract_config/extract_config_/extract_config -imageTar bazel-out/k8-fastbuild/bin/tests/docker/util/test_container_commit.build -outputConfig bazel-out/k8-fastbuild/bin/tests/docker/util/test_container_commit_image.test_container_commit.build.config -outputManifest bazel-out/k8-fastbuild/bin/tests/docker/util/test_container_commit_image.test_container_commit.build.manifest)
Execution platform: @buildkite_config//config:platform
2021/04/24 20:05:17 Unable to load docker image from bazel-out/k8-fastbuild/bin/tests/docker/util/test_container_commit.build: archive/tar: invalid tar header
```

## What is the new behavior?

This PR introduces the fix for this.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

