### PR TITLE
Support multi-architecture base-images in go. Use the base image for …

### DIFF
--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -18,8 +18,8 @@
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
 DIGESTS = {
-	# "gcr.io/distroless/cc:debug" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/cc:debug" circa 2021-10-14 18:19 -0400
     "debug": "sha256:f14ed37906f4ecca4e32a16bcc5cc562ee573e4283cff4b36eba4fe7b624a1a7",
-    # "gcr.io/distroless/cc:latest" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/cc:latest" circa 2021-10-14 18:19 -0400
     "latest": "sha256:16364c4c292686f5a3e79931caf9f65727711952fbadca05dd3bed3c5f24453c",
 }

--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -17,10 +17,9 @@
 #
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
-
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:3680c61e81f68fc00bfb5e1ec65e8e678aaafa7c5f056bc2681c29527ebbb30c",
-    # "gcr.io/distroless/cc:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:2c4bb6b7236db0a55ec54ba8845e4031f5db2be957ac61867872bf42e56c4deb",
+	# "gcr.io/distroless/cc:debug" circa 2021-10-08 23:17 -0400
+    "debug": "sha256:f14ed37906f4ecca4e32a16bcc5cc562ee573e4283cff4b36eba4fe7b624a1a7",
+    # "gcr.io/distroless/cc:latest" circa 2021-10-08 23:17 -0400
+    "latest": "sha256:16364c4c292686f5a3e79931caf9f65727711952fbadca05dd3bed3c5f24453c",
 }

