### PR TITLE
Add support for pulling docker images on Apple Silicon

### DIFF
--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -82,9 +82,15 @@ _container_pull_attrs = {
     "platform_features": attr.string_list(
         doc = "Specifies platform features when pulling a multi-platform manifest list.",
     ),
-    "puller_darwin": attr.label(
+    "puller_darwin_amd64": attr.label(
         executable = True,
-        default = Label("@go_puller_darwin//file:downloaded"),
+        default = Label("@go_puller_darwin_amd64//file:downloaded"),
+        cfg = "host",
+        doc = "Exposed to provide a way to test other pullers on macOS",
+    ),
+    "puller_darwin_arm64": attr.label(
+        executable = True,
+        default = Label("@go_puller_darwin_arm64//file:downloaded"),
         cfg = "host",
         doc = "Exposed to provide a way to test other pullers on macOS",
     ),
@@ -144,7 +150,11 @@ def _impl(repository_ctx):
 
     puller = repository_ctx.attr.puller_linux_amd64
     if repository_ctx.os.name.lower().startswith("mac os"):
-        puller = repository_ctx.attr.puller_darwin
+       arch = repository_ctx.execute(["uname", "-m"]).stdout.strip()
+       if arch == "arm64" or arch == "aarch64":
+           puller = repository_ctx.attr.puller_darwin_arm64
+       else:
+           puller = repository_ctx.attr.puller_darwin_amd64
     elif repository_ctx.os.name.lower().startswith("linux"):
         arch = repository_ctx.execute(["uname", "-m"]).stdout.strip()
         if arch == "arm64" or arch == "aarch64":

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -56,13 +56,20 @@ def repositories():
             urls = [("https://storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-linux-s390x")],
         )
 
-    if "go_puller_darwin" not in excludes:
+    if "go_puller_darwin_amd64" not in excludes:
         http_file(
-            name = "go_puller_darwin",
+            name = "go_puller_darwin_amd64",
             executable = True,
             sha256 = "4855c4f5927f8fb0f885510ab3e2a166d5fa7cde765fbe9aec97dc6b2761bb22",
             urls = [("https://storage.googleapis.com/rules_docker/" + RULES_DOCKER_GO_BINARY_RELEASE + "/puller-darwin-amd64")],
         )
+
+    if "go_puller_darwin_arm64" not in excludes:
+       http_file(
+            name = "go_puller_darwin_arm64",
+            executable = True,
+            urls = [("https://github.com/ray-project/rules_docker/releases/download/darwin-arm64/puller-darwin-arm64")],
+       )
 
     if "loader_linux_amd64" not in excludes:
         http_file(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, `rules_docker` gives an error when an image is pulled on Apple Silicon hardware (M1).


## What is the new behavior?

This PR adds support for the docker puller on Apple Silicon.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Before this PR is merged, the maintainers of `rules_docker` should build the binary, upload it to https://storage.googleapis.com/rules_docker/ and change the relevant URL. The current binaries https://github.com/ray-project/rules_docker/releases/download/darwin-arm64/puller-darwin-arm64 have been built on the author's laptop with
```
bazelisk build @io_bazel_rules_docker//container/go/cmd/puller:puller
```