### PR TITLE
Silence go module warnings in go_repository

### DIFF
--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -37,8 +37,15 @@ def go_deps():
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(
             name = "com_github_google_go_containerregistry",
-            commit = "c061b3f39cff652d18f95ee23ebfd39cb3f5ee89",  # v0.5.1
+            urls = ["https://api.github.com/repos/google/go-containerregistry/tarball/c061b3f39cff652d18f95ee23ebfd39cb3f5ee89"],  # v0.5.1
+            sha256 = "742b8a99f43800ec2e7e6d6c5bf04b7ac3887af597ac85986c84aed37b160ebf",
             importpath = "github.com/google/go-containerregistry",
+            strip_prefix = "google-go-containerregistry-c061b3f",
+            type = "tar.gz",
+            build_directives = [
+                # Silence Go module warnings about unused modules.
+                "gazelle:exclude pkg/authn/k8schain",
+            ],
         )
     if "com_github_pkg_errors" not in excludes:
         go_repository(
@@ -49,7 +56,6 @@ def go_deps():
             strip_prefix = "pkg-errors-614d223",
             type = "tar.gz",
         )
-
     if "in_gopkg_yaml_v2" not in excludes:
         go_repository(
             name = "in_gopkg_yaml_v2",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When executing the repository rule `com_github_google_go_containerregistry`, the following warning is printed:

```
DEBUG: /private/var/tmp/_bazel_martin/37de97fe4a6bb79f99ddaabf4bd12042/external/bazel_gazelle/internal/go_repository.bzl:184:18: com_github_google_go_containerregistry: gazelle: finding module path for import github.com/vdemeester/k8s-pkg-credentialprovider: exit status 1: go: finding module for package github.com/vdemeester/k8s-pkg-credentialprovider
go: found github.com/vdemeester/k8s-pkg-credentialprovider in github.com/vdemeester/k8s-pkg-credentialprovider v1.21.0
go: github.com/vdemeester/k8s-pkg-credentialprovider@v1.21.0 requires
	k8s.io/kubelet@v0.0.0: reading k8s.io/kubelet/go.mod at revision v0.0.0: unknown revision v0.0.0
gazelle: finding module path for import github.com/vdemeester/k8s-pkg-credentialprovider: exit status 1: go: finding module for package github.com/vdemeester/k8s-pkg-credentialprovider
go: found github.com/vdemeester/k8s-pkg-credentialprovider in github.com/vdemeester/k8s-pkg-credentialprovider v1.21.0
go: github.com/vdemeester/k8s-pkg-credentialprovider@v1.21.0 requires
	k8s.io/kubelet@v0.0.0: reading k8s.io/kubelet/go.mod at revision v0.0.0: unknown revision v0.0.0
gazelle: finding module path for import github.com/vdemeester/k8s-pkg-credentialprovider: exit status 1: go: finding module for package github.com/vdemeester/k8s-pkg-credentialprovider
go: found github.com/vdemeester/k8s-pkg-credentialprovider in github.com/vdemeester/k8s-pkg-credentialprovider v1.21.0
go: github.com/vdemeester/k8s-pkg-credentialprovider@v1.21.0 requires
	k8s.io/kubelet@v0.0.0: reading k8s.io/kubelet/go.mod at revision v0.0.0: unknown revision v0.0.0
gazelle: finding module path for import github.com/vdemeester/k8s-pkg-credentialprovider: exit status 1: go: finding module for package github.com/vdemeester/k8s-pkg-credentialprovider
go: found github.com/vdemeester/k8s-pkg-credentialprovider in github.com/vdemeester/k8s-pkg-credentialprovider v1.21.0
go: github.com/vdemeester/k8s-pkg-credentialprovider@v1.21.0 requires
	k8s.io/kubelet@v0.0.0: reading k8s.io/kubelet/go.mod at revision v0.0.0: unknown revision v0.0.0
gazelle: finding module path for import github.com/vdemeester/k8s-pkg-credentialprovider: exit status 1: go: finding module for package github.com/vdemeester/k8s-pkg-credentialprovider
go: found github.com/vdemeester/k8s-pkg-credentialprovider in github.com/vdemeester/k8s-pkg-credentialprovider v1.21.0
go: github.com/vdemeester/k8s-pkg-credentialprovider@v1.21.0 requires
	k8s.io/kubelet@v0.0.0: reading k8s.io/kubelet/go.mod at revision v0.0.0: unknown revision v0.0.0
gazelle: finding module path for import k8s.io/client-go/kubernetes: exit status 1: go: finding module for package k8s.io/client-go/kubernetes
module k8s.io/client-go@latest found (v1.5.2), but does not contain package k8s.io/client-go/kubernetes
gazelle: finding module path for import k8s.io/client-go/rest: exit status 1: go: finding module for package k8s.io/client-go/rest
module k8s.io/client-go@latest found (v1.5.2), but does not contain package k8s.io/client-go/rest
gazelle: finding module path for import k8s.io/client-go/kubernetes: exit status 1: go: finding module for package k8s.io/client-go/kubernetes
module k8s.io/client-go@latest found (v1.5.2), but does not contain package k8s.io/client-go/kubernetes
```

The `github.com/vdemeester/k8s-pkg-credentialprovider` package is used by `github.com/google/go-containerregistry/pkg/authn/k8schain`, but [`k8schain`](https://github.com/google/go-containerregistry/tree/main/pkg/authn/k8schain) itself is not used by `rules_docker`. In fact, afaict `k8schain` was spun off into its own module so that `go-containerregistry` wouldn't have to vendor k8s.

## What is the new behavior?

No warnings printed. Build targets are also not generated for the `k8schain` package, however this is should be okay as it is not used by `rules_docker` and not likely to be used as it contains a rather heavy dependency on the k8s client.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

