### PR TITLE
Update container-structure-test binaries to v0.11.0

### DIFF
--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -138,24 +138,24 @@ def repositories():
         http_file(
             name = "structure_test_linux",
             executable = True,
-            sha256 = "9ddc0791491dc8139af5af4d894e48db4eeaca4b2cb9196293efd615bdb79122",
-            urls = ["https://storage.googleapis.com/container-structure-test/v1.9.1/container-structure-test-linux-amd64"],
+            sha256 = "1524da5fd5a0fc88c4c9257a3de05a45f135df07e6a684380dd5f659b9ce189b",
+            urls = ["https://storage.googleapis.com/container-structure-test/v1.11.0/container-structure-test-linux-amd64"],
         )
 
     if "structure_test_linux_aarch64" not in excludes:
         http_file(
             name = "structure_test_linux_aarch64",
             executable = True,
-            sha256 = "b8fd54ed5f3fcb65861dec8aea5ccf05856c9e030a67461e601eab64c1fe70b1",
-            urls = ["https://storage.googleapis.com/container-structure-test/v1.9.1/container-structure-test-linux-arm64"],
+            sha256 = "b376ff80134d2d609c591b98d65d653a514755b4861185fd93159af7062ec65d",
+            urls = ["https://storage.googleapis.com/container-structure-test/v1.11.0/container-structure-test-linux-arm64"],
         )
 
     if "structure_test_darwin" not in excludes:
         http_file(
             name = "structure_test_darwin",
             executable = True,
-            sha256 = "0b8c019b5a3df1a84515b75c2eb47aaf9db51dec621a39d1c4fa31a4a8f6c855",
-            urls = ["https://storage.googleapis.com/container-structure-test/v1.9.1/container-structure-test-darwin-amd64"],
+            sha256 = "0a4ac9e221a86cda6bb9fedb2a0dfdce56f918327b8881977ad787ea15d0e82f",
+            urls = ["https://storage.googleapis.com/container-structure-test/v1.11.0/container-structure-test-darwin-amd64"],
         )
 
     if "container_diff" not in excludes:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Version 1.9.1 of the container-structure-test-darwin-amd64 binary is not compatible with MacOS Monterey. 

```
❯ ./container-structure-test-darwin-amd64
fatal error: runtime: bsdthread_register error

runtime stack:
runtime.throw(0x15e1aff, 0x21)
	/usr/local/go/src/runtime/panic.go:605 +0x95 fp=0x7ff7bfeff6f0 sp=0x7ff7bfeff6d0 pc=0x102a1b5
runtime.goenvs()
	/usr/local/go/src/runtime/os_darwin.go:108 +0x83 fp=0x7ff7bfeff720 sp=0x7ff7bfeff6f0 pc=0x1027a53
runtime.schedinit()
	/usr/local/go/src/runtime/proc.go:492 +0xa4 fp=0x7ff7bfeff760 sp=0x7ff7bfeff720 pc=0x102cb94
runtime.rt0_go(0x7ff7bfeff798, 0x1, 0x7ff7bfeff798, 0x0, 0x1000000, 0x1, 0x7ff7bfeff978, 0x0, 0x7ff7bfeff9a0, 0x7ff7bfeff9dc, ...)
	/usr/local/go/src/runtime/asm_amd64.s:175 +0x1eb fp=0x7ff7bfeff768 sp=0x7ff7bfeff760 pc=0x105452b
```

Issue Number: #2012

## What is the new behavior?

Version 1.11.0 works as expected.

```
❯ ./container-structure-test-darwin-amd64
container-structure-test provides a powerful framework to validate
the structure of a container image.
These tests can be used to check the output of commands in an image,
as well as verify metadata and contents of the filesystem.

Usage:
  container-structure-test [command]
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

