### PR TITLE
.bazelrc: remove --incompatible_disable_depset_items

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,8 +18,6 @@
 build --incompatible_use_python_toolchains
 test --incompatible_use_python_toolchains
 
-build --incompatible_disable_depset_items
-
 # The flags below enable running tests using Remote Build Execution
 # for the provided toolchain.
 # Note that your WORKSPACE must contain an rbe_autoconfig target with


### PR DESCRIPTION
`--incompatible_disable_depset_items` is removed at Bazel@HEAD and is turned on by default in 5.0.
See https://github.com/bazelbuild/rules_docker/pull/1977#issuecomment-998651425

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

