### PR TITLE
Add target as an attribute to dockerfile_build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -398,6 +398,7 @@ dockerfile_image(
         "ALPINE_version": "3.9",
     },
     dockerfile = "//testdata/dockerfile_build:Dockerfile",
+    target = "test",
     vars = [
         "SOME_VAR",
     ],

--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -36,7 +36,7 @@ def _docker(repository_ctx):
       repository_ctx: The repository context
 
     Returns:
-      Tha path to the docker tool
+      The path to the docker tool
     """
 
     if repository_ctx.attr.docker_path:
@@ -74,6 +74,9 @@ def _impl(repository_ctx):
         img_name,
         str(dockerfile_path.dirname),
     ])
+
+    if repository_ctx.attr.target:
+        command.extend(["--target", repository_ctx.attr.target])
 
     build_result = repository_ctx.execute(command)
     if build_result.return_code:
@@ -119,6 +122,9 @@ dockerfile_image = repository_rule(
         ),
         "vars": attr.string_list(
             doc = "List of environment vars to include in the build.",
+        ),
+        "target": attr.string(
+            doc = "Specify which intermediate stage to finish at, passed to `--target`.",
         ),
     },
     implementation = _impl,

--- a/testdata/dockerfile_build/Dockerfile
+++ b/testdata/dockerfile_build/Dockerfile
@@ -1,7 +1,7 @@
 ARG ALPINE_version
 ARG SOME_VAR=default_value
 
-FROM alpine:${ALPINE_version}
+FROM alpine:${ALPINE_version} AS base
 ENTRYPOINT ["echo"]
 CMD ["Hello World!"]
 
@@ -19,3 +19,11 @@ EXPOSE 9876/udp
 VOLUME /myVol1 /usr/myVol2
 
 RUN apk add gcc python2
+
+FROM base AS test 
+
+RUN echo "Hello from test stage" > /target_test.txt
+
+FROM base
+
+RUN echo "A file that should not exist" > /target_test_base.txt

--- a/tests/contrib/configs/dockerfile_image.yaml
+++ b/tests/contrib/configs/dockerfile_image.yaml
@@ -28,6 +28,12 @@ fileExistenceTests:
   - name: 'copy_txt_file_exists'
     path: '/file_to_copy.txt'
     shouldExist: true
+  - name: 'target_txt_exists'
+    path: '/target_test.txt'
+    shouldExist: true
+  - name: 'base_txt_not_exists'
+    path: '/target_test_base.txt'
+    shouldExist: false
 
 fileContentTests:
   - name: "Alpine version check"
@@ -42,6 +48,9 @@ fileContentTests:
   - name: 'copy_txt_file_contains'
     path: '/file_to_copy.txt'
     expectedContents: ['Another file to copy']
+  - name: 'target_txt_contains'
+    path: '/target_test.txt'
+    expectedContents: ['Hello from test stage']
 
 commandTests:
   - name: "gcc_test"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I wasn't able to build a specific stage of a Dockerfile with the current implementation of `dockerfile_build`

Issue Number: N/A


## What is the new behavior?

You can optionally specify a `target` attribute for `dockerfile_build` that will tell docker to build to that stage. [Docker documentation here](https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

