### PR TITLE
More fixes for actions that shouldn't upload to remote-cache

### DIFF
--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -151,6 +151,11 @@ def build_layer(
         arguments = [args],
         tools = files + file_map.values() + tars + debs + [manifest_file],
         outputs = [layer],
+        execution_requirements = {
+            # This action produces large output files, so it's not
+            # economical to send this to the remote-cache
+            "no-remote-cache": "1",
+        },
         use_default_shell_env = True,
         mnemonic = "ImageLayer",
     )

--- a/docker/package_managers/install_pkgs.bzl
+++ b/docker/package_managers/install_pkgs.bzl
@@ -126,6 +126,12 @@ def _impl(ctx, image_tar = None, installables_tar = None, installation_cleanup_c
             installables_tar,
             image_util,
         ],
+        execution_requirements = {
+            # This action produces large output files, and isn't economical to
+            # upload to a remote cache.
+            "no-remote-cache": "1",
+        },
+        mnemonic = "ExtractImageId",
         tools = [ctx.executable._extract_image_id, ctx.executable._to_json_tool],
         executable = script,
         use_default_shell_env = True,

--- a/docker/util/run.bzl
+++ b/docker/util/run.bzl
@@ -386,6 +386,12 @@ def _commit_layer_impl(
         outputs = [output_layer_tar, output_diff_id],
         inputs = runfiles,
         executable = script,
+        execution_requirements = {
+            # This action produces large output files, and isn't economical to
+            # upload to a remote cache.
+            "no-remote-cache": "1",
+        },
+        mnemonic = "RunAndCommitLayer",
         tools = [ctx.executable._extract_image_id, ctx.executable._last_layer_extractor_tool],
         use_default_shell_env = True,
     )


### PR DESCRIPTION
Similar to #1856. I found these by patching that PR and running through a big monorepo and searching execution log for more remote cache uploads over 10MB
