### PR TITLE
Stamp e2e tests

### DIFF
--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -261,12 +261,12 @@ function test_new_container_push_with_stamp() {
   cid=$(docker run --rm -d -p 5000:5000 --name registry registry:2)
 
   # Push a legacy image with stamp substitution
-  bazel run tests/container:new_push_stamped_test_legacy
-  EXPECT_CONTAINS "$(bazel run @io_bazel_rules_docker//tests/container:new_push_stamped_test_legacy 2>&1)" "Successfully pushed Docker image"
+  bazel run --stamp tests/container:new_push_stamped_test_legacy
+  EXPECT_CONTAINS "$(bazel run --stamp @io_bazel_rules_docker//tests/container:new_push_stamped_test_legacy 2>&1)" "Successfully pushed Docker image"
 
   # Push a oci image with stamp substitution
-  bazel run tests/container:new_push_stamped_test_oci
-  EXPECT_CONTAINS "$(bazel run @io_bazel_rules_docker//tests/container:new_push_stamped_test_oci 2>&1)" "Successfully pushed OCI image"
+  bazel run --stamp tests/container:new_push_stamped_test_oci
+  EXPECT_CONTAINS "$(bazel run --stamp @io_bazel_rules_docker//tests/container:new_push_stamped_test_oci 2>&1)" "Successfully pushed OCI image"
   docker stop -t 0 $cid
 }
 
