### PR TITLE
[layer_tools/generate_args_for_image] Inject extra argument to the given callback

### DIFF
--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -59,7 +59,7 @@ def _file_path(ctx, val):
     """
     return val.path
 
-def generate_args_for_image(ctx, image, to_path = _file_path):
+def generate_args_for_image(ctx, image, to_path = _file_path, **kwargs):
     """Generates arguments & inputs for the given image.
 
     Args:
@@ -67,6 +67,7 @@ def generate_args_for_image(ctx, image, to_path = _file_path):
         image: The image parts dictionary as returned by 'get_from_target'.
         to_path: A function to transform the string paths as they
                         are added as arguments.
+        **kwargs: Arguments to give to the `to_path` function.
 
     Returns:
         The arguments to call the pusher, digester & flatenner with to load
@@ -77,7 +78,7 @@ def generate_args_for_image(ctx, image, to_path = _file_path):
     uncompressed_layers = image.get("unzipped_layer", [])
     digest_files = image.get("blobsum", [])
     diff_id_files = image.get("diff_id", [])
-    args = ["--config={}".format(to_path(ctx, image["config"]))]
+    args = ["--config={}".format(to_path(ctx, image["config"], **kwargs))]
     inputs = [image["config"]]
     inputs += compressed_layers
     inputs += uncompressed_layers
@@ -89,18 +90,18 @@ def generate_args_for_image(ctx, image, to_path = _file_path):
         diff_id_file = diff_id_files[i]
         args.append(
             "--layer={},{},{},{}".format(
-                to_path(ctx, compressed_layer),
-                to_path(ctx, uncompressed_layer),
-                to_path(ctx, digest_file),
-                to_path(ctx, diff_id_file),
+                to_path(ctx, compressed_layer, **kwargs),
+                to_path(ctx, uncompressed_layer, **kwargs),
+                to_path(ctx, digest_file, **kwargs),
+                to_path(ctx, diff_id_file, **kwargs),
             ),
         )
     if image.get("legacy"):
         inputs.append(image["legacy"])
-        args.append("--tarball={}".format(to_path(ctx, image["legacy"])))
+        args.append("--tarball={}".format(to_path(ctx, image["legacy"], **kwargs)))
     if image["manifest"]:
         inputs.append(image["manifest"])
-        args.append("--manifest={}".format(to_path(ctx, image["manifest"])))
+        args.append("--manifest={}".format(to_path(ctx, image["manifest"], **kwargs)))
     return args, inputs
 
 def get_from_target(ctx, name, attr_target, file_target = None):


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Just improve the flexibility of a starlark function. 

## What is the current behavior?

```starlark
generate_args_for_image(ctx, image, to_path = _file_path)
```

Issue Number: N/A

## What is the new behavior?

```starlark
generate_args_for_image(ctx, image, to_path = _file_path, **kwargs)
```

When using a transition we need to give a callback function to compute a path specific for this transition.
This information is not available from the context (`ctx`) and the given file.
We need to have a way to inject this extra information.

Example with an architecture specific transition:

```starlark
load("@io_bazel_rules_docker//container:layer_tools.bzl", "generate_args_for_image")

def _to_arch_path(ctx, f, arch = None):
    """Returns the architecture specific path of the given file f."""
    return paths.join(
        paths.dirname(f.short_path),
        arch,
        paths.basename(f.short_path),
    )

def _xxx_impl(ctx):

    ...

    # Here `image` is an attribute with a 1:2+ transition
    # All of their files share the same `short_path`.
    for image_target in ctx.attr.image:
        image = ... [ImageInfo].container_parts
        arch = ...

        ...

        img_args, img_inputs = generate_args_for_image(
            ctx, image, _to_arch_path, arch = arch,
        )

        ...

        # Use symlinks in `runfiles()` to make available all files through their arch specific path.
        symlinks.update({
            _to_arch_path(ctx, i, arch = arch): i
            for i in img_inputs
        })

    ...

    runfiles = ctx.runfiles(
        files = ...
        symlinks = symlinks
    )
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No