### PR TITLE
Fix empty container_bundle

### DIFF
--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -214,18 +214,22 @@ def incremental_load(
 
     toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
 
-    if len(images) > 1 and run:
-        fail("Bazel run does not currently support execution of " +
-             "multiple containers (only loading).")
+    if run:
+        if len(images) != 1:
+            fail("Bazel run currently only supports the execution of a single " +
+                 "container. Only loading multiple containers is supported")
 
-    # Default to interactively launching the container, and cleaning up when
-    # it exits. These template variables are unused if "run" is not set, so
-    # it is harmless to always define them as a function of the first image.
-    run_flags = run_flags or "-i --rm"
-    run_statement = "\"${DOCKER}\" ${DOCKER_FLAGS} run %s" % run_flags
-    run_tag = images.keys()[0]
-    if stamp:
-        run_tag = run_tag.replace("{", "${")
+        # Default to interactively launching the container, and cleaning up when
+        # it exits. These template variables are unused if "run" is not set, so
+        # it is harmless to always define them as a function of the first image.
+        run_flags = run_flags or "-i --rm"
+        run_statement = "\"${DOCKER}\" ${DOCKER_FLAGS} run %s" % run_flags
+        run_tag = images.keys()[0]
+        if stamp:
+            run_tag = run_tag.replace("{", "${")
+    else:
+        run_statement = ""
+        run_tag = ""
 
     load_statements = []
     tag_statements = []


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

incremental_load is used for both defining single container targets and container_bundles. Defining an empty `container_bundle` crashes as there's an assumption that at least one image is defined regardless. 

Issue Number: fixes #2010 


## What is the new behavior?

An empty `container_bundle` does not crash. We do not try to build a run command if `run` is not set to True


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

