### PR TITLE
fix: add label to tar warning message

### DIFF
--- a/container/push.bzl
+++ b/container/push.bzl
@@ -82,7 +82,7 @@ def _impl(ctx):
     tarball = image.get("legacy")
     if tarball:
         print("Pushing an image based on a tarball can be very " +
-              "expensive.  If the image is the output of a " +
+              "expensive. If the image set on %s is the output of a " % ctx.label +
               "container_build, consider dropping the '.tar' extension. " +
               "If the image is checked in, consider using " +
               "container_import instead.")


### PR DESCRIPTION
Add the label to the warning message about setting a tar on a push rule. 
In a large repo, the source of this warning is tricky to track down without the label of the rule being present in the message.