### PR TITLE
Make jar_app_layer._classpath_as_file public

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -69,12 +69,15 @@ tasks:
       - -//tests/container/go:go_image_test
       - -//tests/container/go:go_static_image_test
       - -//tests/container/groovy:groovy_image_test
+      - -//tests/container/groovy:groovy_classpath_as_file_image_test
       - -//tests/container/java:java_image_test
+      - -//tests/container/java:java_classpath_as_file_image_test
       - -//tests/container/java:java_partial_entrypoint_image_test
       - -//tests/container/java:java_runfiles_as_lib_image_test
       - -//tests/container/java:java_runfiles_image_test
       - -//tests/container/java:simple_java_entrypoint_image_test
       - -//tests/container/kotlin:kotlin_image_test
+      - -//tests/container/kotlin:kotlin_classpath_as_file_image_test
       - -//tests/container/nodejs:nodejs_image_custom_binary_test
       - -//tests/container/nodejs:nodejs_image_custom_binary_with_args_test
       - -//tests/container/nodejs:nodejs_image_empty_list_args_test
@@ -86,6 +89,7 @@ tasks:
       - -//tests/container/python3:py3_image_test
       - -//tests/container/rust:rust_image_test
       - -//tests/container/scala:scala_image_test
+      - -//tests/container/scala:scala_classpath_as_file_image_test
       - -//tests/contrib:derivative_with_volume_repro_test
       - -//tests/contrib:random_file_img_non_repro_test
       - -//tests/contrib:rbe-test-xenial_repro_test

--- a/groovy/image.bzl
+++ b/groovy/image.bzl
@@ -33,6 +33,7 @@ def groovy_image(
         deps = [],
         layers = [],
         jvm_flags = [],
+        classpath_as_file = None,
         **kwargs):
     """Builds a container image overlaying the groovy_binary.
 
@@ -93,6 +94,7 @@ def groovy_image(
         args = kwargs.get("args"),
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
+        classpath_as_file = classpath_as_file,
     )
 
 def repositories():

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -265,6 +265,7 @@ def java_image(
         runtime_deps = [],
         layers = [],
         jvm_flags = [],
+        classpath_as_file = None,
         **kwargs):
     """Builds a container image overlaying the java_binary.
 
@@ -327,6 +328,7 @@ def java_image(
         args = kwargs.get("args"),
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
+        classpath_as_file = classpath_as_file,
     )
 
 def _war_dep_layer_impl(ctx):

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -201,7 +201,7 @@ def _jar_app_layer_impl(ctx):
         "/usr/bin/java",
         "-cp",
         # Support optionally passing the classpath as a file.
