### PR TITLE
Update convert bytes to string for py3

### DIFF
--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -42,7 +42,7 @@ class TarFile(object):
 
   @staticmethod
   def parse_pkg_name(metadata, filename):
-    pkg_name_match = TarFile.PKG_NAME_RE.match(str(metadata))
+    pkg_name_match = TarFile.PKG_NAME_RE.match(metadata)
     if pkg_name_match:
       return pkg_name_match.group('pkg_name')
     else:
@@ -231,7 +231,7 @@ class TarFile(object):
         control_file = tar.extractfile(control_file_member[0])
         metadata = b''.join(control_file.readlines())
         destination_file = os.path.join(TarFile.DPKG_STATUS_DIR,
-                                        TarFile.parse_pkg_name(metadata, deb))
+                                        TarFile.parse_pkg_name(metadata.decode("utf-8"), deb))
         with self.write_temp_file(data=metadata) as metadata_file:
           self.add_file(metadata_file, destination_file)
     except (KeyError, TypeError) as e:

--- a/tests/container/build_tar_test.py
+++ b/tests/container/build_tar_test.py
@@ -59,6 +59,32 @@ Version: 1.2.4
 """
     self.assertEqual('test', TarFile.parse_pkg_name(metadata, "test.deb"))
 
+  def testPkgMetadataStatusFileName(self):
+    metadata = """Package: test
+Description: Dummy
+Version: 1.2.4
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+      # write control file into a metadata tar
+      control_file_name = path.join(tmp, "control")
+      with open(control_file_name, "w") as control_file:
+        control_file.write(metadata)
+      metadata_tar_file_name = path.join(tmp, "metadata.tar")
+      with tarfile.open(metadata_tar_file_name, "w") as metadata_tar_file:
+        metadata_tar_file.add(control_file_name, arcname="control")
+
+
+      output_file_name = path.join(tmp, "output.tar")
+      with TarFile(output_file_name, directory="/", compression=None, root_directory="./", default_mtime=None,
+                   enable_mtime_preservation=False, xz_path="", force_posixpath=False) as output_file:
+        output_file.add_pkg_metadata(metadata_tar_file_name, "ignored.deb")
+
+      with tarfile.open(output_file_name) as output_file:
+        contained_names = output_file.getnames()
+
+        self.assertIn('./var/lib/dpkg/status.d/test', contained_names)
+
+
   def testPackageNameParserInvalidMetadata(self):
     metadata = "Package Name: Invalid"
     self.assertEqual('test-invalid-pkg',


### PR DESCRIPTION
EDIT: the bug itself isn't about writing base64 files, it's about writing the filename instead of parsing Package information from the metadata file.

~~Fixes a bug where dpkg/status.d writes base64 data instead of human readable strings
`var/lib/dpkg/status.d/YmFzZS1maWxlcw==` vs  `var/lib/dpkg/status.d/base-files`~~

Signed-off-by: Appu Goundan <appu@google.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

Honestly can't get tests running locally, bazel is so unfamiliar, I'm pretty confused. But I ran against distroless using my local copy and it seems to work.

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
https://github.com/GoogleContainerTools/distroless/issues/787
https://github.com/GoogleContainerTools/distroless/issues/581
https://github.com/bazelbuild/rules_docker/issues/1625

## What is the new behavior?
Continues behavior in py3 that appeared to previously work with py2


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


