### PR TITLE
Add tool target attribute to docker toolchain

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -135,7 +135,10 @@ bzl_library(
 bzl_library(
     name = "layer_tools",
     srcs = ["layer_tools.bzl"],
-    deps = ["//skylib:path"],
+    deps = [
+        "//skylib:docker",
+        "//skylib:path",
+    ],
 )
 
 bzl_library(

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -22,6 +22,10 @@ load(
     "//skylib:path.bzl",
     _get_runfile_path = "runfile",
 )
+load(
+    "//skylib:docker.bzl",
+    "docker_path",
+)
 
 def _extract_layers(ctx, name, artifact):
     config_file = ctx.actions.declare_file(name + "." + artifact.basename + ".config")
@@ -277,7 +281,7 @@ def incremental_load(
         template = ctx.file.incremental_load_template,
         substitutions = {
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
-            "%{docker_tool_path}": toolchain_info.tool_path,
+            "%{docker_tool_path}": docker_path(toolchain_info),
             "%{load_statements}": "\n".join(load_statements),
             "%{run_statements}": "\n".join(run_statements),
             "%{run}": str(run),

--- a/contrib/automatic_container_release/BUILD
+++ b/contrib/automatic_container_release/BUILD
@@ -23,6 +23,7 @@ exports_files(["run_checker.sh.tpl"])
 bzl_library(
     name = "configs_test",
     srcs = ["configs_test.bzl"],
+    deps = ["//skylib:docker"],
 )
 
 bzl_library(

--- a/contrib/automatic_container_release/configs_test.bzl
+++ b/contrib/automatic_container_release/configs_test.bzl
@@ -70,7 +70,7 @@ def _impl(ctx):
         substitutions = {
             "%{cmd_args}": " ".join(cmd_args),
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
-            "%{docker_path}": toolchain_info.tool_path,
+            "%{docker_path}": docker_path(toolchain_info),
             "%{image_name}": ctx.attr._checker + ":" + ctx.attr.checker_tag,
             "%{spec_container_paths}": " ".join(spec_container_paths),
             "%{specs}": " ".join(specs),

--- a/contrib/automatic_container_release/configs_test.bzl
+++ b/contrib/automatic_container_release/configs_test.bzl
@@ -20,6 +20,10 @@ load(
     "//skylib:path.bzl",
     "runfile",
 )
+load(
+    "//skylib:docker.bzl",
+    "docker_path",
+)
 
 def _get_runfile_path(ctx, f):
     return "${RUNFILES}/%s" % runfile(ctx, f)

--- a/docker/package_managers/BUILD
+++ b/docker/package_managers/BUILD
@@ -34,5 +34,6 @@ bzl_library(
     deps = [
         "//container",
         "//docker/util",
+        "//skylib:docker",
     ],
 )

--- a/docker/package_managers/download_pkgs.bzl
+++ b/docker/package_managers/download_pkgs.bzl
@@ -101,7 +101,7 @@ def _impl(ctx, image_tar = None, packages = None, additional_repos = None, outpu
         output = output_script,
         substitutions = {
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
-            "%{docker_tool_path}": toolchain_info.tool_path,
+            "%{docker_tool_path}": docker_path(toolchain_info),
             "%{download_commands}": _generate_download_commands(ctx, packages, additional_repos),
             "%{image_id_extractor_path}": ctx.executable._extract_image_id.path,
             "%{image_tar}": image_tar.path,
@@ -127,7 +127,7 @@ def _impl(ctx, image_tar = None, packages = None, additional_repos = None, outpu
         output = output_executable,
         substitutions = {
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
-            "%{docker_tool_path}": toolchain_info.tool_path,
+            "%{docker_tool_path}": docker_path(toolchain_info),
             "%{download_commands}": _generate_download_commands(ctx, packages, additional_repos),
             "%{image_id_extractor_path}": "${RUNFILES}/%s" % runfile(ctx, ctx.executable._extract_image_id),
             "%{image_tar}": image_tar.short_path,

--- a/docker/package_managers/download_pkgs.bzl
+++ b/docker/package_managers/download_pkgs.bzl
@@ -18,6 +18,10 @@ load(
     "//skylib:path.bzl",
     "runfile",
 )
+load(
+    "//skylib:docker.bzl",
+    "docker_path",
+)
 
 def _generate_add_additional_repo_commands(ctx, additional_repos):
     return """printf "{repos}" >> /etc/apt/sources.list.d/{name}_repos.list""".format(

--- a/docker/package_managers/install_pkgs.bzl
+++ b/docker/package_managers/install_pkgs.bzl
@@ -39,6 +39,11 @@ users will write something like:
 
 """
 
+load(
+    "//skylib:docker.bzl",
+    "docker_path",
+)
+
 def _generate_install_commands(tar, installation_cleanup_commands):
     return """
 tar -xvf {tar}

--- a/docker/package_managers/install_pkgs.bzl
+++ b/docker/package_managers/install_pkgs.bzl
@@ -94,7 +94,7 @@ def _impl(ctx, image_tar = None, installables_tar = None, installation_cleanup_c
         output = image_util,
         substitutions = {
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
-            "%{docker_tool_path}": toolchain_info.tool_path,
+            "%{docker_tool_path}": docker_path(toolchain_info),
         },
         is_executable = True,
     )
@@ -106,7 +106,7 @@ def _impl(ctx, image_tar = None, installables_tar = None, installation_cleanup_c
         substitutions = {
             "%{base_image_tar}": image_tar.path,
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
-            "%{docker_tool_path}": toolchain_info.tool_path,
+            "%{docker_tool_path}": docker_path(toolchain_info),
             "%{image_id_extractor_path}": ctx.executable._extract_image_id.path,
             "%{installables_tar}": installables_tar_path,
             "%{installer_script}": install_script.path,

--- a/docker/util/BUILD
+++ b/docker/util/BUILD
@@ -40,6 +40,7 @@ exports_files([
 bzl_library(
     name = "util",
     srcs = ["run.bzl"],
+    deps = ["//skylib:docker"],
 )
 
 # Re-package config_stripper as a library to be used in unit tests.

--- a/docker/util/run.bzl
+++ b/docker/util/run.bzl
@@ -29,6 +29,10 @@ load(
     "//skylib:zip.bzl",
     _zip_tools = "tools",
 )
+load(
+    "//skylib:docker.bzl",
+    "docker_path",
+)
 
 def _extract_impl(
         ctx,

--- a/docker/util/run.bzl
+++ b/docker/util/run.bzl
@@ -79,7 +79,7 @@ def _extract_impl(
             "%{commands}": _process_commands(commands),
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
             "%{docker_run_flags}": " ".join(docker_run_flags),
-            "%{docker_tool_path}": toolchain_info.tool_path,
+            "%{docker_tool_path}": docker_path(toolchain_info),
             "%{extract_file}": extract_file,
             "%{image_id_extractor_path}": ctx.executable._extract_image_id.path,
             "%{image_tar}": image.path,
@@ -196,7 +196,7 @@ def _commit_impl(
         output = image_utils,
         substitutions = {
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
-            "%{docker_tool_path}": toolchain_info.tool_path,
+            "%{docker_tool_path}": docker_path(toolchain_info),
         },
         is_executable = True,
     )
@@ -209,7 +209,7 @@ def _commit_impl(
             "%{commands}": _process_commands(commands),
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
             "%{docker_run_flags}": " ".join(docker_run_flags),
-            "%{docker_tool_path}": toolchain_info.tool_path,
+            "%{docker_tool_path}": docker_path(toolchain_info),
             "%{image_id_extractor_path}": ctx.executable._extract_image_id.path,
             "%{image_tar}": image.path,
             "%{output_image}": "bazel/%s:%s" % (
@@ -344,7 +344,7 @@ def _commit_layer_impl(
         output = image_utils,
         substitutions = {
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
-            "%{docker_tool_path}": toolchain_info.tool_path,
+            "%{docker_tool_path}": docker_path(toolchain_info),
         },
         is_executable = True,
     )
@@ -370,7 +370,7 @@ def _commit_layer_impl(
             "%{commands}": _process_commands(commands),
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
             "%{docker_run_flags}": " ".join(docker_run_flags),
-            "%{docker_tool_path}": toolchain_info.tool_path,
+            "%{docker_tool_path}": docker_path(toolchain_info),
             "%{env_file_path}": env_file.path,
             "%{image_id_extractor_path}": ctx.executable._extract_image_id.path,
             "%{image_last_layer_extractor_path}": ctx.executable._last_layer_extractor_tool.path,

--- a/skylib/BUILD
+++ b/skylib/BUILD
@@ -19,6 +19,11 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 bzl_library(
+    name = "docker",
+    srcs = ["docker.bzl"],
+)
+
+bzl_library(
     name = "filetype",
     srcs = ["filetype.bzl"],
 )

--- a/skylib/docker.bzl
+++ b/skylib/docker.bzl
@@ -1,0 +1,13 @@
+def docker_path(toolchain_info):
+    """Resolve the user-supplied docker path, if any.
+
+    Args:
+       toolchain_info: The DockerToolchainInfo
+
+    Returns:
+       Path to docker
+    """
+    if toolchain_info.tool_target:
+        return toolchain_info.tool_target.files_to_run.executable.path
+    else:
+        return toolchain_info.tool_path

--- a/skylib/docker.bzl
+++ b/skylib/docker.bzl
@@ -1,3 +1,18 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Common functions for docker library"""
+
 def docker_path(toolchain_info):
     """Resolve the user-supplied docker path, if any.
 

--- a/toolchains/docker/BUILD.tpl
+++ b/toolchains/docker/BUILD.tpl
@@ -22,7 +22,7 @@ docker_toolchain(
     name = "toolchain",
     client_config = "%{DOCKER_CONFIG}",
     %{GZIP_ATTR}
-    tool_path = "%{DOCKER_TOOL}",
+    %{TOOL_ATTR}
     docker_flags = ["%{DOCKER_FLAGS}"],
     %{XZ_ATTR}
 )

--- a/toolchains/docker/readme.md
+++ b/toolchains/docker/readme.md
@@ -58,7 +58,7 @@ def _impl(ctx):
     # Get the DockerToolchainInfo provider
     toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
     # Path to the docker tool
-    docker_path = toolchain_info.tool_path
+    docker_path = docker_path(toolchain_info)
     ...
 ```
 See [toolchain.bzl](toolchain.bzl) for the definition of the DockerToolchainInfo provider

--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -29,7 +29,7 @@ DockerToolchainInfo = provider(
                        "Should only be set if gzip_path is unset.",
         "tool_path": "Path to the docker executable",
         "tool_target": "Bazel target for the docker tool. " +
-                        "Should only be set if tool_path is unset.",
+                       "Should only be set if tool_path is unset.",
         "xz_path": "Optional path to the xz binary. This is used by " +
                    "build_tar.py when the Python lzma module is unavailable. " +
                    "If not set found via which.",

--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -46,6 +46,7 @@ def _docker_toolchain_impl(ctx):
             gzip_path = ctx.attr.gzip_path,
             gzip_target = ctx.attr.gzip_target,
             tool_path = ctx.attr.tool_path,
+            tool_target = ctx.attr.tool_target,
             xz_path = ctx.attr.xz_path,
             xz_target = ctx.attr.xz_target,
         ),

--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -28,6 +28,8 @@ DockerToolchainInfo = provider(
         "gzip_target": "Optional Bazel target for the gzip tool. " +
                        "Should only be set if gzip_path is unset.",
         "tool_path": "Path to the docker executable",
+        "tool_target": "Bazel target for the docker tool. " +
+                        "Should only be set if tool_path is unset.",
         "xz_path": "Optional path to the xz binary. This is used by " +
                    "build_tar.py when the Python lzma module is unavailable. " +
                    "If not set found via which.",
@@ -80,6 +82,13 @@ docker_toolchain = rule(
         "tool_path": attr.string(
             doc = "Path to the docker binary.",
         ),
+        "tool_target": attr.label(
+            allow_files = True,
+            doc = "Bazel target for the docker tool. " +
+                  "Should only be set if tool_path is unset.",
+            cfg = "host",
+            executable = True,
+        ),
         "xz_path": attr.string(
             doc = "Optional path to the xz binary. This is used by " +
                   "build_tar.py when the Python lzma module is unavailable.",
@@ -95,15 +104,20 @@ docker_toolchain = rule(
 )
 
 def _toolchain_configure_impl(repository_ctx):
+    if repository_ctx.attr.docker_target and repository_ctx.attr.docker_path:
+        fail("Only one of docker_target or docker_path can be set.")
     if repository_ctx.attr.gzip_target and repository_ctx.attr.gzip_path:
         fail("Only one of gzip_target or gzip_path can be set.")
     if repository_ctx.attr.xz_target and repository_ctx.attr.xz_path:
         fail("Only one of xz_target or xz_path can be set.")
-    tool_path = ""
-    if repository_ctx.attr.docker_path:
-        tool_path = repository_ctx.attr.docker_path
+
+    tool_attr = ""
+    if repository_ctx.attr.docker_target:
+        tool_attr = "tool_target = \"%s\"," % repository_ctx.attr.tool_target
+    elif repository_ctx.attr.docker_path:
+        tool_attr = "tool_path = \"%s\"," % repository_ctx.attr.docker_path
     elif repository_ctx.which("docker"):
-        tool_path = repository_ctx.which("docker")
+        tool_attr = "tool_path = \"%s\"," % repository_ctx.which("docker")
 
     xz_attr = ""
     if repository_ctx.attr.xz_target:
@@ -130,7 +144,7 @@ def _toolchain_configure_impl(repository_ctx):
         {
             "%{DOCKER_CONFIG}": "%s" % client_config,
             "%{DOCKER_FLAGS}": "%s" % "\", \"".join(docker_flags),
-            "%{DOCKER_TOOL}": "%s" % tool_path,
+            "%{TOOL_ATTR}": "%s" % tool_attr,
             "%{GZIP_ATTR}": "%s" % gzip_attr,
             "%{XZ_ATTR}": "%s" % xz_attr,
         },
@@ -170,6 +184,11 @@ toolchain_configure = repository_rule(
             doc = "The full path to the docker binary. If not specified, it will " +
                   "be searched for in the path. If not available, running commands " +
                   "that require docker (e.g., incremental load) will fail.",
+        ),
+        "docker_target": attr.string(
+            mandatory = False,
+            doc = "The bazel target for the docker tool. " +
+                  "Can only be set if docker_path is not set.",
         ),
         "gzip_path": attr.string(
             mandatory = False,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

Regarding 👇, do you have docs about how to add tests and how to generate docs?

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, there is no way to supply a docker client as a target, which requires you to install docker not part of Bazel


## What is the new behavior?
Just like the other tools in the toolchain (gzip, xz), you can supply `docker_target` in order to get the docker client from bazel

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
