### PR TITLE
toolchain: allow to configure build_tar target

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ load("@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
 )
 docker_toolchain_configure(
   name = "docker_config",
+  # OPTIONAL: Bazel target for the build_tar tool, must be compatible with build_tar.py
+  build_tar_target="<enter absolute path (i.e., must start with repo name @...//:...) to an executable build_tar target>",
   # OPTIONAL: Path to a directory which has a custom docker client config.json.
   # See https://docs.docker.com/engine/reference/commandline/cli/#configuration-files
   # for more details.

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -102,7 +102,10 @@ def build_layer(
     """
     toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
     layer = output_layer
-    build_layer_exec = ctx.executable.build_layer
+    if toolchain_info.build_tar_target:
+        build_layer_exec = toolchain_info.build_tar_target.files_to_run.executable
+    else:
+        build_layer_exec = ctx.executable.build_layer
     args = ctx.actions.args()
     args.add(layer, format = "--output=%s")
     args.add(directory, format = "--directory=%s")

--- a/testing/default_toolchain/WORKSPACE
+++ b/testing/default_toolchain/WORKSPACE
@@ -27,6 +27,10 @@ load(
 )
 
 local_tool(
+    name = "build_tar",
+)
+
+local_tool(
     name = "xz",
 )
 
@@ -37,6 +41,7 @@ load(
 
 docker_toolchain_configure(
     name = "docker_config",
+    build_tar_target = "@build_tar//:build_tar",
     xz_target = "@xz//:xz",
 )
 

--- a/toolchains/docker/BUILD.tpl
+++ b/toolchains/docker/BUILD.tpl
@@ -21,6 +21,7 @@ load("@io_bazel_rules_docker//toolchains/docker:toolchain.bzl", "docker_toolchai
 docker_toolchain(
     name = "toolchain",
     client_config = "%{DOCKER_CONFIG}",
+    %{BUILD_TAR_ATTR}
     %{GZIP_ATTR}
     tool_path = "%{DOCKER_TOOL}",
     docker_flags = ["%{DOCKER_FLAGS}"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Current behavior of `build_tar` tool used by `container_layer` is not hermetic, because it implicitly depends on the python toolchain, and as demonstrated by  #1680, this can lead to non-reproducible builds.

## What is the new behavior?

Similar to #1881, this PR adds an optional attribute for toolchain configuration, allowing to pass a hermetic `build_tar_target` executable.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No