-        "@" + classpath_path if ctx.attr._classpath_as_file else classpath,
+        "@" + classpath_path if ctx.attr.classpath_as_file else classpath,
     ] + jvm_flags + ([ctx.attr.main_class] + args if ctx.attr.main_class != "" else [])
 
     file_map = {
@@ -245,7 +245,7 @@ jar_app_layer = rule(
         "workdir": attr.string(default = ""),
 
         # Whether the classpath should be passed as a file.
-        "_classpath_as_file": attr.bool(default = False),
+        "classpath_as_file": attr.bool(default = False),
         "_jdk": attr.label(
             default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
             providers = [java_common.JavaRuntimeInfo],

--- a/kotlin/image.bzl
+++ b/kotlin/image.bzl
@@ -34,6 +34,7 @@ def kt_jvm_image(
         deps = [],
         layers = [],
         jvm_flags = [],
+        classpath_as_file = None,
         **kwargs):
     """Builds a container image overlaying the kt_jvm_binary.
 
@@ -92,6 +93,7 @@ def kt_jvm_image(
         args = kwargs.get("args"),
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
+        classpath_as_file = classpath_as_file,
     )
 
 def repositories():

--- a/scala/image.bzl
+++ b/scala/image.bzl
@@ -33,6 +33,7 @@ def scala_image(
         runtime_deps = [],
         layers = [],
         jvm_flags = [],
+        classpath_as_file = None,
         **kwargs):
     """Builds a container image overlaying the scala_binary.
 
@@ -85,6 +86,7 @@ def scala_image(
         args = kwargs.get("args"),
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
+        classpath_as_file = classpath_as_file,
     )
 
 def repositories():

--- a/tests/container/groovy/BUILD
+++ b/tests/container/groovy/BUILD
@@ -38,8 +38,29 @@ groovy_image(
     main_class = "examples.images.Binary",
 )
 
+groovy_image(
+    name = "groovy_classpath_as_file_image",
+    srcs = ["//testdata:Binary.groovy"],
+    args = [
+        "arg0",
+        "arg1",
+        "$(location :BUILD)",
+    ],
+    classpath_as_file = True,
+    data = [":BUILD"],
+    jvm_flags = ["-Dbuild.location=$(location :BUILD)"],
+    layers = [":groovy_image_library"],
+    main_class = "examples.images.Binary",
+)
+
 container_test(
     name = "groovy_image_test",
     configs = ["//tests/container/groovy/configs:groovy_image.yaml"],
     image = ":groovy_image",
+)
+
+container_test(
+    name = "groovy_classpath_as_file_image_test",
+    configs = ["//tests/container/groovy/configs:groovy_classpath_as_file_image.yaml"],
+    image = ":groovy_classpath_as_file_image",
 )

--- a/tests/container/groovy/configs/groovy_classpath_as_file_image.yaml
+++ b/tests/container/groovy/configs/groovy_classpath_as_file_image.yaml
@@ -1,0 +1,13 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  entrypoint: [
+    '/usr/bin/java',
+    '-cp',
+    '@/app/io_bazel_rules_docker/tests/container/groovy/groovy_classpath_as_file_image.classpath',
+    '-Dbuild.location=tests/container/groovy/BUILD',
+    'examples.images.Binary',
+    'arg0',
+    'arg1',
+    'tests/container/groovy/BUILD',
+  ]

--- a/tests/container/java/BUILD
+++ b/tests/container/java/BUILD
@@ -52,6 +52,23 @@ java_image(
 )
 
 java_image(
+    name = "java_classpath_as_file_image",
+    srcs = ["//testdata:Binary.java"],
+    args = [
+        "arg0",
+        "arg1",
+        "$(location :BUILD)",
+    ],
+    classpath_as_file = True,
+    data = [":BUILD"],
+    jvm_flags = [
+        "-Dbuild.location=$(location :BUILD)",
+    ],
+    layers = [":java_image_library"],
+    main_class = "examples.images.Binary",
+)
+
+java_image(
     name = "java_runfiles_image",
     srcs = ["//testdata:Runfiles.java"],
     data = [
@@ -89,6 +106,12 @@ container_test(
     name = "java_image_test",
     configs = ["//tests/container/java/configs:java_image.yaml"],
     image = ":java_image",
+)
+
+container_test(
+    name = "java_classpath_as_file_image_test",
+    configs = ["//tests/container/java/configs:java_classpath_as_file_image.yaml"],
+    image = ":java_classpath_as_file_image",
 )
 
 container_test(

--- a/tests/container/java/configs/java_classpath_as_file_image.yaml
+++ b/tests/container/java/configs/java_classpath_as_file_image.yaml
@@ -1,0 +1,15 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  env:
+    - key: JAVA_RUNFILES
+      value: "/app"
+  entrypoint: [
+        '/usr/bin/java',
+        '-cp',
+        '@/app/io_bazel_rules_docker/tests/container/java/java_classpath_as_file_image.classpath',
+        '-Dbuild.location=tests/container/java/BUILD',
+        'examples.images.Binary',
+        'arg0',
+        'arg1',
+        'tests/container/java/BUILD']

--- a/tests/container/kotlin/BUILD
+++ b/tests/container/kotlin/BUILD
@@ -34,8 +34,32 @@ kt_jvm_image(
     deps = [],
 )
 
+kt_jvm_image(
+    name = "kt_jvm_classpath_as_file_image",
+    srcs = [
+        "//testdata:Binary.kt",
+        "//testdata:Library.kt",
+    ],
+    args = [
+        "arg0",
+        "arg1",
+        "$(location :BUILD)",
+    ],
+    classpath_as_file = True,
+    data = [":BUILD"],
+    jvm_flags = ["-Dbuild.location=$(location :BUILD)"],
+    main_class = "examples.images.Binary",
+    deps = [],
+)
+
 container_test(
     name = "kotlin_image_test",
     configs = ["//tests/container/kotlin/configs:kt_jvm_image.yaml"],
     image = ":kt_jvm_image",
+)
+
+container_test(
+    name = "kotlin_classpath_as_file_image_test",
+    configs = ["//tests/container/kotlin/configs:kt_jvm_classpath_as_file_image.yaml"],
+    image = ":kt_jvm_classpath_as_file_image",
 )

--- a/tests/container/kotlin/configs/kt_jvm_classpath_as_file_image.yaml
+++ b/tests/container/kotlin/configs/kt_jvm_classpath_as_file_image.yaml
@@ -1,0 +1,13 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  entrypoint: [
+    '/usr/bin/java',
+    '-cp',
+    '@/app/io_bazel_rules_docker/tests/container/kotlin/kt_jvm_classpath_as_file_image.classpath',
+    '-Dbuild.location=tests/container/kotlin/BUILD',
+    'examples.images.Binary',
+    'arg0',
+    'arg1',
+    'tests/container/kotlin/BUILD',
+  ]

--- a/tests/container/scala/BUILD
+++ b/tests/container/scala/BUILD
@@ -43,3 +43,24 @@ container_test(
     configs = ["//tests/container/scala/configs:scala_image.yaml"],
     image = ":scala_image",
 )
+
+scala_image(
+    name = "scala_classpath_as_file_image",
+    srcs = ["//testdata:Binary.scala"],
+    args = [
+        "arg0",
+        "arg1",
+        "$(location :BUILD)",
+    ],
+    classpath_as_file = True,
+    data = [":BUILD"],
+    jvm_flags = ["-Dbuild.location=$(location :BUILD)"],
+    layers = [":scala_image_library"],
+    main_class = "examples.images.Binary",
+)
+
+container_test(
+    name = "scala_classpath_as_file_image_test",
+    configs = ["//tests/container/scala/configs:scala_classpath_as_file_image.yaml"],
+    image = ":scala_classpath_as_file_image",
+)

--- a/tests/container/scala/configs/scala_classpath_as_file_image.yaml
+++ b/tests/container/scala/configs/scala_classpath_as_file_image.yaml
@@ -1,0 +1,13 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  entrypoint: [
+    '/usr/bin/java',
+    '-cp',
+    '@/app/io_bazel_rules_docker/tests/container/scala/scala_classpath_as_file_image.classpath',
+    '-Dbuild.location=tests/container/scala/BUILD',
+    'examples.images.Binary',
+    'arg0',
+    'arg1',
+    'tests/container/scala/BUILD',
+  ]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Callers of `jar_app_layer` can not specify `_classpath_as_file`.

## What is the new behavior?

Yes. It changes the `jar_app_layer._classpath_as_file` private attribute to a public attribute `jar_app_layer.classpath_as_file`. This allows callers to override the default value of `False` when applying the `jar_app_layer` rule.

The PR also make the callers of `jar_app_layer` expose an optional `classpath_as_file` argument so that folks can passthrough the argument to `jar_app_layer`.

Some details of why someone would want to do this can be found in the [Bazel slack](https://bazelbuild.slack.com/archives/CA3NW13MH/p1635778927010700?thread_ts=1635545233.009800&cid=CA3NW13MH)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Given that the `classpath_as_file` was private before, folks couldn't pass it in before so I would think that changing from private to public is a non-breaking change. The other changes to the various jvm `*_image` macros keep the previous behavior as the default.


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

