### PR TITLE
Bump the container-structure-test tool to v1.11.0

### DIFF
--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -138,24 +138,24 @@ def repositories():
         http_file(
             name = "structure_test_linux",
             executable = True,
-            sha256 = "9ddc0791491dc8139af5af4d894e48db4eeaca4b2cb9196293efd615bdb79122",
-            urls = ["https://storage.googleapis.com/container-structure-test/v1.9.1/container-structure-test-linux-amd64"],
+            sha256 = "1524da5fd5a0fc88c4c9257a3de05a45f135df07e6a684380dd5f659b9ce189b",
+            urls = ["https://storage.googleapis.com/container-structure-test/v1.11.0/container-structure-test-linux-amd64"],
         )
 
     if "structure_test_linux_aarch64" not in excludes:
         http_file(
             name = "structure_test_linux_aarch64",
             executable = True,
-            sha256 = "b8fd54ed5f3fcb65861dec8aea5ccf05856c9e030a67461e601eab64c1fe70b1",
-            urls = ["https://storage.googleapis.com/container-structure-test/v1.9.1/container-structure-test-linux-arm64"],
+            sha256 = "b376ff80134d2d609c591b98d65d653a514755b4861185fd93159af7062ec65d",
+            urls = ["https://storage.googleapis.com/container-structure-test/v1.11.0/container-structure-test-linux-arm64"],
         )
 
     if "structure_test_darwin" not in excludes:
         http_file(
             name = "structure_test_darwin",
             executable = True,
-            sha256 = "0b8c019b5a3df1a84515b75c2eb47aaf9db51dec621a39d1c4fa31a4a8f6c855",
-            urls = ["https://storage.googleapis.com/container-structure-test/v1.9.1/container-structure-test-darwin-amd64"],
+            sha256 = "0a4ac9e221a86cda6bb9fedb2a0dfdce56f918327b8881977ad787ea15d0e82f",
+            urls = ["https://storage.googleapis.com/container-structure-test/v1.11.0/container-structure-test-darwin-amd64"],
         )
 
     if "container_diff" not in excludes:


### PR DESCRIPTION
Old v1.9.1 version was segfaulting on Monteray (Mac OS 12.3). I've
confirmed that the v1.11.0 version works correctly.

The (closed) upstream bug is https://github.com/GoogleContainerTools/container-structure-test/issues/286

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Update tool version (for `container-structure-test`)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

when using `container_test()` on Mac OS X Monterey, on an M1 Pro, I get a segmentation fault:
Segmentation fault: 11  ../structure_test_darwin/file/downloaded version

## What is the new behavior?

`container_test()` now successfully invokes the tool

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

