### PR TITLE
Maintain old API for backwards compatibility.

### DIFF
--- a/container/go/cmd/digester/digester.go
+++ b/container/go/cmd/digester/digester.go
@@ -49,8 +49,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Unable to determine parts of the image from the specified arguments: %v", err)
 	}
-	r := compat.Reader{Parts: imgParts}
-	img, err := r.ReadImage()
+	img, err := compat.ReadImage(imgParts)
 	if err != nil {
 		log.Fatalf("Error reading image: %v", err)
 	}

--- a/container/go/cmd/flattener/flattener.go
+++ b/container/go/cmd/flattener/flattener.go
@@ -52,8 +52,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Unable to determine parts of the image from the specified arguments: %v", err)
 	}
-	r := compat.Reader{Parts: imgParts}
-	img, err := r.ReadImage()
+	img, err := compat.ReadImage(imgParts)
 	if err != nil {
 		log.Fatalf("Error reading image: %v", err)
 	}

--- a/container/go/cmd/pusher/pusher.go
+++ b/container/go/cmd/pusher/pusher.go
@@ -99,8 +99,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Unable to determine parts of the image from the specified arguments: %v", err)
 	}
-	r := compat.Reader{Parts: imgParts}
-	img, err := r.ReadImage()
+	img, err := compat.ReadImage(imgParts)
 	if err != nil {
 		log.Fatalf("Error reading image: %v", err)
 	}

--- a/container/go/pkg/compat/reader.go
+++ b/container/go/pkg/compat/reader.go
@@ -296,7 +296,7 @@ func (r *Reader) loadLayers() error {
 	return nil
 }
 
-// ReadImage loads a v1.Image from the given ImageParts
+// ReadImage loads a v1.Image from the ImageParts section in the reader.
 func (r *Reader) ReadImage() (v1.Image, error) {
 	// Special case: if we only have a tarball, we can instantiate the image
 	// directly from that. Otherwise, we'll process the image layers
@@ -342,4 +342,11 @@ func (r *Reader) ReadImage() (v1.Image, error) {
 		return nil, errors.Wrap(err, "unable to initialize image from parts")
 	}
 	return img, nil
+}
+
+// ReadImage loads a v1.Image from the given ImageParts
+func ReadImage(parts ImageParts) (v1.Image, error) {
+	r := Reader{Parts: parts}
+	img, err := r.ReadImage()
+	return img, err
 }


### PR DESCRIPTION
Turns out rules_k8s also depended on the ReadImage function. If anyone
else is depending on this, we can maintain backwards compatibility by
keeping the same function signature and having it wrap
Reader.ReadImage().

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

