### PR TITLE
Update to a more recent rules rust and update to use defs.bzl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -333,11 +333,11 @@ _go_image_repos()
 # For our rust_image test
 http_archive(
     name = "rules_rust",
-    sha256 = "42e60f81e2b269d28334b73b70d02fb516c8de0c16242f5d376bfe6d94a3509f",
-    strip_prefix = "rules_rust-58f709ffec90da93c4e622d8d94f0cd55cd2ef54",
+    sha256 = "d6a8bc37502f252ef190b37945c922e0d0104dc2250940a3ea5f9c42e7a0dc10",
+    strip_prefix = "rules_rust-e2f0fccda912daac686b533ad77c5bc5d2f2ddb7",
     urls = [
-        # Master branch as of 2021-02-04
-        "https://github.com/bazelbuild/rules_rust/archive/58f709ffec90da93c4e622d8d94f0cd55cd2ef54.tar.gz",
+        # `main` branch as of 2021-11-05
+        "https://github.com/bazelbuild/rules_rust/archive/e2f0fccda912daac686b533ad77c5bc5d2f2ddb7.tar.gz",
     ],
 )
 

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -16,7 +16,7 @@
 The signature of this rule is compatible with rust_binary.
 """
 
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 load(
     "//cc:image.bzl",
     "DEFAULT_BASE",


### PR DESCRIPTION
Rules rust has made some changes upstream that remove the rust.bzl file.
It had previously been left in there for compatibility purposes.  This
has been ongoing since February 16th.  See this issue for additional
context: https://github.com/bazelbuild/rules_rust/issues/591.  Replaces
PRs #1950 and #1951.

Fixes #1949

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe: