### PR TITLE
remove dependency on external python for sha256

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -99,10 +99,10 @@ bzl_library(
         ":layer_tools",
         ":providers",
         "//skylib:filetype",
+        "//skylib:hash",
         "//skylib:label",
         "//skylib:path",
         "@bazel_skylib//lib:dicts",
-        "@bazel_tools//tools/build_defs/hash:hash.bzl",
     ],
 )
 
@@ -113,9 +113,9 @@ bzl_library(
         ":layer_tools",
         ":providers",
         "//skylib:filetype",
+        "//skylib:hash",
         "//skylib:path",
         "//skylib:zip",
-        "@bazel_tools//tools/build_defs/hash:hash.bzl",
     ],
 )
 
@@ -126,9 +126,9 @@ bzl_library(
         ":layer_tools",
         ":providers",
         "//skylib:filetype",
+        "//skylib:hash",
         "//skylib:path",
         "//skylib:zip",
-        "@bazel_tools//tools/build_defs/hash:hash.bzl",
     ],
 )
 

--- a/container/go/cmd/sha256/BUILD
+++ b/container/go/cmd/sha256/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+# Build file for sha256 binary.
+
+go_library(
+    name = "go_default_library",
+    srcs = ["sha256.go"],
+    importpath = "github.com/bazelbuild/rules_docker/container/go/cmd/sha256",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "sha256",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/container/go/cmd/sha256/sha256.go
+++ b/container/go/cmd/sha256/sha256.go
@@ -1,4 +1,21 @@
-// Portable SHA256 tool.
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////
+// This binary computes SHA256 for //skylib:hash.bzl
+//
+// Drop-in replacement for @bazel_tools//tools/build_defs/hash:sha256.py
+// See: https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/hash/sha256.py
 package main
 
 import (

--- a/container/go/cmd/sha256/sha256.go
+++ b/container/go/cmd/sha256/sha256.go
@@ -1,0 +1,39 @@
+// Portable SHA256 tool.
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+func main() {
+	flag.Parse()
+	if len(os.Args) != 3 {
+		log.Fatalf("Usage: %s input output", os.Args[0])
+	}
+
+	inputfile, err := os.Open(os.Args[1])
+	if err != nil {
+		log.Fatalf("error reading %s: %s", os.Args[1], err)
+	}
+
+	h := sha256.New()
+	if _, err := io.Copy(h, inputfile); err != nil {
+		log.Fatalf("error reading %s: %s", os.Args[1], err)
+	}
+
+	if err := inputfile.Close(); err != nil {
+		log.Fatalf("error reading %s: %s", os.Args[1], err)
+	}
+	sum := h.Sum(nil)
+	hexSum := hex.EncodeToString(sum)
+
+	if err := ioutil.WriteFile(os.Args[2], []byte(hexSum), 0666); err != nil {
+		log.Fatalf("error writing %s: %s", os.Args[2], err)
+	}
+}

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -20,7 +20,7 @@ more specialized build leveraging the same implementation.
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
-    "@bazel_tools//tools/build_defs/hash:hash.bzl",
+    "//skylib:hash.bzl",
     _hash_tools = "tools",
     _sha256 = "sha256",
 )

--- a/container/import.bzl
+++ b/container/import.bzl
@@ -15,7 +15,7 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
-    "@bazel_tools//tools/build_defs/hash:hash.bzl",
+    "//skylib:hash.bzl",
     _hash_tools = "tools",
     _sha256 = "sha256",
 )

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -15,7 +15,7 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
-    "@bazel_tools//tools/build_defs/hash:hash.bzl",
+    "//skylib:hash.bzl",
     _hash_tools = "tools",
     _sha256 = "sha256",
 )

--- a/docker/util/run.bzl
+++ b/docker/util/run.bzl
@@ -20,7 +20,7 @@ the host machine.
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
-    "@bazel_tools//tools/build_defs/hash:hash.bzl",
+    "//skylib:hash.bzl",
     _hash_tools = "tools",
 )
 load("@io_bazel_rules_docker//container:layer.bzl", "zip_layer")

