### PR TITLE
Replace non existing "build_tar" local tool with a repo target

### DIFF
--- a/testing/default_toolchain/WORKSPACE
+++ b/testing/default_toolchain/WORKSPACE
@@ -27,10 +27,6 @@ load(
 )
 
 local_tool(
-    name = "build_tar",
-)
-
-local_tool(
     name = "xz",
 )
 
@@ -41,7 +37,7 @@ load(
 
 docker_toolchain_configure(
     name = "docker_config",
-    build_tar_target = "@build_tar//:build_tar",
+    build_tar_target = "@io_bazel_rules_docker//container:build_tar",
     xz_target = "@xz//:xz",
 )
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```
$ cd testing/default_toolchain/

$ bazel cquery --override_repository=io_bazel_rules_docker=/home/user/bazelbuild/rules_docker '@docker_config//:*'
INFO: Invocation ID: b42e2f4d-afa1-4269-8594-21b2babb178e
INFO: Repository build_tar instantiated at:
  /home/user/bazelbuild/rules_docker/testing/default_toolchain/WORKSPACE:29:11: in <toplevel>
Repository rule local_tool defined at:
  /home/user/bazelbuild/rules_docker/testing/default_toolchain/local_tool.bzl:37:29: in <toplevel>
ERROR: An error occurred during the fetch of repository 'build_tar':
   Traceback (most recent call last):
    File "/home/user/bazelbuild/rules_docker/testing/default_toolchain/local_tool.bzl", line 27, column 17, in _local_tool
        rctx.symlink(realpath, "bin/%s" % rctx.name)
Error in symlink: in call to symlink(), parameter 'from' got value of type 'NoneType', want 'string, Label, or path'
ERROR: Error fetching repository: Traceback (most recent call last):
    File "/home/user/bazelbuild/rules_docker/testing/default_toolchain/local_tool.bzl", line 27, column 17, in _local_tool
        rctx.symlink(realpath, "bin/%s" % rctx.name)
Error in symlink: in call to symlink(), parameter 'from' got value of type 'NoneType', want 'string, Label, or path'
ERROR: no such package '@build_tar//': in call to symlink(), parameter 'from' got value of type 'NoneType', want 'string, Label, or path'
INFO: Elapsed time: 0.333s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
    Fetching @docker_config; Restarting.
```

Issue Number: #1997 


## What is the new behavior?

```
$ cd testing/default_toolchain/

$ bazel cquery --override_repository=io_bazel_rules_docker=/home/user/bazelbuild/rules_docker '@docker_config//:*'
INFO: Invocation ID: 07b7cace-09ed-4117-9ffd-645668ea03ff
INFO: Analyzed 2 targets (24 packages loaded, 149 targets configured).
INFO: Found 2 targets...
@docker_config//:BUILD (null)
@docker_config//:toolchain (50c9e17)
INFO: Elapsed time: 1.701s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
