### PR TITLE
Update bazel-gazelle version

### DIFF
--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -37,7 +37,7 @@ def go_deps(go_repository_default_config = "@//:WORKSPACE"):
         go_repository_default_config (str, optional): A file used to determine the root of the workspace.
     """
     go_rules_dependencies()
-    go_register_toolchains()
+    go_register_toolchains(version = "1.18")
     gazelle_dependencies(go_repository_default_config = go_repository_default_config)
     excludes = native.existing_rules().keys()
     if "com_github_google_go_containerregistry" not in excludes:

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -180,8 +180,8 @@ def repositories():
     if "bazel_gazelle" not in excludes:
         http_archive(
             name = "bazel_gazelle",
-            sha256 = "cdb02a887a7187ea4d5a27452311a75ed8637379a1287d8eeb952138ea485f7d",
-            urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz"],
+            sha256 = "3e51b2a0db7f3b1dcb973f07caf358e64301dcaa40f92bccec0e490f46b18afc",
+            urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz"],
         )
 
     if "rules_pkg" not in excludes:

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -111,10 +111,10 @@ def repositories():
     if "io_bazel_rules_go" not in excludes:
         http_archive(
             name = "io_bazel_rules_go",
-            sha256 = "08c3cd71857d58af3cda759112437d9e63339ac9c6e0042add43f4d94caf632d",
+            sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
             urls = [
-                "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.24.2/rules_go-v0.24.2.tar.gz",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.24.2/rules_go-v0.24.2.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
             ],
         )
     if "rules_python" not in excludes:

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -180,7 +180,7 @@ def repositories():
     if "bazel_gazelle" not in excludes:
         http_archive(
             name = "bazel_gazelle",
-            sha256 = "3e51b2a0db7f3b1dcb973f07caf358e64301dcaa40f92bccec0e490f46b18afc",
+            sha256 = "5982e5463f171da99e3bdaeff8c0f48283a7a5f396ec5282910b9e8a49c0dd7e",
             urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz"],
         )
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x ] Other... Please describe: Dependency update


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

There is a long-running problem with go_repository from `Bazel-gazelle` throttling on `bazel sync` over clean project.
It's well-described [here](https://github.com/bazelbuild/bazel-gazelle/issues/1175) and fixed [here](https://github.com/bazelbuild/bazel-gazelle/pull/1206). There is actually a whole release (0.25.0) that includes these changes. I think we should merge them into the upstream.

UPD. Apparently it's not that simple. Looks like we have to update the version of Go itself here. Should we?