### PR TITLE
Update buildifier warnings

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,13 +1,8 @@
 ---
 buildifier:
   version: 4.0.1
-  warnings: "-rule-impl-return,-uninitialized,-return-value,-rule-impl-return"
-bazel: 4.0.0
-  # Check for issues with the format of our bazel config files.
-  warnings: "-function-docstring-args,-print,-skylark-comment,-provider-params,-unnamed-macro"
-  # List of lint warnings rules_docker does not pass.  Good first issue for new contributors.
   warnings: "-rule-impl-return,-return-value,-function-docstring-args,-print,-skylark-comment,-provider-params,-unnamed-macro"
-bazel: 3.5.0 # keep in sync with .bazelversion
+bazel: 4.0.0
 tasks:
   default_workspace_ubuntu1804:
     platform: ubuntu1804

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,6 +5,8 @@ buildifier:
 bazel: 4.0.0
   # Check for issues with the format of our bazel config files.
   warnings: "-function-docstring-args,-print,-skylark-comment,-provider-params,-unnamed-macro"
+  # List of lint warnings rules_docker does not pass.  Good first issue for new contributors.
+  warnings: "-rule-impl-return,-function-docstring-args,-print,-skylark-comment,-provider-params,-unnamed-macro"
 bazel: 3.5.0 # keep in sync with .bazelversion
 tasks:
   default_workspace_ubuntu1804:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,13 +1,8 @@
 ---
 buildifier:
   version: 4.0.1
-  # Check for issues with the format of our bazel config files.
-  # All warnings from https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md
-  # are enabled except:
-  # rule-impl-return, uninitialized, return-value, rule-impl-return
-  # TODO (suvanjan): Re-enable once issues are fixed.
-  warnings: "attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,confusing-name,constant-glob,ctx-actions,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,function-docstring,git-repository,http-archive,integer-division,load,load-on-top,module-docstring,name-conventions,native-build,native-package,no-effect,out-of-order-load,output-group,package-name,package-on-top,redefined-variable,repository-name,same-origin-load,string-iteration,unreachable,unsorted-dict-items,unused-variable"
-bazel: 4.0.0 # keep in sync with .bazelversion
+  warnings: "-rule-impl-return,-uninitialized,-return-value,-rule-impl-return"
+bazel: 4.0.0
 tasks:
   default_workspace_ubuntu1804:
     platform: ubuntu1804

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,7 +6,7 @@ bazel: 4.0.0
   # Check for issues with the format of our bazel config files.
   warnings: "-function-docstring-args,-print,-skylark-comment,-provider-params,-unnamed-macro"
   # List of lint warnings rules_docker does not pass.  Good first issue for new contributors.
-  warnings: "-rule-impl-return,-function-docstring-args,-print,-skylark-comment,-provider-params,-unnamed-macro"
+  warnings: "-rule-impl-return,-return-value,-function-docstring-args,-print,-skylark-comment,-provider-params,-unnamed-macro"
 bazel: 3.5.0 # keep in sync with .bazelversion
 tasks:
   default_workspace_ubuntu1804:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,6 +3,9 @@ buildifier:
   version: 4.0.1
   warnings: "-rule-impl-return,-uninitialized,-return-value,-rule-impl-return"
 bazel: 4.0.0
+  # Check for issues with the format of our bazel config files.
+  warnings: "-function-docstring-args,-print,-skylark-comment,-provider-params,-unnamed-macro"
+bazel: 3.5.0 # keep in sync with .bazelversion
 tasks:
   default_workspace_ubuntu1804:
     platform: ubuntu1804


### PR DESCRIPTION
This PR updates the buildifier CI warning list.  Before, we were iterating the list of warnings to check for.  After, we will only list those to exclude.

Future PRs can be submitted to remove those exclusions.