--- a/container/go/cmd/update_deps/update_deps.go
+++ b/container/go/cmd/update_deps/update_deps.go
@@ -50,25 +50,25 @@ const digestTemplate = `# Copyright 2017 The Bazel Authors. All rights reserved.
 
 {{- if not .MultiArch }}
 DIGESTS = {
-	# "{{.Debug}}" circa {{.Date}}
-	{{- range $arch, $digest := .DebugTags }}
+    # "{{.Debug}}" circa {{.Date}}
+    {{- range $arch, $digest := .DebugTags }}
     "debug": "{{ $digest }}",
-	{{- end }}
+    {{- end }}
     # "{{.Latest}}" circa {{.Date}}
-	{{- range $arch, $digest := .LatestTags }}
+    {{- range $arch, $digest := .LatestTags }}
     "latest": "{{ $digest }}",
-	{{- end }}
+    {{- end }}
 }
 {{- else }}
 DIGESTS = {
-	# "{{.Debug}}" circa {{.Date}}
-	{{- range $arch, $digest := .DebugTags }}
+    # "{{.Debug}}" circa {{.Date}}
+    {{- range $arch, $digest := .DebugTags }}
     "debug_{{ $arch }}": "{{ $digest }}",
-	{{- end }}
+    {{- end }}
     # "{{.Latest}}" circa {{.Date}}
-	{{- range $arch, $digest := .LatestTags }}
+    {{- range $arch, $digest := .LatestTags }}
     "latest_{{ $arch }}": "{{ $digest }}",
-	{{- end }}
+    {{- end }}
 }
 {{- end }}
 `

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -18,13 +18,13 @@
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
 DIGESTS = {
-	# "gcr.io/distroless/base:debug" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/base:debug" circa 2021-10-14 18:19 -0400
     "debug_amd64": "sha256:c7783573417aba2d12914629147df2ddec11f9105c1b676cfddef58ba3c16601",
     "debug_arm": "sha256:8c08ed18bf369db5ac870236d28fb6da088424763f7b6b8530ae62237fb45d59",
     "debug_arm64": "sha256:a5fd72760beead66f0cb2fbe35f4cdf56e8bc2b0e74feb47fe814b7ec6424987",
     "debug_ppc64le": "sha256:efcf2eeb96fb4822648791f39127d7150b050dbb30e6719868eb3465923ebffd",
     "debug_s390x": "sha256:9611d6068700892a9c3a950c2d785d0b86ff5e6ad4bb682f37338ba2e4c87d94",
-    # "gcr.io/distroless/base:latest" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/base:latest" circa 2021-10-14 18:19 -0400
     "latest_amd64": "sha256:1a80a34cb3d7c4326191047976e4161741aef22c351932b55e32b72ce8827c27",
     "latest_arm": "sha256:4e72c245399db1a2f89d70ce2839c024ded5051d13e78d9d09b9a7c48155d1fd",
     "latest_arm64": "sha256:f557575011fd640f984c56d74ca8f0708a50b3252a15db6e1a4895594c531bbf",

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -17,10 +17,17 @@
 #
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
-
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:efd8711717d9e9b5d0dbb20ea10876dab0609c923bc05321b912f9239090ca80",
-    # "gcr.io/distroless/base:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:ba7a315f86771332e76fa9c3d423ecfdbb8265879c6f1c264d6fff7d4fa460a4",
+	# "gcr.io/distroless/base:debug" circa 2021-10-08 23:17 -0400
+    "debug_amd64": "sha256:c7783573417aba2d12914629147df2ddec11f9105c1b676cfddef58ba3c16601",
+    "debug_arm": "sha256:8c08ed18bf369db5ac870236d28fb6da088424763f7b6b8530ae62237fb45d59",
+    "debug_arm64": "sha256:a5fd72760beead66f0cb2fbe35f4cdf56e8bc2b0e74feb47fe814b7ec6424987",
+    "debug_ppc64le": "sha256:efcf2eeb96fb4822648791f39127d7150b050dbb30e6719868eb3465923ebffd",
+    "debug_s390x": "sha256:9611d6068700892a9c3a950c2d785d0b86ff5e6ad4bb682f37338ba2e4c87d94",
+    # "gcr.io/distroless/base:latest" circa 2021-10-08 23:17 -0400
+    "latest_amd64": "sha256:1a80a34cb3d7c4326191047976e4161741aef22c351932b55e32b72ce8827c27",
+    "latest_arm": "sha256:4e72c245399db1a2f89d70ce2839c024ded5051d13e78d9d09b9a7c48155d1fd",
+    "latest_arm64": "sha256:f557575011fd640f984c56d74ca8f0708a50b3252a15db6e1a4895594c531bbf",
+    "latest_ppc64le": "sha256:a04ec0087837bc289056a5477fe2dc86745951dfe8419afe419426325cbb4c8f",
+    "latest_s390x": "sha256:46c4936e7e3f20c9ae802d4ebf361966bd3a177e1342d566c52d4daad3e355b5",
 }

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -48,6 +48,7 @@ def repositories():
     """
     _go_deps()
     excludes = native.existing_rules().keys()
+
     for goarch in GOARCH_CONSTRAINTS:
         go_image_base = "go_image_base_" + goarch
         if go_image_base not in excludes:

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -37,6 +37,9 @@ load(
 load(":go.bzl", BASE_DIGESTS = "DIGESTS")
 load(":static.bzl", STATIC_DIGESTS = "DIGESTS")
 
+# If you update this list, update update_deps.sh at the workspace root to pull new images digests for all archs
+GOARCH_CONSTRAINTS = ["amd64", "arm", "arm64", "ppc64le", "s390x"]
+
 def repositories():
     """Import the dependencies of the go_image rule.
 
