### PR TITLE
Polish output of package_manager rules

### DIFF
--- a/docker/package_managers/install_pkgs.bzl
+++ b/docker/package_managers/install_pkgs.bzl
@@ -41,7 +41,8 @@ users will write something like:
 
 def _generate_install_commands(tar, installation_cleanup_commands):
     return """
-tar -xvf {tar}
+tar -xf {tar}
+export DEBIAN_FRONTEND=noninteractive
 dpkg -i --force-depends ./*.deb
 dpkg --configure -a
 apt-get install -f

--- a/docker/package_managers/run_download.sh.tpl
+++ b/docker/package_managers/run_download.sh.tpl
@@ -28,8 +28,8 @@ image_id=$(%{image_id_extractor_path} %{image_tar})
 $DOCKER $DOCKER_FLAGS load -i %{image_tar}
 
 # Run the builder image.
-cid=$($DOCKER $DOCKER_FLAGS run -w="/" -d --privileged $image_id sh -c $'%{download_commands}')
-$DOCKER $DOCKER_FLAGS attach $cid
+cid=$($DOCKER $DOCKER_FLAGS create -w="/" --privileged $image_id sh -c $'%{download_commands}')
+$DOCKER $DOCKER_FLAGS start -a $cid
 $DOCKER $DOCKER_FLAGS cp $cid:%{installables}_packages.tar %{output}
 $DOCKER $DOCKER_FLAGS cp $cid:%{installables}_metadata.csv %{output_metadata}
 # Cleanup


### PR DESCRIPTION
Set DEBIAN_FRONTEND to noninterative to suppress "unable to initialize frontend" warnings.

Use `docker create` + `docker start -a` to replace `docker run -d` + `docker attach`.
In the past, because the container is started before running `docker attach`, there will be a few lines at the beginning missing from logs. That will lead to hard to debug errors.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

