### PR TITLE
Fix unbound variable when running container_image targets

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -278,5 +278,5 @@ if [[ "%{run}" == "True" ]]; then
   cleanup
 
   # This generated and injected by docker_*.
-  exec %{run_statement} "${docker_args[@]}" "%{run_tag}" "${container_args[@]}"
+  eval exec %{run_statement} "${docker_args[@]}" "%{run_tag}" "${container_args[@]:-}"
 fi


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently running something like the following produces an error `container_args[@]: unbound variable`
```
bazel run //tests/container/python3:py3_image -- --rm -it --entrypoint /bin/bash
```

Issue Number: This is a minor bugfix to https://github.com/bazelbuild/rules_docker/pull/1957


## What is the new behavior?

This fixes the issue and I'm able to run my container and start a bash shell based on the arguments above.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