@@ -44,50 +47,88 @@ def repositories():
     idempotent if folks call it themselves.
     """
     _go_deps()
-
     excludes = native.existing_rules().keys()
-    if "go_image_base" not in excludes:
-        container_pull(
-            name = "go_image_base",
-            registry = "gcr.io",
-            repository = "distroless/base",
-            digest = BASE_DIGESTS["latest"],
-        )
-    if "go_debug_image_base" not in excludes:
-        container_pull(
-            name = "go_debug_image_base",
-            registry = "gcr.io",
-            repository = "distroless/base",
-            digest = BASE_DIGESTS["debug"],
-        )
-    if "go_image_static" not in excludes:
-        container_pull(
-            name = "go_image_static",
-            registry = "gcr.io",
-            repository = "distroless/static",
-            digest = STATIC_DIGESTS["latest"],
-        )
-    if "go_debug_image_static" not in excludes:
-        container_pull(
-            name = "go_debug_image_static",
-            registry = "gcr.io",
-            repository = "distroless/static",
-            digest = STATIC_DIGESTS["debug"],
-        )
+    for goarch in GOARCH_CONSTRAINTS:
+        go_image_base = "go_image_base_" + goarch
+        if go_image_base not in excludes:
+            container_pull(
+                name = go_image_base,
+                architecture = goarch,
+                registry = "gcr.io",
+                repository = "distroless/base",
+                digest = BASE_DIGESTS["latest_" + goarch],
+            )
+        go_debug_image_base = "go_debug_image_base_" + goarch
+        if go_debug_image_base not in excludes:
+            container_pull(
+                name = go_debug_image_base,
+                architecture = goarch,
+                registry = "gcr.io",
+                repository = "distroless/base",
+                digest = BASE_DIGESTS["debug_" + goarch],
+            )
+        go_image_static = "go_image_static_" + goarch
+        if go_image_static not in excludes:
+            container_pull(
+                name = go_image_static,
+                architecture = goarch,
+                registry = "gcr.io",
+                repository = "distroless/static",
+                digest = STATIC_DIGESTS["latest_" + goarch],
+            )
+        go_debug_image_static = "go_debug_image_static_" + goarch
+        if go_debug_image_static not in excludes:
+            container_pull(
+                name = go_debug_image_static,
+                architecture = goarch,
+                registry = "gcr.io",
+                repository = "distroless/static",
+                digest = STATIC_DIGESTS["debug_" + goarch],
+            )
 
-DEFAULT_BASE = select({
-    "@io_bazel_rules_docker//:debug": "@go_debug_image_base//image",
-    "@io_bazel_rules_docker//:fastbuild": "@go_image_base//image",
-    "@io_bazel_rules_docker//:optimized": "@go_image_base//image",
-    "//conditions:default": "@go_image_base//image",
-})
+    # Provide aliases for the old targets. As alias cannot be used in WORKSPACE we sadly have to rewrite them all
+    container_pull(
+        name = "go_image_base",
+        architecture = "amd64",
+        registry = "gcr.io",
+        repository = "distroless/base",
+        digest = BASE_DIGESTS["latest_amd64"],
+    )
+    container_pull(
+        name = "go_debug_image_base",
+        architecture = "amd64",
+        registry = "gcr.io",
+        repository = "distroless/base",
+        digest = BASE_DIGESTS["debug_amd64"],
+    )
+    container_pull(
+        name = "go_image_static",
+        architecture = "amd64",
+        registry = "gcr.io",
+        repository = "distroless/static",
+        digest = STATIC_DIGESTS["latest_amd64"],
+    )
+    container_pull(
+        name = "go_debug_image_static",
+        architecture = "amd64",
+        registry = "gcr.io",
+        repository = "distroless/static",
+        digest = STATIC_DIGESTS["debug_amd64"],
+    )
 
-STATIC_DEFAULT_BASE = select({
-    "@io_bazel_rules_docker//:debug": "@go_debug_image_static//image",
-    "@io_bazel_rules_docker//:fastbuild": "@go_image_static//image",
-    "@io_bazel_rules_docker//:optimized": "@go_image_static//image",
-    "//conditions:default": "@go_image_static//image",
-})
+DEFAULT_BASE = {goarch: select({
+    "@io_bazel_rules_docker//:debug": "@go_debug_image_base_{}//image".format(goarch),
+    "@io_bazel_rules_docker//:fastbuild": "@go_image_base_{}//image".format(goarch),
+    "@io_bazel_rules_docker//:optimized": "@go_image_base_{}//image".format(goarch),
+    "//conditions:default": "@go_image_base_{}//image".format(goarch),
+}) for goarch in GOARCH_CONSTRAINTS}
+
+STATIC_DEFAULT_BASE = {goarch: select({
+    "@io_bazel_rules_docker//:debug": "@go_debug_image_static_{}//image".format(goarch),
+    "@io_bazel_rules_docker//:fastbuild": "@go_image_static_{}//image".format(goarch),
+    "@io_bazel_rules_docker//:optimized": "@go_image_static_{}//image".format(goarch),
+    "//conditions:default": "@go_image_static_{}//image".format(goarch),
+}) for goarch in GOARCH_CONSTRAINTS}
 
 def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
     """Constructs a container image wrapping a go_binary target.
