### PR TITLE
Allow excluding external dependencies explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",
 )
+# OPTIONAL: pass a list of external repos you want excluded because they will be loaded later:
+# container_repositories(excludes = ["rules_pkg"])
 container_repositories()
 
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -27,9 +27,9 @@ load(
 CONTAINERREGISTRY_RELEASE = "v0.0.38"
 RULES_DOCKER_GO_BINARY_RELEASE = "aad94363e63d31d574cf701df484b3e8b868a96a"
 
-def repositories():
+def repositories(excludes = []):
     """Download dependencies of container rules."""
-    excludes = native.existing_rules().keys()
+    excludes = excludes + native.existing_rules().keys()
 
     # Go binaries.
     if "go_puller_linux_amd64" not in excludes:


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Only those external dependencies that were _already_ present can be excluded. Therefore, to load custom external repository, you'd have to put the definition **before** loading `rules_docker`

Issue Number: N/A


## What is the new behavior?

Allow excluding external dependencies explicitly

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

Exclusion list is empty by default and combined with the old list, so no breaking changes are introduced.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

