### PR TITLE
Upgrade rules_go and Gazelle

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,7 +3,7 @@ buildifier:
   version: 4.0.1
   # Keep this argument in sync with .pre-commit-config.yml
   warnings: "-function-docstring-args,-print,-provider-params,-unnamed-macro"
-bazel: 4.0.0
+bazel: 5.0.0
 tasks:
   default_workspace_ubuntu1804:
     platform: ubuntu1804

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,6 +37,14 @@ load("//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
 
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains")
+
+go_register_toolchains(version = "1.17.6")
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE")
+
 load("//repositories:images.bzl", test_images = "images")
 
 # py_deps are test dependencies only

--- a/repositories/deps.bzl
+++ b/repositories/deps.bzl
@@ -24,15 +24,12 @@ load(":go_repositories.bzl", "go_deps")
 # TODO: `go_repository_default_config` is only useful for working around
 # https://github.com/bazelbuild/rules_docker/issues/1902 and could likely be
 # removed after https://github.com/bazelbuild/rules_docker/issues/1787
-def deps(go_repository_default_config = "@//:WORKSPACE"):
+def deps():
     """Pull in external dependencies needed by rules in this repo.
 
     Pull in all dependencies needed to run rules in this
     repository. This function assumes the repositories imported by the macro
     'repositories' in //repositories:repositories.bzl have been imported
     already.
-
-    Args:
-        go_repository_default_config (str, optional): A file used to determine the root of the workspace.
     """
-    go_deps(go_repository_default_config = go_repository_default_config)
+    go_deps()

--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -19,13 +19,13 @@ Provides functions to pull all Go external package dependencies of this
 repository.
 """
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+load("@bazel_gazelle//:deps.bzl", "go_repository")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 # TODO: `go_repository_default_config` is only useful for working around
 # https://github.com/bazelbuild/rules_docker/issues/1902 and could likely be
 # removed after https://github.com/bazelbuild/rules_docker/issues/1787
-def go_deps(go_repository_default_config = "@//:WORKSPACE"):
+def go_deps():
     """Pull in external Go packages needed by Go binaries in this repo.
 
     Pull in all dependencies needed to build the Go binaries in this
@@ -33,12 +33,8 @@ def go_deps(go_repository_default_config = "@//:WORKSPACE"):
     'repositories' in //repositories:repositories.bzl have been imported
     already.
 
-    Args:
-        go_repository_default_config (str, optional): A file used to determine the root of the workspace.
     """
     go_rules_dependencies()
-    go_register_toolchains()
-    gazelle_dependencies(go_repository_default_config = go_repository_default_config)
     excludes = native.existing_rules().keys()
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(

--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -20,7 +20,7 @@ repository.
 """
 
 load("@bazel_gazelle//:deps.bzl", "go_repository")
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies")
 
 # TODO: `go_repository_default_config` is only useful for working around
 # https://github.com/bazelbuild/rules_docker/issues/1902 and could likely be

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -111,12 +111,13 @@ def repositories():
     if "io_bazel_rules_go" not in excludes:
         http_archive(
             name = "io_bazel_rules_go",
-            sha256 = "08c3cd71857d58af3cda759112437d9e63339ac9c6e0042add43f4d94caf632d",
+            sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
             urls = [
-                "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.24.2/rules_go-v0.24.2.tar.gz",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.24.2/rules_go-v0.24.2.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
             ],
         )
+
     if "rules_python" not in excludes:
         http_archive(
             name = "rules_python",
@@ -180,8 +181,11 @@ def repositories():
     if "bazel_gazelle" not in excludes:
         http_archive(
             name = "bazel_gazelle",
-            sha256 = "cdb02a887a7187ea4d5a27452311a75ed8637379a1287d8eeb952138ea485f7d",
-            urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz"],
+            sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+            ],
         )
 
     if "rules_pkg" not in excludes:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
rules_go and Gazelle are pretty old

Issue Number: #2036


## What is the new behavior?
* Upgrade rules_go to 0.30
* Upgrade Gazelle to 0.24
* Upgrade Bazel to 5.0, because rules_go requires Bazel 4.2.1


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
New rules_go no longer allows to call `go_register_toolchains` multiple times, so we have to move it out of `go_deps`, because it will be called another time in `python/image.bzl`.