@@ -110,7 +151,10 @@ def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
         fail("kwarg does nothing when binary is specified", "deps")
 
     if not base:
-        base = STATIC_DEFAULT_BASE if kwargs.get("pure") == "on" else DEFAULT_BASE
+        arch = kwargs.get("goarch", "amd64")
+        if arch not in GOARCH_CONSTRAINTS:
+            fail("provided goarch is not available as a base image. Base image needs to be provided")
+        base = STATIC_DEFAULT_BASE[arch] if kwargs.get("pure") == "on" else DEFAULT_BASE[arch]
 
     tags = kwargs.get("tags", None)
     for index, dep in enumerate(layers):
@@ -131,4 +175,5 @@ def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
         testonly = kwargs.get("testonly"),
         restricted_to = restricted_to,
         compatible_with = compatible_with,
+        architecture = kwargs.get("goarch"),
     )

--- a/go/static.bzl
+++ b/go/static.bzl
@@ -18,13 +18,13 @@
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
 DIGESTS = {
-	# "gcr.io/distroless/static:debug" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/static:debug" circa 2021-10-14 18:19 -0400
     "debug_amd64": "sha256:1af78637652cdc7e85d26810c38b1bbaddb1c93226a52a432e10931a84567691",
     "debug_arm": "sha256:9bc29eb8ea783f0681a7b9593a3e6568e2699fc61abea357730efa004ec45b8c",
     "debug_arm64": "sha256:6aebbe289b416302d6e6795f047a1053fee5ca9070558d1fb8e44327773e5448",
     "debug_ppc64le": "sha256:2361a56ab561d8e7e720288328b388cd39edc3712f8937a8c6166534f55d5240",
     "debug_s390x": "sha256:9d5cb7471e6b9ce814d6666b8652c1b49cedf2c0f919a40775e84832261f43d7",
-    # "gcr.io/distroless/static:latest" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/static:latest" circa 2021-10-14 18:19 -0400
     "latest_amd64": "sha256:a5635fa9dda1cf81666d8c288130bf3519bdeab1b7ed717db496a73d25d1b35c",
     "latest_arm": "sha256:a81c4c77b601a31c2b4a77ff9fd2aa7f80b1d542ea2d6cc0d9b056a6e6f17a0d",
     "latest_arm64": "sha256:cc7389ac8f818fa1af21bd9ff456987cc2d42577013ab2d02807c51378f5c036",

--- a/go/static.bzl
+++ b/go/static.bzl
@@ -17,10 +17,17 @@
 #
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
-
 DIGESTS = {
-    # "gcr.io/distroless/static:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:a8fc00a6b3fe7b536b0731df01574c2113cad63c6196246126224c698265a885",
-    # "gcr.io/distroless/static:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:aadea1b1f16af043a34491eec481d0132479382096ea34f608087b4bef3634be",
+	# "gcr.io/distroless/static:debug" circa 2021-10-08 23:17 -0400
+    "debug_amd64": "sha256:1af78637652cdc7e85d26810c38b1bbaddb1c93226a52a432e10931a84567691",
+    "debug_arm": "sha256:9bc29eb8ea783f0681a7b9593a3e6568e2699fc61abea357730efa004ec45b8c",
+    "debug_arm64": "sha256:6aebbe289b416302d6e6795f047a1053fee5ca9070558d1fb8e44327773e5448",
+    "debug_ppc64le": "sha256:2361a56ab561d8e7e720288328b388cd39edc3712f8937a8c6166534f55d5240",
+    "debug_s390x": "sha256:9d5cb7471e6b9ce814d6666b8652c1b49cedf2c0f919a40775e84832261f43d7",
+    # "gcr.io/distroless/static:latest" circa 2021-10-08 23:17 -0400
+    "latest_amd64": "sha256:a5635fa9dda1cf81666d8c288130bf3519bdeab1b7ed717db496a73d25d1b35c",
+    "latest_arm": "sha256:a81c4c77b601a31c2b4a77ff9fd2aa7f80b1d542ea2d6cc0d9b056a6e6f17a0d",
+    "latest_arm64": "sha256:cc7389ac8f818fa1af21bd9ff456987cc2d42577013ab2d02807c51378f5c036",
+    "latest_ppc64le": "sha256:e0d91a3255efe07a17ca828eab3a9068e4757a1e86bc8d83c9a031ebda7a19ad",
+    "latest_s390x": "sha256:3e60feae6e1cd2b6fe0d8e0c4d9811231e73b0ce4cf5059373d56d1de469ecc9",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -17,10 +17,9 @@
 #
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
-
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:0551431d74d180cb50e5354732388aff55e896691ad79f20da4897fecee1feed",
-    # "gcr.io/distroless/java:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:5b4bb0f378489f8b15547d79844a9e7b5343539051d99942f414872e380124a2",
+	# "gcr.io/distroless/java:debug" circa 2021-10-08 23:17 -0400
+    "debug": "sha256:9fde41750076a667ceb29973f4d24c0231d630cf7f4cc0baf40c4cbaae017f58",
+    # "gcr.io/distroless/java:latest" circa 2021-10-08 23:17 -0400
+    "latest": "sha256:5e933733982c5af8524e78fb22b9e0b283f708195187fe44189fcc10a1a8a36b",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -18,8 +18,8 @@
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
 DIGESTS = {
-	# "gcr.io/distroless/java:debug" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/java:debug" circa 2021-10-14 18:19 -0400
     "debug": "sha256:9fde41750076a667ceb29973f4d24c0231d630cf7f4cc0baf40c4cbaae017f58",
-    # "gcr.io/distroless/java:latest" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/java:latest" circa 2021-10-14 18:19 -0400
     "latest": "sha256:5e933733982c5af8524e78fb22b9e0b283f708195187fe44189fcc10a1a8a36b",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -18,8 +18,8 @@
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
 DIGESTS = {
-	# "gcr.io/distroless/java/jetty:debug" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/java/jetty:debug" circa 2021-10-14 18:19 -0400
     "debug": "sha256:0e9dbeb0c9eb4cb2698baea1723f87899bf93fa3906be44d59f0b636fb758158",
-    # "gcr.io/distroless/java/jetty:latest" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/java/jetty:latest" circa 2021-10-14 18:19 -0400
     "latest": "sha256:68183b2ad2e8d80a5165360b0a2bb3fdef52608ac39d6afd9e8cd7ed213330f1",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -17,10 +17,9 @@
 #
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
-
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:c5966df7d452e1e91043d364bc193ad0fc084fab9885d1d1c55c78c69bf810d7",
-    # "gcr.io/distroless/java/jetty:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:3b4445909b0af7d1203ba9d6cd571cbc4ea14f3fd2eb5cedc51f9fc2c5560f77",
+	# "gcr.io/distroless/java/jetty:debug" circa 2021-10-08 23:17 -0400
+    "debug": "sha256:0e9dbeb0c9eb4cb2698baea1723f87899bf93fa3906be44d59f0b636fb758158",
+    # "gcr.io/distroless/java/jetty:latest" circa 2021-10-08 23:17 -0400
+    "latest": "sha256:68183b2ad2e8d80a5165360b0a2bb3fdef52608ac39d6afd9e8cd7ed213330f1",
 }

--- a/nodejs/nodejs.bzl
+++ b/nodejs/nodejs.bzl
@@ -17,10 +17,9 @@
 #
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
-
 DIGESTS = {
-    # "gcr.io/google-appengine/debian9:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:b64677de34eeb83c55dd874d9b7e3ae74ff6e41a81bbe199c5f80bbcb339f9f4",
-    # "gcr.io/google-appengine/debian9:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:b64677de34eeb83c55dd874d9b7e3ae74ff6e41a81bbe199c5f80bbcb339f9f4",
+	# "gcr.io/google-appengine/debian9:debug" circa 2021-10-08 23:17 -0400
+    "debug": "sha256:8e4639cb270046abd646f7cc7c16363b778149513a2f27b86494e135b2760dbf",
+    # "gcr.io/google-appengine/debian9:latest" circa 2021-10-08 23:17 -0400
+    "latest": "sha256:8e4639cb270046abd646f7cc7c16363b778149513a2f27b86494e135b2760dbf",
 }

--- a/nodejs/nodejs.bzl
+++ b/nodejs/nodejs.bzl
@@ -18,8 +18,8 @@
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
 DIGESTS = {
-	# "gcr.io/google-appengine/debian9:debug" circa 2021-10-08 23:17 -0400
+    # "gcr.io/google-appengine/debian9:debug" circa 2021-10-14 18:19 -0400
     "debug": "sha256:8e4639cb270046abd646f7cc7c16363b778149513a2f27b86494e135b2760dbf",
-    # "gcr.io/google-appengine/debian9:latest" circa 2021-10-08 23:17 -0400
+    # "gcr.io/google-appengine/debian9:latest" circa 2021-10-14 18:19 -0400
     "latest": "sha256:8e4639cb270046abd646f7cc7c16363b778149513a2f27b86494e135b2760dbf",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -18,8 +18,8 @@
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
 DIGESTS = {
-	# "gcr.io/distroless/python2.7:debug" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/python2.7:debug" circa 2021-10-14 18:19 -0400
     "debug": "sha256:85f45e3b5ab66da2eb04c10d29519deb21bf14bcfa8fa6769817db4f031ad3c9",
-    # "gcr.io/distroless/python2.7:latest" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/python2.7:latest" circa 2021-10-14 18:19 -0400
     "latest": "sha256:83b8dc7881f3e3c85740bfffd32b7ce64527757e74c68d6a31102a7d1b2a977b",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -17,10 +17,9 @@
 #
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
-
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2021-09-25 14:45 -0400
+	# "gcr.io/distroless/python2.7:debug" circa 2021-10-08 23:17 -0400
     "debug": "sha256:85f45e3b5ab66da2eb04c10d29519deb21bf14bcfa8fa6769817db4f031ad3c9",
-    # "gcr.io/distroless/python2.7:latest" circa 2021-09-25 14:45 -0400
+    # "gcr.io/distroless/python2.7:latest" circa 2021-10-08 23:17 -0400
     "latest": "sha256:83b8dc7881f3e3c85740bfffd32b7ce64527757e74c68d6a31102a7d1b2a977b",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -18,8 +18,8 @@
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
 DIGESTS = {
-	# "gcr.io/distroless/python3:debug" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/python3:debug" circa 2021-10-14 18:19 -0400
     "debug": "sha256:bfeac5d2d8e98cfe0013851e29a0ee982275620607b8a33a906ff9fbcfcda9cb",
-    # "gcr.io/distroless/python3:latest" circa 2021-10-08 23:17 -0400
+    # "gcr.io/distroless/python3:latest" circa 2021-10-14 18:19 -0400
     "latest": "sha256:2f08fcfb34ac60e69751c6c9379b939cbe691450fe110fde58d47b427aaa3017",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -17,10 +17,9 @@
 #
 # To regenerate this file, run ./update_deps.sh from the root of the
 # git repository.
-
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:ec7b6f080ace2ad18677441351405477f41c9b3bb2574cc524bddc5218e8231b",
-    # "gcr.io/distroless/python3:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:646751d617197447aedc0899d5d3db65b5538f21dec368e5406f96178151b206",
+	# "gcr.io/distroless/python3:debug" circa 2021-10-08 23:17 -0400
+    "debug": "sha256:bfeac5d2d8e98cfe0013851e29a0ee982275620607b8a33a906ff9fbcfcda9cb",
+    # "gcr.io/distroless/python3:latest" circa 2021-10-08 23:17 -0400
+    "latest": "sha256:2f08fcfb34ac60e69751c6c9379b939cbe691450fe110fde58d47b427aaa3017",
 }

--- a/tests/container/go/BUILD
+++ b/tests/container/go/BUILD
@@ -40,6 +40,31 @@ container_test(
     image = ":go_image",
 )
 
+# go_image(
+#     name = "go_image_arm",
+#     srcs = ["//testdata:main.go"],
+#     args = [
+#         "arg0",
+#         "arg1",
+#         "$(location :BUILD)",
+#     ],
+#     data = [":BUILD"],
+#     goarch = "arm64",
+#     goos = "linux",
+#     importpath = "github.com/bazelbuild/rules_docker/docker/tests/container/go",
+#     pure = "off",  # we should be using gcr.io/distroless/base as a base image
+#     tags = [
+#         "tag1",
+#         "tag2",
+#     ],
+# )
+
+# container_test(
+#     name = "go_image_arm_test",
+#     configs = ["//tests/container/go/configs:go_image.yaml"],
+#     image = ":go_image_arm",
+# )
+
 go_image(
     name = "go_static_image",
     srcs = ["//testdata:main.go"],
@@ -62,3 +87,28 @@ container_test(
     configs = ["//tests/container/go/configs:go_static_image.yaml"],
     image = ":go_static_image",
 )
+
+# go_image(
+#     name = "go_static_image_arm",
+#     srcs = ["//testdata:main.go"],
+#     args = [
+#         "arg0",
+#         "arg1",
+#         "$(location :BUILD)",
+#     ],
+#     data = [":BUILD"],
+#     goarch = "arm64",
+#     goos = "linux",
+#     importpath = "github.com/bazelbuild/rules_docker/docker/tests/container/go",
+#     pure = "on",  # we should be using gcr.io/distroless/static as a base image
+#     tags = [
+#         "tag1",
+#         "tag2",
+#     ],
+# )
+
+# container_test(
+#     name = "go_static_image_arm_test",
+#     configs = ["//tests/container/go/configs:go_static_image.yaml"],
+#     image = ":go_static_image_arm",
+# )

--- a/tests/container/go/BUILD
+++ b/tests/container/go/BUILD
@@ -40,31 +40,6 @@ container_test(
     image = ":go_image",
 )
 
-# go_image(
-#     name = "go_image_arm",
-#     srcs = ["//testdata:main.go"],
-#     args = [
-#         "arg0",
-#         "arg1",
-#         "$(location :BUILD)",
-#     ],
-#     data = [":BUILD"],
-#     goarch = "arm64",
-#     goos = "linux",
-#     importpath = "github.com/bazelbuild/rules_docker/docker/tests/container/go",
-#     pure = "off",  # we should be using gcr.io/distroless/base as a base image
-#     tags = [
-#         "tag1",
-#         "tag2",
-#     ],
-# )
-
-# container_test(
-#     name = "go_image_arm_test",
-#     configs = ["//tests/container/go/configs:go_image.yaml"],
-#     image = ":go_image_arm",
-# )
-
 go_image(
     name = "go_static_image",
     srcs = ["//testdata:main.go"],
@@ -87,28 +62,3 @@ container_test(
     configs = ["//tests/container/go/configs:go_static_image.yaml"],
     image = ":go_static_image",
 )
-
-# go_image(
-#     name = "go_static_image_arm",
-#     srcs = ["//testdata:main.go"],
-#     args = [
-#         "arg0",
-#         "arg1",
-#         "$(location :BUILD)",
-#     ],
-#     data = [":BUILD"],
-#     goarch = "arm64",
-#     goos = "linux",
-#     importpath = "github.com/bazelbuild/rules_docker/docker/tests/container/go",
-#     pure = "on",  # we should be using gcr.io/distroless/static as a base image
-#     tags = [
-#         "tag1",
-#         "tag2",
-#     ],
-# )
-
-# container_test(
-#     name = "go_static_image_arm_test",
-#     configs = ["//tests/container/go/configs:go_static_image.yaml"],
-#     image = ":go_static_image_arm",
-# )

--- a/update_deps.sh
+++ b/update_deps.sh
@@ -16,8 +16,8 @@
 set -eu
 set -o pipefail
 
-bazel run //container/go/cmd/update_deps -- --repository=gcr.io/distroless/base --output=$PWD/go/go.bzl
-bazel run //container/go/cmd/update_deps -- --repository=gcr.io/distroless/static --output=$PWD/go/static.bzl
+bazel run //container/go/cmd/update_deps -- --repository=gcr.io/distroless/base --output=$PWD/go/go.bzl --architectures=amd64,arm,arm64,ppc64le,s390x
+bazel run //container/go/cmd/update_deps -- --repository=gcr.io/distroless/static --output=$PWD/go/static.bzl --architectures=amd64,arm,arm64,ppc64le,s390x
 bazel run //container/go/cmd/update_deps -- --repository=gcr.io/distroless/cc --output=$PWD/cc/cc.bzl
 bazel run //container/go/cmd/update_deps -- --repository=gcr.io/distroless/python2.7 --output=$PWD/python/python.bzl
 bazel run //container/go/cmd/update_deps -- --repository=gcr.io/distroless/python3 --output=$PWD/python3/python3.bzl


### PR DESCRIPTION
Currently the go_image target always uses an amd64 base image even when goarch is provided by the user
This can be partially worked-around by specifying a base image properly using the arm64 version of the distroless/base manifest, but the call to app_layer does not provide the architecture, resulting in the image being considered as amd64 by docker
This PR makes sure to pass the architecture used to app_layer when actually provided. It is also sourcing the different architectures currently supported by the distroless/base image to be used automatically as base depending on the goarch provided (defaulting to amd64 - current behavior) if not set. If the user wants to still use an amd64 base with an arm64 binary (not sure if there is a use case, but current behavior), the user can specify the base image using the _amd64 target

We could enforce this goarch based on platform as done for go_binary [here](https://github.com/bazelbuild/rules_go/blob/728a9e1874bc965b05c415d7f6b332a86ac35102/go/private/sdk.bzl#L46). This was not done to avoid a larger impact for users who would get an implicit change of base image if building on arm-based machines

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When building a go_image without providing the binary but providing the goarch to be used, the final image is based on the amd64 distroless/base image (even if a different arch is used to build the binary) and the new layer is defined as amd64
While the base image can be provided to properly provide an arm64 image, it cannot be configured for the newly added layer

Issue Number: N/A


## What is the new behavior?
When building a go_image without providing a specific goarch, behavior should remain identical, with the base image based on amd64 and the added layer being amd64
When providing a goarch, go_image will now use the proper base architecture if supported by the distroless image or fail. In this case we expect the user to provide a base image (which can be one of the supported one). The newly added layer will also use goarch as the architecture provided to app_layer

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
There is a potential impact for people using goarch in go_image and not supported in distroless/base. User will have to provide a base image in this case, which can simply be `@go_image_base//image`

## Other information

