### PR TITLE
feat(toolchain): add xz_target for remote execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ docker_toolchain_configure(
   # OPTIONAL: Path to the xz binary.
   # Should be set explicitly for remote execution.
   xz_path="<enter absolute path to the xz binary (in the remote exec env) here>",
+  # OPTIONAL: Bazel target for the xz tool.
+  # Either xz_path or xz_target should be set explicitly for remote execution.
+  xz_target="<enter absolute path (i.e., must start with repo name @...//:...) to an executable xz target>",
   # OPTIONAL: List of additional flags to pass to the docker command.
   docker_flags = [
     "--tls",

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -116,8 +116,17 @@ def build_layer(
         args.add("--mtime=portable")
     if ctx.attr.enable_mtime_preservation:
         args.add("--enable_mtime_preservation=true")
-    if toolchain_info.xz_path != "":
-        args.add(toolchain_info.xz_path, format = "--xz_path=%s")
+
+    xz_path = toolchain_info.xz_path
+    xz_tools = []
+    xz_input_manifests = []
+    if toolchain_info.xz_target:
+        xz_path = toolchain_info.xz_target.files_to_run.executable.path
+        xz_tools, _, xz_input_manifests = ctx.resolve_command(tools = [toolchain_info.xz_target])
+    elif toolchain_info.xz_path == "":
+        print("WARNING: xz could not be found. Make sure it is in the path or set it " +
+              "explicitly in the docker_toolchain_configure")
+    args.add(xz_path, format = "--xz_path=%s")
 
     # Windows layer.tar require two separate root directories instead of just 1
     # 'Files' is the equivalent of '.' in Linux images.
@@ -151,7 +160,8 @@ def build_layer(
     ctx.actions.run(
         executable = build_layer_exec,
         arguments = [args],
-        tools = files + file_map.values() + tars + debs + [manifest_file],
+        input_manifests = xz_input_manifests,
+        tools = files + file_map.values() + tars + debs + [manifest_file] + xz_tools,
         outputs = [layer],
         execution_requirements = {
             # This action produces large output files, so it's not

--- a/testing/default_toolchain/WORKSPACE
+++ b/testing/default_toolchain/WORKSPACE
@@ -22,12 +22,22 @@ local_repository(
 )
 
 load(
+    "//:local_tool.bzl",
+    "local_tool",
+)
+
+local_tool(
+    name = "xz",
+)
+
+load(
     "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
     docker_toolchain_configure = "toolchain_configure",
 )
 
 docker_toolchain_configure(
     name = "docker_config",
+    xz_target = "@xz//:xz",
 )
 
 load(

--- a/testing/default_toolchain/local_tool.bzl
+++ b/testing/default_toolchain/local_tool.bzl
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Rule to load a local tool. Used to test gzip_target."""
+"""Rule to load a local tool. Used to test gzip_target and xz_target."""
 
 _local_tool_build_template = """
 sh_binary(

--- a/toolchains/docker/BUILD.tpl
+++ b/toolchains/docker/BUILD.tpl
@@ -24,5 +24,5 @@ docker_toolchain(
     %{GZIP_ATTR}
     tool_path = "%{DOCKER_TOOL}",
     docker_flags = ["%{DOCKER_FLAGS}"],
-    xz_path = "%{XZ_TOOL_PATH}",
+    %{XZ_ATTR}
 )


### PR DESCRIPTION
This PR is a re-opening of https://github.com/bazelbuild/rules_docker/pull/1559, which was closed due to inactivity.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

You cannot provide the `xz` dependency via a Bazel http_archive, instead you must have `xz` already installed on the system, which is not feasible in heterogeneous build environments.


## What is the new behavior?

Allows a hermetic xz binary to be provided.

Worth noting that busybox provides a fully static musl busybox that
should work on any Linux system, that gives you both gzip and xz.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

---

#### Commits _(oldest to newest)_

787a9560 feat(toolchain): add xz_target for remote execution

Copied what is currently done for gzip_target.

<br/>