### PR TITLE
Allow support for `WORKSPACE.bazel` files

### DIFF
--- a/repositories/deps.bzl
+++ b/repositories/deps.bzl
@@ -21,12 +21,18 @@ repository.
 
 load(":go_repositories.bzl", "go_deps")
 
-def deps():
+# TODO: `go_repository_default_config` is only useful for working around
+# https://github.com/bazelbuild/rules_docker/issues/1902 and could likely be
+# removed after https://github.com/bazelbuild/rules_docker/issues/1787
+def deps(go_repository_default_config = "@//:WORKSPACE"):
     """Pull in external dependencies needed by rules in this repo.
 
     Pull in all dependencies needed to run rules in this
     repository. This function assumes the repositories imported by the macro
     'repositories' in //repositories:repositories.bzl have been imported
     already.
+
+    Args:
+        go_repository_default_config (str, optional): A file used to determine the root of the workspace.
     """
-    go_deps()
+    go_deps(go_repository_default_config = go_repository_default_config)

--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -22,17 +22,23 @@ repository.
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
-def go_deps():
+# TODO: `go_repository_default_config` is only useful for working around
+# https://github.com/bazelbuild/rules_docker/issues/1902 and could likely be
+# removed after https://github.com/bazelbuild/rules_docker/issues/1787
+def go_deps(go_repository_default_config = "@//:WORKSPACE"):
     """Pull in external Go packages needed by Go binaries in this repo.
 
     Pull in all dependencies needed to build the Go binaries in this
     repository. This function assumes the repositories imported by the macro
     'repositories' in //repositories:repositories.bzl have been imported
     already.
+
+    Args:
+        go_repository_default_config (str, optional): A file used to determine the root of the workspace.
     """
     go_rules_dependencies()
     go_register_toolchains()
-    gazelle_dependencies()
+    gazelle_dependencies(go_repository_default_config = go_repository_default_config)
     excludes = native.existing_rules().keys()
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/bazelbuild/rules_docker/issues/1902


## What is the new behavior?
Users can now use `WORKSPACE.bazel` files by setting `go_repository_default_config`:

```python
load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")

container_deps(
    # https://github.com/bazelbuild/rules_docker/issues/1902
    go_repository_default_config = "@//:WORKSPACE.bazel"
)
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

