### PR TITLE
chore: enable  --incompatible_disable_depset_items

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -57,7 +57,10 @@ test:remote --remote_timeout=3600
 test:remote --keep_going
 
 # Configuration specific to buildkite CI testing the default workspace
-test:buildkite --action_env=PATH 
-test:buildkite --define=ENV_KEY=my_key # for tests/container:set_env_make_vars_test 
-test:buildkite --define=ENV_VALUE=my_value # for tests/container:set_env_make_vars_test 
+test:buildkite --action_env=PATH
+test:buildkite --define=ENV_KEY=my_key # for tests/container:set_env_make_vars_test
+test:buildkite --define=ENV_VALUE=my_value # for tests/container:set_env_make_vars_test
 test:buildkite --test_output=errors
+
+# These flags are flipped in bazel 5.0.0, let's make sure we don't break again.
+build --incompatible_disable_depset_items

--- a/docker/package_managers/download_pkgs.bzl
+++ b/docker/package_managers/download_pkgs.bzl
@@ -88,6 +88,8 @@ def _impl(ctx, image_tar = None, packages = None, additional_repos = None, outpu
     """
     if types.is_depset(packages):
         packages = packages.to_list()
+    if types.is_depset(additional_repos):
+        additional_repos = additional_repos.to_list()
     image_tar = image_tar or ctx.file.image_tar
     packages = depset(packages or ctx.attr.packages)
     additional_repos = depset(additional_repos or ctx.attr.additional_repos)


### PR DESCRIPTION
The flag is flipped in bazel 5.0.0, and this results in errors.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

