### PR TITLE
Propagate tags to app-layers in docker images for all langs

### DIFF
--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -85,12 +85,12 @@ def cc_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
         fail("kwarg does nothing when binary is specified", "deps")
 
     base = base or DEFAULT_BASE
+    tags = kwargs.get("tags", None)
     for index, dep in enumerate(layers):
-        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary)
+        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep, tags = tags)
+        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary, tags = tags)
 
     visibility = kwargs.get("visibility", None)
-    tags = kwargs.get("tags", None)
     app_layer(
         name = name,
         base = base,

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -54,12 +54,12 @@ def d_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
         fail("kwarg does nothing when binary is specified", "deps")
 
     base = base or DEFAULT_BASE
+    tags = kwargs.get("tags", None)
     for index, dep in enumerate(layers):
-        base = app_layer(name = "%s_%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s_%d-symlinks" % (name, index), base = base, dep = dep, binary = binary)
+        base = app_layer(name = "%s_%d" % (name, index), base = base, dep = dep, tags = tags)
+        base = app_layer(name = "%s_%d-symlinks" % (name, index), base = base, dep = dep, binary = binary, tags = tags)
 
     visibility = kwargs.get("visibility", None)
-    tags = kwargs.get("tags", None)
     app_layer(
         name = name,
         base = base,

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -112,12 +112,12 @@ def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
     if not base:
         base = STATIC_DEFAULT_BASE if kwargs.get("pure") == "on" else DEFAULT_BASE
 
+    tags = kwargs.get("tags", None)
     for index, dep in enumerate(layers):
-        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary)
+        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep, tags = tags)
+        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary, tags = tags)
 
     visibility = kwargs.get("visibility", None)
-    tags = kwargs.get("tags", None)
     restricted_to = kwargs.get("restricted_to", None)
     compatible_with = kwargs.get("compatible_with", None)
     app_layer(

--- a/groovy/image.bzl
+++ b/groovy/image.bzl
@@ -72,14 +72,14 @@ def groovy_image(
 
     index = 0
     base = base or DEFAULT_JAVA_BASE
+    tags = kwargs.get("tags", None)
     for dep in layers:
         this_name = "%s.%d" % (name, index)
-        jar_dep_layer(name = this_name, base = base, dep = dep)
+        jar_dep_layer(name = this_name, base = base, dep = dep, tags = tags)
         base = this_name
         index += 1
 
     visibility = kwargs.get("visibility", None)
-    tags = kwargs.get("tags", None)
     jar_app_layer(
         name = name,
         base = base,

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -420,13 +420,13 @@ def war_image(name, base = None, deps = [], layers = [], **kwargs):
     native.java_library(name = library_name, deps = deps + layers, **kwargs)
 
     base = base or DEFAULT_JETTY_BASE
+    tags = kwargs.get("tags", None)
     for index, dep in enumerate(layers):
         this_name = "%s.%d" % (name, index)
-        _war_dep_layer(name = this_name, base = base, dep = dep)
+        _war_dep_layer(name = this_name, base = base, dep = dep, tags = tags)
         base = this_name
 
     visibility = kwargs.get("visibility", None)
-    tags = kwargs.get("tags", None)
     _war_app_layer(
         name = name,
         base = base,

--- a/kotlin/image.bzl
+++ b/kotlin/image.bzl
@@ -71,14 +71,14 @@ def kt_jvm_image(
 
     index = 0
     base = base or DEFAULT_JAVA_BASE
+    tags = kwargs.get("tags", None)
     for dep in layers:
         this_name = "%s.%d" % (name, index)
-        jar_dep_layer(name = this_name, base = base, dep = dep)
+        jar_dep_layer(name = this_name, base = base, dep = dep, tags = tags)
         base = this_name
         index += 1
 
     visibility = kwargs.get("visibility", None)
-    tags = kwargs.get("tags", None)
     jar_app_layer(
         name = name,
         base = base,

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -108,11 +108,11 @@ def py_image(name, base = None, deps = [], layers = [], **kwargs):
     # TODO(mattmoor): Consider making the directory into which the app
     # is placed configurable.
     base = base or DEFAULT_BASE
-    for index, dep in enumerate(layers):
-        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary_name)
-    visibility = kwargs.get("visibility", None)
     tags = kwargs.get("tags", None)
+    for index, dep in enumerate(layers):
+        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep, tags = tags)
+        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary_name, tags = tags)
+    visibility = kwargs.get("visibility", None)
     app_layer(
         name = name,
         base = base,

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -103,12 +103,12 @@ def py3_image(name, base = None, deps = [], layers = [], **kwargs):
     # TODO(mattmoor): Consider making the directory into which the app
     # is placed configurable.
     base = base or DEFAULT_BASE
+    tags = kwargs.get("tags", None)
     for index, dep in enumerate(layers):
-        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary_name)
+        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep, tags = tags)
+        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary_name, tags = tags)
 
     visibility = kwargs.get("visibility", None)
-    tags = kwargs.get("tags", None)
     app_layer(
         name = name,
         base = base,

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -54,12 +54,12 @@ def rust_image(name, base = None, deps = [], layers = [], binary = None, **kwarg
         fail("kwarg does nothing when binary is specified", "deps")
 
     base = base or DEFAULT_BASE
+    tags = kwargs.get("tags", None)
     for index, dep in enumerate(layers):
-        base = app_layer(name = "%s_%d" % (name, index), base = base, dep = dep)
-        base = app_layer(name = "%s_%d-symlinks" % (name, index), base = base, dep = dep, binary = binary)
+        base = app_layer(name = "%s_%d" % (name, index), base = base, dep = dep, tags = tags)
+        base = app_layer(name = "%s_%d-symlinks" % (name, index), base = base, dep = dep, binary = binary, tags = tags)
 
     visibility = kwargs.get("visibility", None)
-    tags = kwargs.get("tags", None)
     app_layer(
         name = name,
         base = base,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
We are using `py3_image()` with `layers` parameter in one of our projects. These images have `tags = ["manual"]` so we don't expect them to build with `bazel build //...`. However, we observing that `.tar` files with layers are still built. That happened because tags were not propagated to the layer's targets. This PR is trying to fix the issue.

Issue Number: N/A


## What is the new behavior?
`bazel build //...` doesn't build extra targets like layers when manual tag is used.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

