### PR TITLE
feat(contrib:push-all): add "skip_unchanged_digest" to the push-all rule

### DIFF
--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -50,6 +50,8 @@ def _impl(ctx):
         pusher_args += ["--stamp-info-file=%s" % _get_runfile_path(ctx, f) for f in stamp_inputs]
         pusher_args.append("--dst={}".format(tag))
         pusher_args.append("--format={}".format(ctx.attr.format))
+        if ctx.attr.skip_unchanged_digest:
+            pusher_args.append("-skip-unchanged-digest")
         out = ctx.actions.declare_file("%s.%d.push" % (ctx.label.name, index))
         ctx.actions.expand_template(
             template = ctx.file._tag_tpl,
@@ -108,6 +110,10 @@ container_push = rule(
         "sequential": attr.bool(
             default = False,
             doc = "If true, push images sequentially.",
+        ),
+        "skip_unchanged_digest": attr.bool(
+            default = False,
+            doc = "Only push images if the digest has changed, default to False",
         ),
         "_all_tpl": attr.label(
             default = Label("//contrib:push-all.sh.tpl"),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently there is no way to skip images push when re-tagging even if the digest has not changed.


## What is the new behavior?
Implemented the existing feature of the original push rule to allow skipping when no digest changes on retmote.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

