### PR TITLE
Update providers.bzl

### DIFF
--- a/container/providers.bzl
+++ b/container/providers.bzl
@@ -52,8 +52,6 @@ LayerInfo = provider(fields = [
 PushInfo = provider(fields = [
     "registry",
     "repository",
-    "tag",
-    "stamp_inputs",
     "digest",
 ])
 


### PR DESCRIPTION
On Bazel 5.0, I am getting below error:
```sh
File "/home/ajithu/.cache/bazel/_bazel_ajithu/3e767109738c8b2d608cdfe5de369b17/external/io_bazel_rules_docker/container/providers.bzl", line 52, column 20, in PushInfo
		PushInfo = provider(fields = [
Error: unexpected keywords stamp, stamp, stamp, stamp_inputs, tag in call to instantiate provider PushInfo
```sh

It looks like we need to delete `stamp_inputs` and `tags` as well

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

