### PR TITLE
feat(*_image): allow setting env vars

### DIFF
--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -63,16 +63,17 @@ DEFAULT_BASE = select({
     "//conditions:default": "@cc_image_base//image",
 })
 
-def cc_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+def cc_image(name, base = None, deps = [], layers = [], env = {}, binary = None, **kwargs):
     """Constructs a container image wrapping a cc_binary target.
 
   Args:
     name: Name of the cc_image target.
     base: Base image to use for the cc_image.
     deps: Dependencies of the cc_image.
-    binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
+    env: Environment variables for the cc_image.
+    binary: An alternative binary target to use instead of generating one.
     **kwargs: See cc_binary.
   """
     if layers:
@@ -94,6 +95,7 @@ def cc_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
     app_layer(
         name = name,
         base = base,
+        env = env,
         binary = binary,
         visibility = visibility,
         tags = tags,

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -32,16 +32,17 @@ def repositories():
     """
     _repositories()
 
-def d_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+def d_image(name, base = None, deps = [], layers = [], env = {}, binary = None, **kwargs):
     """Constructs a container image wrapping a d_binary target.
 
   Args:
     name: Name of the d_image target.
     base: Base image to use for the d_image.
     deps: Dependencies of the d_image target.
-    binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
+    env: Environment variables for the d_image.
+    binary: An alternative binary target to use instead of generating one.
     **kwargs: See d_binary.
   """
     if layers:
@@ -63,6 +64,7 @@ def d_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
     app_layer(
         name = name,
         base = base,
+        env = env,
         binary = binary,
         visibility = visibility,
         tags = tags,

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -89,15 +89,16 @@ STATIC_DEFAULT_BASE = select({
     "//conditions:default": "@go_image_static//image",
 })
 
-def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+def go_image(name, base = None, deps = [], layers = [], env = {}, binary = None, **kwargs):
     """Constructs a container image wrapping a go_binary target.
 
   Args:
     name: Name of the go_image target.
     base: Base image to use to build the go_image.
     deps: Dependencies of the go image target.
-    binary: An alternative binary target to use instead of generating one.
     layers: Augments "deps" with dependencies that should be put into their own layers.
+    env: Environment variables for the go_image.
+    binary: An alternative binary target to use instead of generating one.
     **kwargs: See go_binary.
   """
     if layers:
@@ -123,6 +124,7 @@ def go_image(name, base = None, deps = [], layers = [], binary = None, **kwargs)
     app_layer(
         name = name,
         base = base,
+        env = env,
         binary = binary,
         visibility = visibility,
         tags = tags,

--- a/groovy/image.bzl
+++ b/groovy/image.bzl
@@ -32,6 +32,7 @@ def groovy_image(
         srcs = [],
         deps = [],
         layers = [],
+        env = {},
         jvm_flags = [],
         classpath_as_file = None,
         **kwargs):
@@ -44,9 +45,10 @@ def groovy_image(
     srcs: List of groovy source files that will be used to build the binary
           to be included in the groovy_image.
     deps: The dependencies of the groovy_image target.
-    jvm_flags: The flags to pass to the JVM when running the groovy image.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
+    env: Environment variables for the groovy_image.
+    jvm_flags: The flags to pass to the JVM when running the groovy image.
     **kwargs: See groovy_binary.
   """
     binary_name = name + ".binary"
@@ -84,6 +86,7 @@ def groovy_image(
     jar_app_layer(
         name = name,
         base = base,
+        env = env,
         binary = binary_name,
         main_class = main_class,
         jvm_flags = jvm_flags,

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -169,6 +169,9 @@ jar_dep_layer = rule(
 def _jar_app_layer_impl(ctx):
     """Appends the app layer with all remaining runfiles."""
 
+    for k in ctx.attr.env:
+        print("jar_app_layer", k, ctx.attr.env[k])
+
     # layers don't include runfiles
     available = depset(transitive = [java_files(jar) for jar in ctx.attr.jar_layers])
 
@@ -214,9 +217,9 @@ def _jar_app_layer_impl(ctx):
         ctx,
         # We use all absolute paths.
         directory = "/",
-        env = {
+        env = dicts.add({
             "JAVA_RUNFILES": "/app",
-        },
+        }, ctx.attr.env),
         file_map = file_map,
         entrypoint = entrypoint,
     )
@@ -266,6 +269,7 @@ def java_image(
         deps = [],
         runtime_deps = [],
         layers = [],
+        env = {},
         jvm_flags = [],
         classpath_as_file = None,
         **kwargs):
@@ -276,9 +280,10 @@ def java_image(
     base: Base image to use for the java image.
     deps: Dependencies of the java image rule.
     runtime_deps: Runtime dependencies of the java image.
-    jvm_flags: Flags to pass to the JVM when running the java image.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
+    env: Environment variables for the java_image.
+    jvm_flags: Flags to pass to the JVM when running the java image.
     main_class: This parameter is optional. If provided it will be used in the
                 compilation of any additional sources, and as part of the
                 construction of the container entrypoint. If not provided, the
@@ -327,6 +332,7 @@ def java_image(
         jar_layers = layers,
         visibility = visibility,
         tags = tags,
+        env = env,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
@@ -406,7 +412,7 @@ _war_app_layer = rule(
     cfg = _container.image.cfg,
 )
 
-def war_image(name, base = None, deps = [], layers = [], **kwargs):
+def war_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     """Builds a container image overlaying the java_library as an exploded WAR.
 
   TODO(mattmoor): For `bazel run` of this to be useful, we need to be able
@@ -419,6 +425,7 @@ def war_image(name, base = None, deps = [], layers = [], **kwargs):
     deps: Dependencies of the way image target.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
+    env: Environment variables for the war_image.
     **kwargs: See java_library.
   """
     library_name = name + ".library"
@@ -438,6 +445,7 @@ def war_image(name, base = None, deps = [], layers = [], **kwargs):
         base = base,
         library = library_name,
         jar_layers = layers,
+        env = env,
         visibility = visibility,
         tags = tags,
     )

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -169,9 +169,6 @@ jar_dep_layer = rule(
 def _jar_app_layer_impl(ctx):
     """Appends the app layer with all remaining runfiles."""
 
-    for k in ctx.attr.env:
-        print("jar_app_layer", k, ctx.attr.env[k])
-
     # layers don't include runfiles
     available = depset(transitive = [java_files(jar) for jar in ctx.attr.jar_layers])
 

--- a/kotlin/image.bzl
+++ b/kotlin/image.bzl
@@ -33,23 +33,25 @@ def kt_jvm_image(
         srcs = [],
         deps = [],
         layers = [],
+        env = {},
         jvm_flags = [],
         classpath_as_file = None,
         **kwargs):
     """Builds a container image overlaying the kt_jvm_binary.
 
-    Args:
-        name: Name of the kt_jvm_image target.
-        base: Base image to use for the kt_jvm_image.
-        main_class: The main entrypoint class in the kotlin image.
-        srcs: List of kotlin source files that will be used to build the binary
-            to be included in the kt_jvm_image.
-        deps: The dependencies of the kt_jvm_image target.
-        jvm_flags: The flags to pass to the JVM when running the kotlin image.
-        layers: Augments "deps" with dependencies that should be put into
-            their own layers.
-        **kwargs: See kt_jvm_binary.
-    """
+  Args:
+    name: Name of the kt_jvm_image target.
+    base: Base image to use for the kt_jvm_image.
+    main_class: The main entrypoint class in the kotlin image.
+    srcs: List of kotlin source files that will be used to build the binary
+        to be included in the kt_jvm_image.
+    deps: The dependencies of the kt_jvm_image target.
+    layers: Augments "deps" with dependencies that should be put into
+        their own layers.
+    env: Environment variables for the kt_jvm_image.
+    jvm_flags: The flags to pass to the JVM when running the kotlin image.
+    **kwargs: See kt_jvm_binary.
+  """
     binary_name = name + ".binary"
 
     # This is an inlined copy of kt_jvm_binary so that we properly collect
@@ -83,6 +85,7 @@ def kt_jvm_image(
     jar_app_layer(
         name = name,
         base = base,
+        env = env,
         binary = binary_name,
         main_class = main_class,
         jvm_flags = jvm_flags,

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -116,6 +116,7 @@ def nodejs_image(
         base = None,
         data = [],
         layers = [],
+        env = {},
         binary = None,
         launcher = None,
         launcher_args = None,
@@ -130,6 +131,7 @@ def nodejs_image(
     data: Runtime dependencies of the nodejs_image.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
+    env: Environment variables for the nodejs_image.
     binary: An alternative binary target to use instead of generating one.
     launcher: The container_image launcher to set.
     launcher_args: The args for the container_image launcher.
@@ -172,6 +174,7 @@ def nodejs_image(
     app_layer(
         name = name,
         base = npm_deps_layer_name,
+        env = env,
         binary = binary,
         visibility = visibility,
         tags = tags,

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -78,17 +78,18 @@ def py_layer(name, deps, filter = "", **kwargs):
     native.py_library(name = binary_name, deps = deps, **kwargs)
     filter_layer(name = name, dep = binary_name, filter = filter)
 
-def py_image(name, base = None, deps = [], layers = [], **kwargs):
+def py_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
-    Args:
-        name: Name of the py_image target.
-        base: Base image to use in the py_image.
-        deps: Dependencies of the py_image target.
-        layers: Augments "deps" with dependencies that should be put into
-            their own layers.
-        **kwargs: See py_binary.
-    """
+  Args:
+    name: Name of the py_image target.
+    base: Base image to use in the py_image.
+    deps: Dependencies of the py_image target.
+    layers: Augments "deps" with dependencies that should be put into
+        their own layers.
+    env: Environment variables for the py_image.
+    **kwargs: See py_binary.
+  """
     binary_name = name + ".binary"
 
     if "main" not in kwargs:
@@ -117,6 +118,7 @@ def py_image(name, base = None, deps = [], layers = [], **kwargs):
         name = name,
         base = base,
         entrypoint = ["/usr/bin/python"],
+        env = env,
         binary = binary_name,
         visibility = visibility,
         tags = tags,

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -73,7 +73,7 @@ DEFAULT_BASE = select({
     "//conditions:default": "@py3_image_base//image",
 })
 
-def py3_image(name, base = None, deps = [], layers = [], **kwargs):
+def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
   Args:
@@ -82,6 +82,7 @@ def py3_image(name, base = None, deps = [], layers = [], **kwargs):
     deps: Dependencies of the py3_image.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
+    env: Environment variables for the py_image.
     **kwargs: See py_binary.
   """
     binary_name = name + ".binary"
@@ -113,6 +114,7 @@ def py3_image(name, base = None, deps = [], layers = [], **kwargs):
         name = name,
         base = base,
         entrypoint = ["/usr/bin/python"],
+        env = env,
         binary = binary_name,
         visibility = visibility,
         tags = tags,

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -32,16 +32,17 @@ def repositories():
     """
     _repositories()
 
-def rust_image(name, base = None, deps = [], layers = [], binary = None, **kwargs):
+def rust_image(name, base = None, deps = [], layers = [], env = {}, binary = None, **kwargs):
     """Constructs a container image wrapping a rust_binary target.
 
-    Args:
-        name: Name of the rust_image target.
-        base: Base image to use for the rust_image.
-        deps: Dependencies of the rust_image target.
-        layers: Augments "deps" with dependencies that should be put into their own layers.
-        binary: An alternative binary target to use instead of generating one.
-        **kwargs: See rust_binary.
+  Args:
+    name: Name of the rust_image target.
+    base: Base image to use for the rust_image.
+    deps: Dependencies of the rust_image target.
+    layers: Augments "deps" with dependencies that should be put into their own layers.
+    env: Environment variables for the rust_image.
+    binary: An alternative binary target to use instead of generating one.
+    **kwargs: See rust_binary.
   """
     if layers:
         # buildifier: disable=print
@@ -63,6 +64,7 @@ def rust_image(name, base = None, deps = [], layers = [], binary = None, **kwarg
     app_layer(
         name = name,
         base = base,
+        env = env,
         binary = binary,
         visibility = visibility,
         tags = tags,

--- a/scala/image.bzl
+++ b/scala/image.bzl
@@ -32,6 +32,7 @@ def scala_image(
         deps = [],
         runtime_deps = [],
         layers = [],
+        env = {},
         jvm_flags = [],
         classpath_as_file = None,
         **kwargs):
@@ -44,9 +45,10 @@ def scala_image(
                 image.
     deps: Dependencies of the scala image target.
     runtime_deps: Runtime dependencies of the scala image.
-    jvm_flags: Flags to pass to the JVM when running the scala image.
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
+    env: Environment variables for the scala_image.
+    jvm_flags: Flags to pass to the JVM when running the scala image.
     **kwargs: See scala_binary.
   """
     binary_name = name + ".binary"
@@ -81,6 +83,7 @@ def scala_image(
         deps = deps,
         runtime_deps = runtime_deps,
         jar_layers = layers,
+        env = env,
         visibility = visibility,
         tags = tags,
         args = kwargs.get("args"),

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -896,6 +896,7 @@ java_image(
 war_image(
     name = "war_image",
     srcs = ["Servlet.java"],
+    env = {"WAR_IMAGE_TEST_KEY": "war_image_test_value"},
     layers = [
         ":java_image_library",
         "@javax_servlet_api//jar:jar",

--- a/testdata/Servlet.java
+++ b/testdata/Servlet.java
@@ -33,5 +33,6 @@ public class Servlet extends HttpServlet {
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
       PrintWriter out = resp.getWriter();
       out.println(Library.SayHello());
+      out.printf("WAR_IMAGE_TEST_KEY=%s\n", System.getenv("WAR_IMAGE_TEST_KEY"));
   }
 }

--- a/testing/e2e.sh
+++ b/testing/e2e.sh
@@ -77,6 +77,7 @@ function test_war_image() {
   ID=$(docker run -d -p 8080:8080 bazel/testdata:war_image)
   sleep 5
   EXPECT_CONTAINS "$(curl localhost:8080)" "Hello World"
+  EXPECT_CONTAINS "$(curl localhost:8080)" "WAR_IMAGE_TEST_KEY=war_image_test_value"
   docker rm -f "${ID}"
 }
 

--- a/tests/container/cc/BUILD
+++ b/tests/container/cc/BUILD
@@ -32,6 +32,7 @@ cc_image(
         "$(location :BUILD)",
     ],
     data = [":BUILD"],
+    env = {"CC_IMAGE_TEST_KEY": "cc_image_test_value"},
     # This creates an empty layer, due to linking.
     layers = [":cc_image_library"],
 )

--- a/tests/container/cc/configs/cc_image.yaml
+++ b/tests/container/cc/configs/cc_image.yaml
@@ -7,6 +7,9 @@ metadataTest:
     'arg1',
     'tests/container/cc/BUILD',
   ]
+  env:
+    - key: CC_IMAGE_TEST_KEY
+      value: cc_image_test_value
 
 fileExistenceTests:
 - name: 'cc_image.binary'

--- a/tests/container/go/BUILD
+++ b/tests/container/go/BUILD
@@ -26,6 +26,7 @@ go_image(
         "$(location :BUILD)",
     ],
     data = [":BUILD"],
+    env = {"GO_IMAGE_TEST_KEY": "go_image_test_value"},
     importpath = "github.com/bazelbuild/rules_docker/docker/tests/container/go",
     pure = "off",  # we should be using gcr.io/distroless/base as a base image
     tags = [

--- a/tests/container/go/configs/go_image.yaml
+++ b/tests/container/go/configs/go_image.yaml
@@ -1,12 +1,15 @@
 schemaVersion: 2.0.0
 
 metadataTest:
-  entrypoint: ['/app/tests/container/go/go_image.binary']
   cmd: [
     'arg0',
     'arg1',
     'tests/container/go/BUILD',
   ]
+  entrypoint: ['/app/tests/container/go/go_image.binary']
+  env:
+    - key: GO_IMAGE_TEST_KEY
+      value: go_image_test_value
 
 # File info taken from https://github.com/GoogleContainerTools/distroless/tree/master/base
 

--- a/tests/container/groovy/BUILD
+++ b/tests/container/groovy/BUILD
@@ -33,6 +33,7 @@ groovy_image(
         "$(location :BUILD)",
     ],
     data = [":BUILD"],
+    env = {"GROOVY_IMAGE_TEST_KEY": "groovy_image_test_value"},
     jvm_flags = ["-Dbuild.location=$(location :BUILD)"],
     layers = [":groovy_image_library"],
     main_class = "examples.images.Binary",

--- a/tests/container/groovy/configs/groovy_image.yaml
+++ b/tests/container/groovy/configs/groovy_image.yaml
@@ -11,3 +11,6 @@ metadataTest:
     'arg1',
     'tests/container/groovy/BUILD',
   ]
+  env:
+    - key: "GROOVY_IMAGE_TEST_KEY"
+      value: "groovy_image_test_value"

--- a/tests/container/java/BUILD
+++ b/tests/container/java/BUILD
@@ -44,6 +44,7 @@ java_image(
         "$(location :BUILD)",
     ],
     data = [":BUILD"],
+    env = {"JAVA_IMAGE_TEST_KEY": "java_image_test_value"},
     jvm_flags = [
         "-Dbuild.location=$(location :BUILD)",
     ],

--- a/tests/container/java/configs/java_image.yaml
+++ b/tests/container/java/configs/java_image.yaml
@@ -1,9 +1,6 @@
 schemaVersion: 2.0.0
 
 metadataTest:
-  env:
-    - key: JAVA_RUNFILES
-      value: "/app"
   entrypoint: [
         '/usr/bin/java',
         '-cp',
@@ -13,3 +10,8 @@ metadataTest:
         'arg0',
         'arg1',
         'tests/container/java/BUILD']
+  env:
+    - key: JAVA_RUNFILES
+      value: "/app"
+    - key: JAVA_IMAGE_TEST_KEY
+      value: java_image_test_value

--- a/tests/container/kotlin/BUILD
+++ b/tests/container/kotlin/BUILD
@@ -29,6 +29,7 @@ kt_jvm_image(
         "$(location :BUILD)",
     ],
     data = [":BUILD"],
+    env = {"KT_JVM_IMAGE_TEST_KEY": "kt_jvm_image_test_value"},
     jvm_flags = ["-Dbuild.location=$(location :BUILD)"],
     main_class = "examples.images.Binary",
     deps = [],

--- a/tests/container/kotlin/configs/kt_jvm_image.yaml
+++ b/tests/container/kotlin/configs/kt_jvm_image.yaml
@@ -11,3 +11,6 @@ metadataTest:
     'arg1',
     'tests/container/kotlin/BUILD',
   ]
+  env:
+    - key: KT_JVM_IMAGE_TEST_KEY
+      value: kt_jvm_image_test_value

--- a/tests/container/nodejs/BUILD
+++ b/tests/container/nodejs/BUILD
@@ -31,6 +31,7 @@ nodejs_image(
         "@npm//jsesc",
     ],
     entry_point = "@io_bazel_rules_docker//testdata:nodejs_image.js",
+    env = {"NODEJS_IMAGE_TEST_KEY": "nodejs_image_test_value"},
 )
 
 nodejs_image(

--- a/tests/container/nodejs/configs/nodejs_image.yaml
+++ b/tests/container/nodejs/configs/nodejs_image.yaml
@@ -2,12 +2,14 @@ schemaVersion: 2.0.0
 
 metadataTest:
   cmd: ["arg0", "arg1"]
+  entrypoint: ['/app/tests/container/nodejs/nodejs_image.binary']
   env:
-    - key: PORT
-      value: "8080"
     - key: DEBIAN_FRONTEND
       value: "noninteractive"
+    - key: NODEJS_IMAGE_TEST_KEY
+      value: nodejs_image_test_value
     - key: PATH
       value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-  entrypoint: ['/app/tests/container/nodejs/nodejs_image.binary']
+    - key: PORT
+      value: "8080"
   workdir: "/app/tests/container/nodejs/nodejs_image.binary.runfiles/io_bazel_rules_docker"

--- a/tests/container/python/BUILD
+++ b/tests/container/python/BUILD
@@ -32,6 +32,7 @@ py3_image(
         "$(location :BUILD)",
     ],
     data = [":BUILD"],
+    env = {"PY_IMAGE_TEST_KEY": "py_image_test_value"},
     layers = [
         ":py_image_library",
     ],

--- a/tests/container/python/configs/py_image.yaml
+++ b/tests/container/python/configs/py_image.yaml
@@ -1,12 +1,15 @@
 schemaVersion: 2.0.0
 
 metadataTest:
-  entrypoint: [
-    '/usr/bin/python',
-    '/app/tests/container/python/py_image.binary',
-  ]
   cmd: [
     'arg0',
     'arg1',
     'tests/container/python/BUILD',
   ]
+  entrypoint: [
+    '/usr/bin/python',
+    '/app/tests/container/python/py_image.binary',
+  ]
+  env:
+    - key: "PY_IMAGE_TEST_KEY"
+      value: "py_image_test_value"

--- a/tests/container/python3/BUILD
+++ b/tests/container/python3/BUILD
@@ -26,6 +26,7 @@ py3_image(
         "$(location :BUILD)",
     ],
     data = [":BUILD"],
+    env = {"PY3_IMAGE_TEST_KEY": "py3_image_test_value"},
     layers = [
         "//tests/container/python:py_image_library",
     ],

--- a/tests/container/python3/configs/py3_image.yaml
+++ b/tests/container/python3/configs/py3_image.yaml
@@ -1,12 +1,15 @@
 schemaVersion: 2.0.0
 
 metadataTest:
-  entrypoint: [
-    '/usr/bin/python',
-    '/app/tests/container/python3/py3_image.binary',
-  ]
   cmd: [
     'arg0',
     'arg1',
     'tests/container/python3/BUILD',
   ]
+  entrypoint: [
+    '/usr/bin/python',
+    '/app/tests/container/python3/py3_image.binary',
+  ]
+  env:
+    - key: "PY3_IMAGE_TEST_KEY"
+      value: "py3_image_test_value"

--- a/tests/container/rust/BUILD
+++ b/tests/container/rust/BUILD
@@ -26,6 +26,7 @@ rust_image(
         "$(location :BUILD)",
     ],
     data = [":BUILD"],
+    env = {"RUST_IMAGE_TEST_KEY": "rust_image_test_value"},
 )
 
 container_test(

--- a/tests/container/rust/configs/rust_image.yaml
+++ b/tests/container/rust/configs/rust_image.yaml
@@ -1,9 +1,12 @@
 schemaVersion: 2.0.0
 
 metadataTest:
-  entrypoint: ['/app/tests/container/rust/rust_image_binary']
   cmd: [
     'arg0',
     'arg1',
     'tests/container/rust/BUILD',
   ]
+  entrypoint: ['/app/tests/container/rust/rust_image_binary']
+  env:
+    - key: RUST_IMAGE_TEST_KEY
+      value: rust_image_test_value

--- a/tests/container/scala/BUILD
+++ b/tests/container/scala/BUILD
@@ -33,6 +33,7 @@ scala_image(
         "$(location :BUILD)",
     ],
     data = [":BUILD"],
+    env = {"SCALA_IMAGE_TEST_KEY": "scala_image_test_value"},
     jvm_flags = ["-Dbuild.location=$(location :BUILD)"],
     layers = [":scala_image_library"],
     main_class = "examples.images.Binary",

--- a/tests/container/scala/configs/scala_image.yaml
+++ b/tests/container/scala/configs/scala_image.yaml
@@ -11,3 +11,6 @@ metadataTest:
     'arg1',
     'tests/container/scala/BUILD',
   ]
+  env:
+    - key: SCALA_IMAGE_TEST_KEY
+      value: scala_image_test_value


### PR DESCRIPTION
Introduce an `env` parameter in every `*_image` rule, which is a dict
whose keys and values will become environment variables in the resulting
Docker image.

Apply consistent formatting to every rule's docstring (args in the
docstring are now listed in the same order as in the method declaration)
as well as the container structure tests (`metadataTest` keys are now
sorted alphabetically).

Aside: the docstring formatting seems weird to me, but I'm sticking with the more common one in the repo.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

It is not possible to wire environment variables through to a `*_image` instance; they are forwarded to the `env` of the underlying `*_binary` (usually).

## What is the new behavior?

It is now possible to wire environment variables through to a `*_image`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

