### PR TITLE
DRAFT (RFC): Allow images to have abi representation

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -562,6 +562,11 @@ _attrs = dicts.add(_layer.attrs, {
         allow_files = container_filetype,
         doc = "The base layers on top of which to overlay this layer, equivalent to FROM.",
     ),
+    "abi": attr.string(
+        doc = """The optional [ABI](https://en.wikipedia.org/wiki/Application_binary_interface)
+        representationt to use for the image.
+        """,
+    ),
     "cmd": attr.string_list(
         doc = """List of commands to execute in the image.
 
@@ -770,7 +775,7 @@ _outputs["config_digest"] = "%{name}.json.sha256"
 _outputs["build_script"] = "%{name}.executable"
 
 def _image_transition_impl(settings, attr):
-    return dicts.add(settings, {
+    transitions = dicts.add(settings, {
         "//command_line_option:platforms": "@io_bazel_rules_docker//platforms:image_transition",
         "@io_bazel_rules_docker//platforms:image_transition_cpu": "@platforms//cpu:" + {
             # Architecture aliases.
@@ -781,6 +786,13 @@ def _image_transition_impl(settings, attr):
         "@io_bazel_rules_docker//platforms:image_transition_os": "@platforms//os:" + attr.operating_system,
     })
 
+    if attr.abi:
+        transitions = dicts.add(transitions, {
+            "@io_bazel_rules_docker//platforms:image_transition_abi": "@platforms//abi:" + attr.abi,
+        })
+
+    return transitions
+
 _image_transition = transition(
     implementation = _image_transition_impl,
     inputs = [],
@@ -788,6 +800,7 @@ _image_transition = transition(
         "//command_line_option:platforms",
         "@io_bazel_rules_docker//platforms:image_transition_cpu",
         "@io_bazel_rules_docker//platforms:image_transition_os",
+        "@io_bazel_rules_docker//platforms:image_transition_abi",
     ],
 )
 

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -60,6 +60,7 @@ platform(
 _IMAGE_TRANSITION_CONSTRAINTS = [
     ("cpu", "@platforms//cpu"),
     ("os", "@platforms//os"),
+    ("abi", "@platforms//abi"),
 ]
 
 [[


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes https://github.com/bazelbuild/rules_docker/issues/2063


## What is the new behavior?

This pull-request is a draft aimed at exploring requirements for https://github.com/bazelbuild/platforms/issues/38. A similar change was proposed to make `rules_rust` ABI aware (https://github.com/bazelbuild/rules_rust/pull/1270) with the desire to be able to build targets for the `x86_64-unknown-linux-musl` platform and as a dependency to an [Alpine](https://www.alpinelinux.org/) image ([which uses `musl`](https://www.alpinelinux.org/posts/Alpine-Linux-has-switched-to-musl-libc.html)). 


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information





