### PR TITLE
Keep the same behaviour for the 'base' argument between the rule `container_image` and its implementation function (#2083)

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -39,7 +39,8 @@ load(
     "//container:layer_tools.bzl",
     _assemble_image = "assemble",
     _gen_img_args = "generate_args_for_image",
-    _get_layers = "get_from_target",
+    _get_layers_from_archive_file = "get_from_archive_file",
+    _get_layers_from_target = "get_from_target",
     _incr_load = "incremental_load",
     _layer_tools = "tools",
 )
@@ -55,20 +56,6 @@ load(
     "//skylib:path.bzl",
     _join_path = "join",
 )
-
-def _get_base_config(ctx, name, base):
-    if ctx.files.base or base:
-        # The base is the first layer in container_parts if provided.
-        layer = _get_layers(ctx, name, ctx.attr.base, base)
-        return layer.get("config")
-    return None
-
-def _get_base_manifest(ctx, name, base):
-    if ctx.files.base or base:
-        # The base is the first layer in container_parts if provided.
-        layer = _get_layers(ctx, name, ctx.attr.base, base)
-        return layer.get("manifest")
-    return None
 
 def _add_create_image_config_args(
         ctx,
@@ -356,6 +343,7 @@ def _impl(
         null_entrypoint: bool, overrides ctx.attr.null_entrypoint
     """
     name = name or ctx.label.name
+    base = base or ctx.attr.base
     entrypoint = entrypoint or ctx.attr.entrypoint
     cmd = cmd or ctx.attr.cmd
     architecture = architecture or ctx.attr.architecture
@@ -421,7 +409,10 @@ def _impl(
     # Get the layers and shas from our base.
     # These are ordered as they'd appear in the v2.2 config,
     # so they grow at the end.
-    parent_parts = _get_layers(ctx, name, ctx.attr.base, base)
+    if hasattr(base, "basename"):
+        parent_parts = _get_layers_from_archive_file(ctx, name, base)
+    else:
+        parent_parts = _get_layers_from_target(ctx, name, base)
     zipped_layers = parent_parts.get("zipped_layer", []) + [layer.zipped_layer for layer in layers]
     shas = parent_parts.get("blobsum", []) + [layer.blob_sum for layer in layers]
     unzipped_layers = parent_parts.get("unzipped_layer", []) + [layer.unzipped_layer for layer in layers]
@@ -434,11 +425,11 @@ def _impl(
     transitive_files = depset(new_files + new_emptyfiles + new_symlinks, transitive = [parent_transitive_files])
 
     # Get the config for the base layer
-    config_file = _get_base_config(ctx, name, base)
+    config_file = parent_parts.get("config")
     config_digest = None
 
     # Get the manifest for the base layer
-    manifest_file = _get_base_manifest(ctx, name, base)
+    manifest_file = parent_parts.get("manifest")
     manifest_digest = None
 
     # Generate the new config layer by layer, using the attributes specified and the diff_id

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -103,29 +103,39 @@ def generate_args_for_image(ctx, image, to_path = _file_path):
         args.append("--manifest={}".format(to_path(ctx, image["manifest"])))
     return args, inputs
 
-def get_from_target(ctx, name, attr_target, file_target = None):
+def get_from_target(ctx, name, attr_target):
     """Gets all layers from the given target.
 
     Args:
        ctx: The context
        name: The name of the target
        attr_target: The attribute to get layers from
-       file_target: If not None, layers are extracted from this target
 
     Returns:
        The extracted layers
     """
-    if file_target:
-        return _extract_layers(ctx, name, file_target)
-    elif attr_target and ImageInfo in attr_target:
+    if not attr_target:
+        return {}
+    elif ImageInfo in attr_target:
         return attr_target[ImageInfo].container_parts
-    elif attr_target and ImportInfo in attr_target:
+    elif ImportInfo in attr_target:
         return attr_target[ImportInfo].container_parts
     else:
-        if not hasattr(attr_target, "files"):
-            return {}
-        target = attr_target.files.to_list()[0]
-        return _extract_layers(ctx, name, target)
+        archive_file = attr_target.files.to_list()[0]
+        return get_from_archive_file(ctx, name, archive_file)
+
+def get_from_archive_file(ctx, name, archive_file):
+    """Gets all layers from the given archive file.
+
+    Args:
+       ctx: The context
+       name: The name of the target
+       archive_file: The archive file to get layers from
+
+    Returns:
+       The extracted layers
+    """
+    return _extract_layers(ctx, name, archive_file)
 
 def _add_join_layers_args(args, inputs, images):
     """Add args & inputs needed to call the Go join_layers for the given images


### PR DESCRIPTION
Really override the ctx.attr.base attribute with the 'base' argument of
the implementattion function of the `container_image` rule.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #2083 

## What is the new behavior?

We can give the same object type to the `base` argument of the `container_image` implementation function than the `base` attribute of the associated rule.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No