### PR TITLE
Add digests of the images being used for examples

### DIFF
--- a/testing/examples/WORKSPACE
+++ b/testing/examples/WORKSPACE
@@ -43,6 +43,7 @@ _java_image_repos()
 
 container_pull(
     name = "alpine_linux_amd64",
+    digest = "sha256:954b378c375d852eb3c63ab88978f640b4348b01c1b3456a024a81536dafbbf4",
     registry = "index.docker.io",
     repository = "library/alpine",
     tag = "3.8",
@@ -50,6 +51,7 @@ container_pull(
 
 container_pull(
     name = "ubuntu1604",
+    digest = "sha256:8f0b64fd212007183434b8b3271b723700ab14e4230b5bec1415b79aaa3ac97b",
     registry = "l.gcr.io",
     repository = "google/ubuntu1604",
     tag = "latest",
@@ -57,6 +59,7 @@ container_pull(
 
 container_pull(
     name = "bazel_image",
+    digest = "sha256:ace9881e6e9c5d48b5fd637321361aeffe54000265894a65f7d818dc1065bd80",
     registry = "launcher.gcr.io",
     repository = "google/bazel",
 )

--- a/testing/examples/WORKSPACE
+++ b/testing/examples/WORKSPACE
@@ -46,6 +46,7 @@ container_pull(
     digest = "sha256:954b378c375d852eb3c63ab88978f640b4348b01c1b3456a024a81536dafbbf4",
     registry = "index.docker.io",
     repository = "library/alpine",
+    # tag field is ignored since digest is set
     tag = "3.8",
 )
 
@@ -54,6 +55,7 @@ container_pull(
     digest = "sha256:8f0b64fd212007183434b8b3271b723700ab14e4230b5bec1415b79aaa3ac97b",
     registry = "l.gcr.io",
     repository = "google/ubuntu1604",
+    # tag field is ignored since digest is set
     tag = "latest",
 )
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

In `testing/examples`, running `bazel test //...` yields the following warnings that digests of the images being used are not specified:

```
DEBUG: Rule 'ubuntu1604' indicated that a canonical reproducible form can be obtained by modifying arguments digest = "sha256:8f0b64fd212007183434b8b3271b723700ab14e4230b5bec1415b79aaa3ac97b"
DEBUG: Repository ubuntu1604 instantiated at:
  /home/t/rules_docker/testing/examples/WORKSPACE:51:15: in <toplevel>
Repository rule container_pull defined at:
  /home/t/.cache/bazel/_bazel_t/8f44971fccf59391c1b86a62b75f492c/external/io_bazel_rules_docker/container/pull.bzl:270:33: in <toplevel>
DEBUG: Rule 'bazel_image' indicated that a canonical reproducible form can be obtained by modifying arguments digest = "sha256:ace9881e6e9c5d48b5fd637321361aeffe54000265894a65f7d818dc1065bd80"
DEBUG: Repository bazel_image instantiated at:
  /home/t/rules_docker/testing/examples/WORKSPACE:58:15: in <toplevel>
Repository rule container_pull defined at:
  /home/t/.cache/bazel/_bazel_t/8f44971fccf59391c1b86a62b75f492c/external/io_bazel_rules_docker/container/pull.bzl:270:33: in <toplevel>
DEBUG: Rule 'alpine_linux_amd64' indicated that a canonical reproducible form can be obtained by modifying arguments digest = "sha256:954b378c375d852eb3c63ab88978f640b4348b01c1b3456a024a81536dafbbf4"
DEBUG: Repository alpine_linux_amd64 instantiated at:
  /home/t/rules_docker/testing/examples/WORKSPACE:44:15: in <toplevel>
Repository rule container_pull defined at:
  /home/t/.cache/bazel/_bazel_t/8f44971fccf59391c1b86a62b75f492c/external/io_bazel_rules_docker/container/pull.bzl:270:33: in <toplevel>
```

Issue Number: N/A

## What is the new behavior?

Specifies the digests suggested by the warnings.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

