### PR TITLE
forward $@ through push-all.bzl to the pusher command

### DIFF
--- a/contrib/push-all.bzl
+++ b/contrib/push-all.bzl
@@ -71,11 +71,11 @@ def _impl(ctx):
         template = ctx.file._all_tpl,
         substitutions = {
             "%{async_push_statements}": "\n".join([
-                "async \"%s\"" % _get_runfile_path(ctx, command)
+                "async \"%s\" \"$@\"" % _get_runfile_path(ctx, command)
                 for command in scripts
             ]),
             "%{push_statements}": "\n".join([
-                "\"%s\"" % _get_runfile_path(ctx, command)
+                "\"%s\" \"$@\"" % _get_runfile_path(ctx, command)
                 for command in scripts
             ]),
             "%{sequential}": "true" if ctx.attr.sequential else "",


### PR DESCRIPTION
This has always been done in `push.bzl` (via `push-tag.sh.tpl`).  Just making `push-all.bzl` consistent.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Aribtrary flags can now be passed to the pusher through push-all.bzl

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

