### PR TITLE
perf: remove no-remote-cache execution requirements

### DIFF
--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -166,11 +166,6 @@ def build_layer(
         input_manifests = xz_input_manifests,
         tools = files + file_map.values() + tars + debs + [manifest_file] + xz_tools,
         outputs = [layer],
-        execution_requirements = {
-            # This action produces large output files, so it's not
-            # economical to send this to the remote-cache
-            "no-remote-cache": "1",
-        },
         use_default_shell_env = True,
         mnemonic = "ImageLayer",
     )

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -187,12 +187,6 @@ def assemble(
         arguments = [args],
         tools = inputs,
         outputs = [output],
-        execution_requirements = {
-            # This action produces large output files, but doesn't require much CPU to compute.
-            # It's not economical to send this to the remote-cache, instead local cache misses
-            # should just run join_layers again.
-            "no-remote-cache": "1",
-        },
         mnemonic = "JoinLayers",
     )
 

--- a/docker/package_managers/install_pkgs.bzl
+++ b/docker/package_managers/install_pkgs.bzl
@@ -131,11 +131,6 @@ def _impl(ctx, image_tar = None, installables_tar = None, installation_cleanup_c
             installables_tar,
             image_util,
         ],
-        execution_requirements = {
-            # This action produces large output files, and isn't economical to
-            # upload to a remote cache.
-            "no-remote-cache": "1",
-        },
         mnemonic = "ExtractImageId",
         tools = [ctx.executable._extract_image_id, ctx.executable._to_json_tool],
         executable = script,

--- a/docker/util/run.bzl
+++ b/docker/util/run.bzl
@@ -396,11 +396,6 @@ def _commit_layer_impl(
         outputs = [output_layer_tar, output_diff_id],
         inputs = runfiles,
         executable = script,
-        execution_requirements = {
-            # This action produces large output files, and isn't economical to
-            # upload to a remote cache.
-            "no-remote-cache": "1",
-        },
         mnemonic = "RunAndCommitLayer",
         tools = [ctx.executable._extract_image_id, ctx.executable._last_layer_extractor_tool],
         use_default_shell_env = True,

--- a/skylib/zip.bzl
+++ b/skylib/zip.bzl
@@ -50,12 +50,6 @@ def _gzip(ctx, artifact, out, decompress, options, mnemonic):
             ) + (options or []),
             inputs = [artifact],
             outputs = [out],
-            execution_requirements = {
-                # This action produces large output files, but doesn't require much CPU to compute.
-                # It's not economical to send this to the remote-cache, instead local cache misses
-                # should just run gzip again.
-                "no-remote-cache": "1",
-            },
             mnemonic = mnemonic,
             tools = ctx.attr._zipper[DefaultInfo].default_runfiles.files,
         )
@@ -75,13 +69,6 @@ def _gzip(ctx, artifact, out, decompress, options, mnemonic):
             input_manifests = input_manifests,
             inputs = [artifact],
             outputs = [out],
-            execution_requirements = {
-                # See comment above.
-                # In this case it's not guaranteed that the user's gzip implementation
-                # is actually faster than a network fetch, but we guess that any typical
-                # one should be.
-                "no-remote-cache": "1",
-            },
             use_default_shell_env = True,
             mnemonic = mnemonic,
             tools = tools,


### PR DESCRIPTION
These were introduced to reduce load on a remote-cache instance to avoid network saturation.
A month later, a feature was added in one remote-cache implementatation which provides a different fix:
https://github.com/buchgr/bazel-remote/issues/440 rejects large input files on upload.

In practice, while these action do often produce huge outputs, they are also slow to re-execute.
In many cases it's worth it to use a remote-cache for RunAndCommitLayer in particular to avoid a local rebuild
even though it's a large network fetch.
Currently users can't configure this because we've hardcoded the values. If they do want to keep the
no-remote-cache execution requirement, they can do this via a tag (provided they opt-in to
experimental_allow_tags_propagation, see https://github.com/bazelbuild/bazel/issues/8830)

https://github.com/bazelbuild/rules_docker/pull/1856#issuecomment-1060240919 is an example of a user
asking for these to be removed.