### PR TITLE
Add buildifier pre-commit hook and instructions

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,7 @@
 ---
 buildifier:
   version: 4.0.1
+  # Keep this argument in sync with .pre-commit-config.yml
   warnings: "-function-docstring-args,-print,-provider-params,-unnamed-macro"
 bazel: 4.0.0
 tasks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# See CONTRIBUTING.md for instructions.
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/keith/pre-commit-buildifier
+    rev: 4.0.1.1
+    hooks:
+      - id: buildifier
+        args: &args
+          # Keep this argument in sync with .bazelci/presubmit.yml
+          - --warnings=-function-docstring-args,-print,-provider-params,-unnamed-macro
+      - id: buildifier-lint
+        args: *args

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,19 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
+## Formatting
+
+Starlark files should be formatted by buildifier.
+We suggest using a pre-commit hook to automate this.
+First [install pre-commit](https://pre-commit.com/#installation),
+then run
+
+```shell
+pre-commit install
+```
+
+Otherwise the Buildkite CI will yell at you about formatting/linting violations.
+
 ## Contributor License Agreement
 
 Contributions to this project must be accompanied by a Contributor License


### PR DESCRIPTION
Based on what just merged into rules_apple: https://github.com/bazelbuild/rules_apple/commit/61bc7c01aeee1324dc276e4f09bba88913ab2a62
