### PR TITLE
toolchain_configure converts Bazel label of config.json to absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1150,13 +1150,13 @@ load("@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
 
 docker_toolchain_configure(
   name = "docker_config",
-  # Replace this with an absolute path to a directory which has a custom docker
-  # client config.json. Note relative paths are not supported.
-  # Docker allows you to specify custom authentication credentials
+  # Replace this with a Bazel label to the config.json file, or an absolute path to a 
+  # directory which has a custom docker client config.json. Note relative paths are 
+  # not supported. Docker allows you to specify custom authentication credentials
   # in the client configuration JSON file.
   # See https://docs.docker.com/engine/reference/commandline/cli/#configuration-files
   # for more details.
-  client_config="/path/to/docker/client/config-dir",
+  client_config="@//path/to/docker:client.json",
 )
 ```
 In `BUILD` file:


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2040


## What is the new behavior?
`toolchain_configure` will build a `docker_toolchain` target with an absolute path to the config.json even given a Bazel label, so `container_push` will always get an absolute path. We cannot pass the Bazel label to `container_push` because it is a regular Bazel rule, which executes in Bazel sandbox and cannot get an absolute path given a label. The `container_pull` rule is able to do that because it is a repository rule.

Revert the doc changes for `docker_toolchain` in #2032 because it's `client_config` cannot take a Bazel label.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
