### PR TITLE
Add a release workflow that with the correct crafted tag of a release…

### DIFF
--- a/.github/workflows/add_binaries_to_release.yml
+++ b/.github/workflows/add_binaries_to_release.yml
@@ -1,0 +1,64 @@
+name: Upload self-contained binaries
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: write # for actions/upload-release-asset to upload release asset
+    runs-on: ubuntu-18.04
+    if:  startsWith(github.event.release.tag_name, 'docker-tools-')
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["linux", "darwin"]
+        cpu: ["amd64", "arm64", "s390x"]
+        application: ["puller", "loader"]
+        executable_mime: ["application/x-executable", "application/x-mach-binary"]
+        exclude:
+          - os: darwin
+            cpu: arm64
+          - os: darwin
+            cpu: s390x
+          - os: darwin
+            executable_mime: "application/x-executable"
+          - os: linux
+            executable_mime: "application/x-mach-binary"
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          curl -L -o /tmp/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
+          chmod +x /tmp/bazelisk
+          /tmp/bazelisk || exit 1
+
+      - name: Build binary
+        run: |
+          /tmp/bazelisk build --platforms=@io_bazel_rules_go//go/toolchain:${{ matrix.os }}_${{ matrix.cpu }} container/go/cmd/${{ matrix.application }}:${{ matrix.application }}
+          shasum -a 256 bazel-bin/container/go/cmd/${{ matrix.application }}/${{ matrix.application }}_/${{ matrix.application }} | awk '{print $1}' > /tmp/output.sha256
+
+      - name: Upload binary as release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: bazel-bin/container/go/cmd/${{ matrix.application }}/${{ matrix.application }}_/${{ matrix.application }}
+          asset_name: ${{ matrix.os }}-${{ matrix.cpu }}_${{ matrix.application }}
+          asset_content_type: ${{ matrix.executable_mime }}
+
+      - name: Upload binary sha as release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: /tmp/output.sha256
+          asset_name: ${{ matrix.os }}-${{ matrix.cpu }}_${{ matrix.application }}.sha256
+          asset_content_type: "text/plain"


### PR DESCRIPTION
… will add the binaries built from the repo

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Right now some external system i believe produces the binaries used in releases



## What is the new behavior?

A maintainer can make a release at any time starting with `docker-tools-`, e.g. `docker-tools-v1` and the github actions will populate that release with binaries hosted by github of the tools used. Github sorts releases, so they won't appear at the top. And so maintainers can as part of a mainline release first do a tools release, get the new binaries and do a main release. Also anyone can fork this repo and reproduce the same experience.

## Does this PR introduce a breaking change?

- [ ] Yes
- []x] No



## Other information