--- a/docs/container.md
+++ b/docs/container.md
@@ -87,7 +87,7 @@ A rule that imports a docker image into our intermediate form.
 | <a id="container_import-layers"></a>layers |  The list of layer .tar.gz files in the order they appear in the config.json's layer section,             or in the order that they appear in the <code>Layers</code> field of the docker save tarballs'             <code>manifest.json</code> (these may or may not be gzipped).<br><br>            Note that the layers should each have a different basename.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 | <a id="container_import-manifest"></a>manifest |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="container_import-repository"></a>repository |  -   | String | optional | "bazel" |
-| <a id="container_import-sha256"></a>sha256 |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //tools/build_defs/hash:sha256 |
+| <a id="container_import-sha256"></a>sha256 |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //container/go/cmd/sha256:sha256 |
 
 
 <a id="#container_layer"></a>
@@ -126,7 +126,7 @@ A rule that assembles data into a tarball which can be use as in layers attr in 
 | <a id="container_layer-mtime"></a>mtime |  -   | Integer | optional | -1 |
 | <a id="container_layer-operating_system"></a>operating_system |  -   | String | optional | "linux" |
 | <a id="container_layer-portable_mtime"></a>portable_mtime |  -   | Boolean | optional | False |
-| <a id="container_layer-sha256"></a>sha256 |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //tools/build_defs/hash:sha256 |
+| <a id="container_layer-sha256"></a>sha256 |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //container/go/cmd/sha256:sha256 |
 | <a id="container_layer-symlinks"></a>symlinks |  Symlinks to create in the Docker image.<br><br>        For example,<br><br>            symlinks = {                 "/path/to/link": "/path/to/target",                 ...             },   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="container_layer-tars"></a>tars |  Tar file to extract in the layer.<br><br>        A list of tar files whose content should be in the Docker image.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 

--- a/skylib/BUILD
+++ b/skylib/BUILD
@@ -42,3 +42,8 @@ bzl_library(
     name = "zip",
     srcs = ["zip.bzl"],
 )
+
+bzl_library(
+    name = "hash",
+    srcs = ["hash.bzl"],
+)

--- a/skylib/hash.bzl
+++ b/skylib/hash.bzl
@@ -1,4 +1,23 @@
-"""Functions for producing the hash of an artifact."""
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions for producing the hash of an artifact.
+
+Drop-in replacement for @bazel_tools//tools/build_defs/hash:hash.bzl
+See: https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/hash/hash.bzl
+
+Computes SHA256 without depending on Python.
+"""
 
 def sha256(ctx, artifact, execution_requirements = None):
     """Create an action to compute the SHA-256 of an artifact."""

--- a/skylib/hash.bzl
+++ b/skylib/hash.bzl
@@ -1,0 +1,23 @@
+"""Functions for producing the hash of an artifact."""
+
+def sha256(ctx, artifact, execution_requirements = None):
+    """Create an action to compute the SHA-256 of an artifact."""
+    out = ctx.actions.declare_file(artifact.basename + ".sha256")
+    ctx.actions.run(
+        executable = ctx.executable.sha256,
+        arguments = [artifact.path, out.path],
+        inputs = [artifact],
+        outputs = [out],
+        mnemonic = "SHA256",
+        execution_requirements = execution_requirements,
+    )
+    return out
+
+tools = {
+    "sha256": attr.label(
+        default = Label("//container/go/cmd/sha256:sha256"),
+        cfg = "host",
+        executable = True,
+        allow_files = True,
+    ),
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

^^ unsure if this is necessary; existing tests probably cover?

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

sha256 computation depends on https://github.com/bazelbuild/bazel/tree/master/tools/build_defs/hash which requires external python.  We can replace this with a simple Go cmd.

Issue Number: #1555


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
