### PR TITLE
Update go-containerregsitry dependency to 0.4.1

### DIFF
--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -37,11 +37,8 @@ def go_deps():
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(
             name = "com_github_google_go_containerregistry",
-            urls = ["https://api.github.com/repos/google/go-containerregistry/tarball/8a2841911ffee4f6892ca0083e89752fb46c48dd"],  # v0.1.4
-            strip_prefix = "google-go-containerregistry-8a28419",
-            sha256 = "cadb09cb5bcbe00688c73d716d1c9e774d6e4959abec4c425a1b995faf33e964",
+            commit = "efb2d62d93a7705315b841d0544cb5b13565ff2a",
             importpath = "github.com/google/go-containerregistry",
-            type = "tar.gz",
         )
     if "com_github_pkg_errors" not in excludes:
         go_repository(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [n] Tests for the changes have been added (for bug fixes / features)
- [n] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1814


## What is the new behavior?

This updates the go-containerregistry dependency from [0.1.4](https://github.com/google/go-containerregistry/releases/tag/v0.1.4) (October 2020) to [0.4.1](https://github.com/google/go-containerregistry/releases/tag/v0.4.1) (March 2021)

This removes a dependency on a non-deterministic package resulting in inconsistent archive SHAs generated by GitHub's archive server. That upstream issue was also fixed in https://github.com/kubernetes/kubernetes/issues/99376.

Other than removing this non-determinism, no major functional changes are expected. Some performance improvements and bugfixes have been added since 0.1.4, which might be beneficial.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

