### PR TITLE
Fix warning message ref invalid rule

### DIFF
--- a/container/push.bzl
+++ b/container/push.bzl
@@ -79,7 +79,7 @@ def _impl(ctx):
     if tarball:
         print("Pushing an image based on a tarball can be very " +
               "expensive. If the image set on %s is the output of a " % ctx.label +
-              "container_build, consider dropping the '.tar' extension. " +
+              "docker_build, consider dropping the '.tar' extension. " +
               "If the image is checked in, consider using " +
               "container_import instead.")
 


### PR DESCRIPTION
In https://github.com/bazelbuild/rules_docker/pull/1118/, the warning
message was mistakenly renamed from `docker_build` to `container_build`.

`container_build` does not exist in the repository, only `docker_build`
does.
