### PR TITLE
[ci] Remove travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Bazel Container Image Rules
 
-Travis CI | Bazel CI
-:---: | :---:
-[![Build Status](https://travis-ci.org/bazelbuild/rules_docker.svg?branch=master)](https://travis-ci.org/bazelbuild/rules_docker) | [![Build status](https://badge.buildkite.com/693d7892250cfd44beea3cd95573388200935906a28cd3146d.svg)](https://buildkite.com/bazel/docker-rules-docker-postsubmit)
+| Bazel CI |
+| :------: |
+[![Build status](https://badge.buildkite.com/693d7892250cfd44beea3cd95573388200935906a28cd3146d.svg)](https://buildkite.com/bazel/docker-rules-docker-postsubmit)
 
 ## Basic Rules
 


### PR DESCRIPTION
The .travis.yml is no longer; this PR updates the readme to reflect that.