### PR TITLE
update distroless images

### DIFF
--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:3680c61e81f68fc00bfb5e1ec65e8e678aaafa7c5f056bc2681c29527ebbb30c",
-    # "gcr.io/distroless/cc:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:2c4bb6b7236db0a55ec54ba8845e4031f5db2be957ac61867872bf42e56c4deb",
+    # "gcr.io/distroless/cc:debug" circa 2021-12-01 22:45 +0200
+    "debug": "sha256:fbf229f6c5fcf038de4a7fa8139119c92785e24e68f9f26ef0906ad6d37bc62c",
+    # "gcr.io/distroless/cc:latest" circa 2021-12-01 22:45 +0200
+    "latest": "sha256:ceab2b378860e134f3b470f153fbd1117b81438ae51ab97e2568149e9883cd32",
 }

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:efd8711717d9e9b5d0dbb20ea10876dab0609c923bc05321b912f9239090ca80",
-    # "gcr.io/distroless/base:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:ba7a315f86771332e76fa9c3d423ecfdbb8265879c6f1c264d6fff7d4fa460a4",
+    # "gcr.io/distroless/base:debug" circa 2021-12-01 22:44 +0200
+    "debug": "sha256:4e644c5d3a7341cf7ca568fe33356734601ad90d6be01a07090cf48c4f329371",
+    # "gcr.io/distroless/base:latest" circa 2021-12-01 22:44 +0200
+    "latest": "sha256:0530d193888bcd7bd0376c8b34178ea03ddb0b2b18caf265135b6d3a393c8d05",
 }

--- a/go/static.bzl
+++ b/go/static.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/static:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:a8fc00a6b3fe7b536b0731df01574c2113cad63c6196246126224c698265a885",
-    # "gcr.io/distroless/static:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:aadea1b1f16af043a34491eec481d0132479382096ea34f608087b4bef3634be",
+    # "gcr.io/distroless/static:debug" circa 2021-12-01 22:44 +0200
+    "debug": "sha256:6450ee51087a953dd2c771d2dcdeb89fa570bfb9f2e9a70efd0494c49e79f319",
+    # "gcr.io/distroless/static:latest" circa 2021-12-01 22:44 +0200
+    "latest": "sha256:fac888659ca3eb59f7d5dcb0d62540cc5c53615e2671062b36c815d000da8ef4",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:0551431d74d180cb50e5354732388aff55e896691ad79f20da4897fecee1feed",
-    # "gcr.io/distroless/java:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:5b4bb0f378489f8b15547d79844a9e7b5343539051d99942f414872e380124a2",
+    # "gcr.io/distroless/java:debug" circa 2021-12-01 22:45 +0200
+    "debug": "sha256:eeb8d72edc294dbc99165147d281ce98ca305b1262aacdb8515f1118e9be73d5",
+    # "gcr.io/distroless/java:latest" circa 2021-12-01 22:45 +0200
+    "latest": "sha256:1d377403a44d32779be00fceec4803be0301c7f4a62b72d7307dc411860c24c3",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:c5966df7d452e1e91043d364bc193ad0fc084fab9885d1d1c55c78c69bf810d7",
-    # "gcr.io/distroless/java/jetty:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:3b4445909b0af7d1203ba9d6cd571cbc4ea14f3fd2eb5cedc51f9fc2c5560f77",
+    # "gcr.io/distroless/java/jetty:debug" circa 2021-12-01 22:45 +0200
+    "debug": "sha256:dd69072db325f955cd55d0adad84e80b9e94f738adc2e2158c1244c3a2c4b2bc",
+    # "gcr.io/distroless/java/jetty:latest" circa 2021-12-01 22:45 +0200
+    "latest": "sha256:3f2d63f336d2adc95547b9a6cb462388130c0ee089a32caaea19df58e05a0f6a",
 }

--- a/nodejs/nodejs.bzl
+++ b/nodejs/nodejs.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/google-appengine/debian9:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:b64677de34eeb83c55dd874d9b7e3ae74ff6e41a81bbe199c5f80bbcb339f9f4",
-    # "gcr.io/google-appengine/debian9:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:b64677de34eeb83c55dd874d9b7e3ae74ff6e41a81bbe199c5f80bbcb339f9f4",
+    # "gcr.io/google-appengine/debian9:debug" circa 2021-12-01 22:45 +0200
+    "debug": "sha256:8e4639cb270046abd646f7cc7c16363b778149513a2f27b86494e135b2760dbf",
+    # "gcr.io/google-appengine/debian9:latest" circa 2021-12-01 22:45 +0200
+    "latest": "sha256:8e4639cb270046abd646f7cc7c16363b778149513a2f27b86494e135b2760dbf",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2021-09-25 14:45 -0400
+    # "gcr.io/distroless/python2.7:debug" circa 2021-12-01 22:45 +0200
     "debug": "sha256:85f45e3b5ab66da2eb04c10d29519deb21bf14bcfa8fa6769817db4f031ad3c9",
-    # "gcr.io/distroless/python2.7:latest" circa 2021-09-25 14:45 -0400
+    # "gcr.io/distroless/python2.7:latest" circa 2021-12-01 22:45 +0200
     "latest": "sha256:83b8dc7881f3e3c85740bfffd32b7ce64527757e74c68d6a31102a7d1b2a977b",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2021-09-25 14:45 -0400
-    "debug": "sha256:ec7b6f080ace2ad18677441351405477f41c9b3bb2574cc524bddc5218e8231b",
-    # "gcr.io/distroless/python3:latest" circa 2021-09-25 14:45 -0400
-    "latest": "sha256:646751d617197447aedc0899d5d3db65b5538f21dec368e5406f96178151b206",
+    # "gcr.io/distroless/python3:debug" circa 2021-12-01 22:45 +0200
+    "debug": "sha256:c6374d0612e77d912c17690eecc6fbca1b9402814cd5bc61adad23824b87388c",
+    # "gcr.io/distroless/python3:latest" circa 2021-12-01 22:45 +0200
+    "latest": "sha256:70feef894a89e769eb0b5e3b0c04d7006d4eb7753fc6b797ce4b86d7deafcf13",
 }


### PR DESCRIPTION
This update was initiated mainly to update `cc_image` distroless image to debian11

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
distroless images have moved to debian11 as a default on 30/09:[https://github.com/GoogleContainerTools/distroless/issues/844](source)

`cc_image` latest digest tag `sha256:2c4bb6b7236db0a55ec54ba8845e4031f5db2be957ac61867872bf42e56c4deb`
still points to a debian10 image: 
```
$ docker run gcr.io/distroless/cc@sha256:2c4bb6b7236db0a55ec54ba8845e4031f5db2be957ac61867872bf42e56c4deb /lib/x86_64-linux-gnu/libc.so.6

GNU C Library (Debian GLIBC 2.28-10) stable release version 2.28.
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.
Compiled by GNU CC version 8.3.0.
libc ABIs: UNIQUE IFUNC ABSOLUTE
For bug reporting instructions, please see:
<http://www.debian.org/Bugs/>.
```
which breaks c++ applications on mismatching glib versions:
```
/app/main: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by /app/main)
/app/main: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /app/main)
```

Issue Number: N/A

## What is the new behavior?

Updated cc_image based on debian11

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

