### PR TITLE
Upgrate PyYAML to 5.4.1

### DIFF
--- a/repositories/requirements-pip.txt
+++ b/repositories/requirements-pip.txt
@@ -2,5 +2,5 @@
 six==1.11.0
 addict==2.1.2
 # required by docker/security & deps
-PyYAML==5.4
+PyYAML==5.4.1
 


### PR DESCRIPTION
The CI is failing to fetch 5.4. Attempt to upgrate to 5.4.1 since that is what pypi seems to say is available.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