@@ -371,7 +371,7 @@ function test_container_push_with_stamp() {
   cd "${ROOT}"
   clear_docker_full
   cid=$(docker run --rm -d -p 5000:5000 --name registry registry:2)
-  bazel run tests/container:push_stamped_test
+  bazel run --stamp tests/container:push_stamped_test
   docker stop -t 0 $cid
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Other... Please describe:

E2E tests

## What is the current behavior?

Tests are failing:
```
$ ./testing/e2e.sh test_new_container_push_with_stamp
Untagged: bazel/testdata:java_image
Deleted: sha256:eb80f78831e79eaece9b9e902ab2a806cf42c343982480fa9effa5eebc01dadd
Deleted: sha256:08d041228c55a55fc73cd9e19f1b5c0e48e2e9db9561cf31406793b9f9614ec9
Deleted: sha256:957efaa4e727e69dc84edb895ad905ae0b0fca30a3fca0ac14bae93dfcdc571f
Deleted: sha256:6801a054c34b4d3fa6ac55f86851b7e7add658b9f6aeea3cda921676d3326e61
Deleted: sha256:85b9a170b808007c1306bbffa8bccc8d737043fa5ed84ae6bff1ad96e85c4be0
Deleted: sha256:cc2aadc8d4ba1fab738a59d14ae92c67b5866476ebb0ba176634e480ae5f7b9c
Deleted: sha256:033fdf5c04846c6cfc205c9e0137e8f92efa7c008cd30cc2472063a2f237e4a9
Deleted: sha256:6d75f23be3ddcb784b51ea7ef9b6a3a038f9e0b2f08f08628b226dba8b5161f8
INFO: Invocation ID: 9fb70e29-49f6-44eb-bcf6-5646662b724c
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/version_check.bzl:68:14:
Current running Bazel is ahead of bazel-toolchains repo. Please update your pin to bazel-toolchains repo in your WORKSPACE file.
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:125:14: buildkite_config not using checked in configs; Bazel version 4.2.1 was picked/selected but no checked in config was found in map {"0.20.0": ["8.0.0"], "0.21.0": ["8.0.0"], "0.22.0": ["8.0.0", "9.0.0"], "0.23.0": ["8.0.0", "9.0.0"], "0.23.1": ["8.0.0", "9.0.0"], "0.23.2": ["9.0.0"], "0.24.0": ["9.0.0"], "0.24.1": ["9.0.0"], "0.25.0": ["9.0.0"], "0.25.1": ["9.0.0"], "0.25.2": ["9.0.0"], "0.26.0": ["9.0.0"], "0.26.1": ["9.0.0"], "0.27.0": ["9.0.0"], "0.27.1": ["9.0.0"], "0.28.0": ["9.0.0"], "0.28.1": ["9.0.0"], "0.29.0": ["9.0.0"], "0.29.1": ["9.0.0", "10.0.0"], "1.0.0": ["9.0.0", "10.0.0"], "1.0.1": ["10.0.0"], "1.1.0": ["10.0.0"], "1.2.0": ["10.0.0"], "1.2.1": ["10.0.0"], "2.0.0": ["10.0.0"], "2.1.0": ["10.0.0"], "2.1.1": ["10.0.0", "11.0.0"], "2.2.0": ["11.0.0"], "3.0.0": ["11.0.0"], "3.1.0": ["11.0.0"], "3.2.0": ["11.0.0"], "3.3.0": ["11.0.0"], "3.3.1": ["11.0.0"], "3.4.1": ["11.0.0"], "3.5.0": ["11.0.0"], "3.5.1": ["11.0.0"], "3.6.0": ["11.0.0"], "3.7.0": ["11.0.0"], "3.7.1": ["11.0.0"], "3.7.2": ["11.0.0"], "4.0.0": ["11.0.0"]}
INFO: Analyzed target //tests/container:new_push_stamped_test_legacy (0 packages loaded, 224 targets configured).
INFO: Found 1 target...
Target //tests/container:new_push_stamped_test_legacy up-to-date:
  bazel-bin/tests/container/new_push_stamped_test_legacy.digest
  bazel-bin/tests/container/new_push_stamped_test_legacy
INFO: Elapsed time: 0.348s, Critical Path: 0.03s
INFO: 5 processes: 4 internal, 1 processwrapper-sandbox.
INFO: Build completed successfully, 5 total actions
INFO: Build completed successfully, 5 total actions
2022/01/14 00:12:08 Error pushing image to localhost:5000/docker/test/{BUILD_USER}:{BUILD_USER}: error parsing "localhost:5000/docker/test/{BUILD_USER}:{BUILD_USER}" as an image reference: could not parse reference: localhost:5000/docker/test/{BUILD_USER}:{BUILD_USER}
```

and
```
$ ./testing/e2e.sh test_container_push_with_stamp
"docker rmi" requires at least 1 argument.
See 'docker rmi --help'.

Usage:  docker rmi [OPTIONS] IMAGE [IMAGE...]

Remove one or more images
INFO: Invocation ID: 643c975b-2386-40d5-ba56-600edb927508
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/version_check.bzl:68:14:
Current running Bazel is ahead of bazel-toolchains repo. Please update your pin to bazel-toolchains repo in your WORKSPACE file.
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:125:14: buildkite_config not using checked in configs; Bazel version 4.2.1 was picked/selected but no checked in config was found in map {"0.20.0": ["8.0.0"], "0.21.0": ["8.0.0"], "0.22.0": ["8.0.0", "9.0.0"], "0.23.0": ["8.0.0", "9.0.0"], "0.23.1": ["8.0.0", "9.0.0"], "0.23.2": ["9.0.0"], "0.24.0": ["9.0.0"], "0.24.1": ["9.0.0"], "0.25.0": ["9.0.0"], "0.25.1": ["9.0.0"], "0.25.2": ["9.0.0"], "0.26.0": ["9.0.0"], "0.26.1": ["9.0.0"], "0.27.0": ["9.0.0"], "0.27.1": ["9.0.0"], "0.28.0": ["9.0.0"], "0.28.1": ["9.0.0"], "0.29.0": ["9.0.0"], "0.29.1": ["9.0.0", "10.0.0"], "1.0.0": ["9.0.0", "10.0.0"], "1.0.1": ["10.0.0"], "1.1.0": ["10.0.0"], "1.2.0": ["10.0.0"], "1.2.1": ["10.0.0"], "2.0.0": ["10.0.0"], "2.1.0": ["10.0.0"], "2.1.1": ["10.0.0", "11.0.0"], "2.2.0": ["11.0.0"], "3.0.0": ["11.0.0"], "3.1.0": ["11.0.0"], "3.2.0": ["11.0.0"], "3.3.0": ["11.0.0"], "3.3.1": ["11.0.0"], "3.4.1": ["11.0.0"], "3.5.0": ["11.0.0"], "3.5.1": ["11.0.0"], "3.6.0": ["11.0.0"], "3.7.0": ["11.0.0"], "3.7.1": ["11.0.0"], "3.7.2": ["11.0.0"], "4.0.0": ["11.0.0"]}
INFO: Analyzed target //tests/container:push_stamped_test (0 packages loaded, 1 target configured).
INFO: Found 1 target...
Target //tests/container:push_stamped_test up-to-date:
  bazel-bin/tests/container/push_stamped_test.digest
  bazel-bin/tests/container/push_stamped_test
INFO: Elapsed time: 0.256s, Critical Path: 0.02s
INFO: 5 processes: 4 internal, 1 processwrapper-sandbox.
INFO: Build completed successfully, 5 total actions
INFO: Build completed successfully, 5 total actions
2022/01/14 00:12:19 Error pushing image to localhost:5000/docker/test/{BUILD_USER}:{BUILD_USER}: error parsing "localhost:5000/docker/test/{BUILD_USER}:{BUILD_USER}" as an image reference: could not parse reference: localhost:5000/docker/test/{BUILD_USER}:{BUILD_USER}
```

Issue Number: #1997 


## What is the new behavior?

Tests are passing:
```
$ ./testing/e2e.sh test_new_container_push_with_stamp
"docker rmi" requires at least 1 argument.
See 'docker rmi --help'.

Usage:  docker rmi [OPTIONS] IMAGE [IMAGE...]

Remove one or more images
INFO: Invocation ID: d2e0188c-93d7-4f2f-930d-20ee03a80169
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/version_check.bzl:68:14:
Current running Bazel is ahead of bazel-toolchains repo. Please update your pin to bazel-toolchains repo in your WORKSPACE file.
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:125:14: buildkite_config not using checked in configs; Bazel version 4.2.1 was picked/selected but no checked in config was found in map {"0.20.0": ["8.0.0"], "0.21.0": ["8.0.0"], "0.22.0": ["8.0.0", "9.0.0"], "0.23.0": ["8.0.0", "9.0.0"], "0.23.1": ["8.0.0", "9.0.0"], "0.23.2": ["9.0.0"], "0.24.0": ["9.0.0"], "0.24.1": ["9.0.0"], "0.25.0": ["9.0.0"], "0.25.1": ["9.0.0"], "0.25.2": ["9.0.0"], "0.26.0": ["9.0.0"], "0.26.1": ["9.0.0"], "0.27.0": ["9.0.0"], "0.27.1": ["9.0.0"], "0.28.0": ["9.0.0"], "0.28.1": ["9.0.0"], "0.29.0": ["9.0.0"], "0.29.1": ["9.0.0", "10.0.0"], "1.0.0": ["9.0.0", "10.0.0"], "1.0.1": ["10.0.0"], "1.1.0": ["10.0.0"], "1.2.0": ["10.0.0"], "1.2.1": ["10.0.0"], "2.0.0": ["10.0.0"], "2.1.0": ["10.0.0"], "2.1.1": ["10.0.0", "11.0.0"], "2.2.0": ["11.0.0"], "3.0.0": ["11.0.0"], "3.1.0": ["11.0.0"], "3.2.0": ["11.0.0"], "3.3.0": ["11.0.0"], "3.3.1": ["11.0.0"], "3.4.1": ["11.0.0"], "3.5.0": ["11.0.0"], "3.5.1": ["11.0.0"], "3.6.0": ["11.0.0"], "3.7.0": ["11.0.0"], "3.7.1": ["11.0.0"], "3.7.2": ["11.0.0"], "4.0.0": ["11.0.0"]}
INFO: Build option --stamp has changed, discarding analysis cache.
INFO: Analyzed target //tests/container:new_push_stamped_test_legacy (0 packages loaded, 7394 targets configured).
INFO: Found 1 target...
Target //tests/container:new_push_stamped_test_legacy up-to-date:
  bazel-bin/tests/container/new_push_stamped_test_legacy.digest
  bazel-bin/tests/container/new_push_stamped_test_legacy
INFO: Elapsed time: 0.717s, Critical Path: 0.06s
INFO: 6 processes: 4 internal, 2 processwrapper-sandbox.
INFO: Build completed successfully, 6 total actions
INFO: Build completed successfully, 6 total actions
2022/01/14 00:13:31 Destination localhost:5000/docker/test/{BUILD_USER}:{BUILD_USER} was resolved to localhost:5000/docker/test/user:user after stamping.
2022/01/14 00:13:31 Successfully pushed Docker image to localhost:5000/docker/test/user:user
Checking INFO: Invocation ID: a1086433-969f-4186-ae9c-38509681fb5c
Loading:
Loading: 0 packages loaded
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/version_check.bzl:68:14:
Current running Bazel is ahead of bazel-toolchains repo. Please update your pin to bazel-toolchains repo in your WORKSPACE file.
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:125:14: buildkite_config not using checked in configs; Bazel version 4.2.1 was picked/selected but no checked in config was found in map {"0.20.0": ["8.0.0"], "0.21.0": ["8.0.0"], "0.22.0": ["8.0.0", "9.0.0"], "0.23.0": ["8.0.0", "9.0.0"], "0.23.1": ["8.0.0", "9.0.0"], "0.23.2": ["9.0.0"], "0.24.0": ["9.0.0"], "0.24.1": ["9.0.0"], "0.25.0": ["9.0.0"], "0.25.1": ["9.0.0"], "0.25.2": ["9.0.0"], "0.26.0": ["9.0.0"], "0.26.1": ["9.0.0"], "0.27.0": ["9.0.0"], "0.27.1": ["9.0.0"], "0.28.0": ["9.0.0"], "0.28.1": ["9.0.0"], "0.29.0": ["9.0.0"], "0.29.1": ["9.0.0", "10.0.0"], "1.0.0": ["9.0.0", "10.0.0"], "1.0.1": ["10.0.0"], "1.1.0": ["10.0.0"], "1.2.0": ["10.0.0"], "1.2.1": ["10.0.0"], "2.0.0": ["10.0.0"], "2.1.0": ["10.0.0"], "2.1.1": ["10.0.0", "11.0.0"], "2.2.0": ["11.0.0"], "3.0.0": ["11.0.0"], "3.1.0": ["11.0.0"], "3.2.0": ["11.0.0"], "3.3.0": ["11.0.0"], "3.3.1": ["11.0.0"], "3.4.1": ["11.0.0"], "3.5.0": ["11.0.0"], "3.5.1": ["11.0.0"], "3.6.0": ["11.0.0"], "3.7.0": ["11.0.0"], "3.7.1": ["11.0.0"], "3.7.2": ["11.0.0"], "4.0.0": ["11.0.0"]}
Analyzing: target //tests/container:new_push_stamped_test_legacy (0 packages loaded, 0 targets configured)
INFO: Analyzed target //tests/container:new_push_stamped_test_legacy (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
[0 / 2] [Prepa] BazelWorkspaceStatusAction stable-status.txt
Target //tests/container:new_push_stamped_test_legacy up-to-date:
  bazel-bin/tests/container/new_push_stamped_test_legacy.digest
  bazel-bin/tests/container/new_push_stamped_test_legacy
INFO: Elapsed time: 0.197s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/tests/container/new_push_stamped_test_legacy
INFO: Build completed successfully, 1 total action
2022/01/14 00:13:32 Destination localhost:5000/docker/test/{BUILD_USER}:{BUILD_USER} was resolved to localhost:5000/docker/test/user:user after stamping.
2022/01/14 00:13:32 Successfully pushed Docker image to localhost:5000/docker/test/user:user contains Successfully pushed Docker image
INFO: Invocation ID: 99df3f9f-9641-4729-93dd-5c8201f1434c
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/version_check.bzl:68:14:
Current running Bazel is ahead of bazel-toolchains repo. Please update your pin to bazel-toolchains repo in your WORKSPACE file.
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:125:14: buildkite_config not using checked in configs; Bazel version 4.2.1 was picked/selected but no checked in config was found in map {"0.20.0": ["8.0.0"], "0.21.0": ["8.0.0"], "0.22.0": ["8.0.0", "9.0.0"], "0.23.0": ["8.0.0", "9.0.0"], "0.23.1": ["8.0.0", "9.0.0"], "0.23.2": ["9.0.0"], "0.24.0": ["9.0.0"], "0.24.1": ["9.0.0"], "0.25.0": ["9.0.0"], "0.25.1": ["9.0.0"], "0.25.2": ["9.0.0"], "0.26.0": ["9.0.0"], "0.26.1": ["9.0.0"], "0.27.0": ["9.0.0"], "0.27.1": ["9.0.0"], "0.28.0": ["9.0.0"], "0.28.1": ["9.0.0"], "0.29.0": ["9.0.0"], "0.29.1": ["9.0.0", "10.0.0"], "1.0.0": ["9.0.0", "10.0.0"], "1.0.1": ["10.0.0"], "1.1.0": ["10.0.0"], "1.2.0": ["10.0.0"], "1.2.1": ["10.0.0"], "2.0.0": ["10.0.0"], "2.1.0": ["10.0.0"], "2.1.1": ["10.0.0", "11.0.0"], "2.2.0": ["11.0.0"], "3.0.0": ["11.0.0"], "3.1.0": ["11.0.0"], "3.2.0": ["11.0.0"], "3.3.0": ["11.0.0"], "3.3.1": ["11.0.0"], "3.4.1": ["11.0.0"], "3.5.0": ["11.0.0"], "3.5.1": ["11.0.0"], "3.6.0": ["11.0.0"], "3.7.0": ["11.0.0"], "3.7.1": ["11.0.0"], "3.7.2": ["11.0.0"], "4.0.0": ["11.0.0"]}
INFO: Analyzed target //tests/container:new_push_stamped_test_oci (0 packages loaded, 4 targets configured).
INFO: Found 1 target...
Target //tests/container:new_push_stamped_test_oci up-to-date:
  bazel-bin/tests/container/new_push_stamped_test_oci.digest
  bazel-bin/tests/container/new_push_stamped_test_oci
INFO: Elapsed time: 0.210s, Critical Path: 0.02s
INFO: 5 processes: 4 internal, 1 processwrapper-sandbox.
INFO: Build completed successfully, 5 total actions
INFO: Build completed successfully, 5 total actions
2022/01/14 00:13:32 Destination localhost:5000/docker/test/{BUILD_USER}:{BUILD_USER} was resolved to localhost:5000/docker/test/user:user after stamping.
2022/01/14 00:13:32 Successfully pushed OCI image to localhost:5000/docker/test/user:user
Checking INFO: Invocation ID: a1658b58-e818-48da-8852-8c9e0536cdd0
Loading:
Loading: 0 packages loaded
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/version_check.bzl:68:14:
Current running Bazel is ahead of bazel-toolchains repo. Please update your pin to bazel-toolchains repo in your WORKSPACE file.
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:125:14: buildkite_config not using checked in configs; Bazel version 4.2.1 was picked/selected but no checked in config was found in map {"0.20.0": ["8.0.0"], "0.21.0": ["8.0.0"], "0.22.0": ["8.0.0", "9.0.0"], "0.23.0": ["8.0.0", "9.0.0"], "0.23.1": ["8.0.0", "9.0.0"], "0.23.2": ["9.0.0"], "0.24.0": ["9.0.0"], "0.24.1": ["9.0.0"], "0.25.0": ["9.0.0"], "0.25.1": ["9.0.0"], "0.25.2": ["9.0.0"], "0.26.0": ["9.0.0"], "0.26.1": ["9.0.0"], "0.27.0": ["9.0.0"], "0.27.1": ["9.0.0"], "0.28.0": ["9.0.0"], "0.28.1": ["9.0.0"], "0.29.0": ["9.0.0"], "0.29.1": ["9.0.0", "10.0.0"], "1.0.0": ["9.0.0", "10.0.0"], "1.0.1": ["10.0.0"], "1.1.0": ["10.0.0"], "1.2.0": ["10.0.0"], "1.2.1": ["10.0.0"], "2.0.0": ["10.0.0"], "2.1.0": ["10.0.0"], "2.1.1": ["10.0.0", "11.0.0"], "2.2.0": ["11.0.0"], "3.0.0": ["11.0.0"], "3.1.0": ["11.0.0"], "3.2.0": ["11.0.0"], "3.3.0": ["11.0.0"], "3.3.1": ["11.0.0"], "3.4.1": ["11.0.0"], "3.5.0": ["11.0.0"], "3.5.1": ["11.0.0"], "3.6.0": ["11.0.0"], "3.7.0": ["11.0.0"], "3.7.1": ["11.0.0"], "3.7.2": ["11.0.0"], "4.0.0": ["11.0.0"]}
Analyzing: target //tests/container:new_push_stamped_test_oci (0 packages loaded, 0 targets configured)
INFO: Analyzed target //tests/container:new_push_stamped_test_oci (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
[0 / 1] [Prepa] BazelWorkspaceStatusAction stable-status.txt
Target //tests/container:new_push_stamped_test_oci up-to-date:
  bazel-bin/tests/container/new_push_stamped_test_oci.digest
  bazel-bin/tests/container/new_push_stamped_test_oci
INFO: Elapsed time: 0.166s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/tests/container/new_push_stamped_test_oci
INFO: Build completed successfully, 1 total action
2022/01/14 00:13:32 Destination localhost:5000/docker/test/{BUILD_USER}:{BUILD_USER} was resolved to localhost:5000/docker/test/user:user after stamping.
2022/01/14 00:13:32 Successfully pushed OCI image to localhost:5000/docker/test/user:user contains Successfully pushed OCI image
f86224a86dc0e5eb43ee697ee5605072b064a28a84ae84bd75fbe8f231c4e190
```

and
```
$ ./testing/e2e.sh test_container_push_with_stamp
"docker rmi" requires at least 1 argument.
See 'docker rmi --help'.

Usage:  docker rmi [OPTIONS] IMAGE [IMAGE...]

Remove one or more images
INFO: Invocation ID: 24218137-c920-45d3-a9fa-133732eed0a8
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/version_check.bzl:68:14:
Current running Bazel is ahead of bazel-toolchains repo. Please update your pin to bazel-toolchains repo in your WORKSPACE file.
DEBUG: /home/user/.cache/bazel/_bazel_user/5e184aea21a9eb5699227e7c322d8bc1/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:125:14: buildkite_config not using checked in configs; Bazel version 4.2.1 was picked/selected but no checked in config was found in map {"0.20.0": ["8.0.0"], "0.21.0": ["8.0.0"], "0.22.0": ["8.0.0", "9.0.0"], "0.23.0": ["8.0.0", "9.0.0"], "0.23.1": ["8.0.0", "9.0.0"], "0.23.2": ["9.0.0"], "0.24.0": ["9.0.0"], "0.24.1": ["9.0.0"], "0.25.0": ["9.0.0"], "0.25.1": ["9.0.0"], "0.25.2": ["9.0.0"], "0.26.0": ["9.0.0"], "0.26.1": ["9.0.0"], "0.27.0": ["9.0.0"], "0.27.1": ["9.0.0"], "0.28.0": ["9.0.0"], "0.28.1": ["9.0.0"], "0.29.0": ["9.0.0"], "0.29.1": ["9.0.0", "10.0.0"], "1.0.0": ["9.0.0", "10.0.0"], "1.0.1": ["10.0.0"], "1.1.0": ["10.0.0"], "1.2.0": ["10.0.0"], "1.2.1": ["10.0.0"], "2.0.0": ["10.0.0"], "2.1.0": ["10.0.0"], "2.1.1": ["10.0.0", "11.0.0"], "2.2.0": ["11.0.0"], "3.0.0": ["11.0.0"], "3.1.0": ["11.0.0"], "3.2.0": ["11.0.0"], "3.3.0": ["11.0.0"], "3.3.1": ["11.0.0"], "3.4.1": ["11.0.0"], "3.5.0": ["11.0.0"], "3.5.1": ["11.0.0"], "3.6.0": ["11.0.0"], "3.7.0": ["11.0.0"], "3.7.1": ["11.0.0"], "3.7.2": ["11.0.0"], "4.0.0": ["11.0.0"]}
INFO: Analyzed target //tests/container:push_stamped_test (0 packages loaded, 1 target configured).
INFO: Found 1 target...
Target //tests/container:push_stamped_test up-to-date:
  bazel-bin/tests/container/push_stamped_test.digest
  bazel-bin/tests/container/push_stamped_test
INFO: Elapsed time: 0.203s, Critical Path: 0.02s
INFO: 5 processes: 4 internal, 1 processwrapper-sandbox.
INFO: Build completed successfully, 5 total actions
INFO: Build completed successfully, 5 total actions
2022/01/14 00:14:25 Destination localhost:5000/docker/test/{BUILD_USER}:{BUILD_USER} was resolved to localhost:5000/docker/test/user:user after stamping.
2022/01/14 00:14:25 Successfully pushed Docker image to localhost:5000/docker/test/user:user
72a952c880bbe78501710c54a6c5224d1bc7a69fbc64a40f1afb6370c446400a
```

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Addressing https://github.com/bazelbuild/rules_docker/releases/tag/v0.22.0 release braking changes of:
```
As of this release, you should run bazel build --stamp enable stamped outputs.
```
