### PR TITLE
Add missing `run_tag` directive.

### DIFF
--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -282,6 +282,7 @@ def incremental_load(
             "%{docker_tool_path}": docker_path(toolchain_info),
             "%{load_statements}": "\n".join(load_statements),
             "%{run_statement}": run_statement,
+            "%{run_tag}": run_tag,
             "%{run}": str(run),
             # If this rule involves stamp variables than load them as bash
             # variables, and turn references to them into bash variable


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
The `docker run` command fails because it is missing a `run_tag` arg due to a missing line merged in #1957.

Issue Number: N/A


## What is the new behavior?
The `docker run` command succeeds and runs as per documentation.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The line `"%{run_tag}": run_tag,` was omitted during this merge commit:
https://github.com/bazelbuild/rules_docker/pull/1957/commits/922e4662e97ed050023248b77ca015a35ac1715c#diff-2a6edca3d784a368586063a7774b7551bbf4476c7345c511ab987bf95c610527L281

Referenced in this comment on the original PR:
https://github.com/bazelbuild/rules_docker/pull/1957#issuecomment-1007904580
