### PR TITLE
Strip legacy `repositories` in config_stripper.py to ensure reproducibility of tars

### DIFF
--- a/docker/util/config_stripper.py
+++ b/docker/util/config_stripper.py
@@ -94,6 +94,19 @@ def strip_tar(input, output):
     with open(mf_path, 'w') as f:
         json.dump(manifest, f, sort_keys=True)
 
+    # Rewrite the legacy repositories file with the new layer name.
+    repositories_path = os.path.join(tempdir, 'repositories')
+    first_manifest_entry = next(iter(manifest), None)
+    if first_manifest_entry is not None:
+        repo_tags = first_manifest_entry['RepoTags'][0]
+        repo, tag = repo_tags.split(":")
+        last_layer = first_manifest_entry['Layers'][-1]
+        repositories = {repo: {tag: last_layer}}
+
+        # Rewrite repositories with the new layer name.
+        with open(repositories_path, 'w') as f:
+            json.dump(repositories, f, sort_keys=True)
+
     # Collect the files before adding, so we can sort them.
     files_to_add = []
     for root, _, files in os.walk(tempdir):

--- a/docker/util/config_stripper_test.py
+++ b/docker/util/config_stripper_test.py
@@ -16,8 +16,11 @@
 
 import os
 import unittest
+import tarfile
+import json
 
 from docker.util.config_stripper import strip_tar
+
 
 class ConfigStripperTest(unittest.TestCase):
     def test_image_with_symlinked_layers(self):
@@ -36,5 +39,32 @@ class ConfigStripperTest(unittest.TestCase):
                 "Config stripper did not produce stripped tarball {}".format(
                     out_tar))
 
+        # Unpack the output.
+        test_image_unpacked = os.path.join(
+            os.environ["TEST_TMPDIR"],
+            "test_image_unpacked")
+        os.mkdir(test_image_unpacked)
+        with tarfile.open(name=out_tar, mode='r') as it:
+            it.extractall(test_image_unpacked)
+
+        # Check the generated manifest.
+        mf_path = os.path.join(test_image_unpacked, 'manifest.json')
+        with open(mf_path, 'r') as mf:
+            manifest = json.load(mf)
+        expected_manifest = [{'Config': 'sha256:e23c58d96cd9b792b2c81802aff2df452dda4eaf8721e3384e00c6f9454d3444',
+                              'Layers': ['sha256:85cea451eec057fa7e734548ca3ba6d779ed5836a3f9de14b8394575ef0d7d8e',
+                                         'sha256:85cea451eec057fa7e734548ca3ba6d779ed5836a3f9de14b8394575ef0d7d8e'],
+                              'RepoTags': ['bazel:small_base_2']}]
+        self.assertEquals(manifest, expected_manifest)
+
+        # Check the generated legacy repositories file.
+        repositories_path = os.path.join(test_image_unpacked, 'repositories')
+        with open(repositories_path, 'r') as rf:
+            repositories = json.load(rf)
+        expected_repositories = {
+            'bazel': {'small_base_2': 'sha256:85cea451eec057fa7e734548ca3ba6d779ed5836a3f9de14b8394575ef0d7d8e'}
+        }
+        self.assertEquals(repositories, expected_repositories)
+
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features): stripping config seems to be a non-documented implementation detail. Stripping manifests is also not documented atm.


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

In a certain sense this is a bugfix for the reproducibility of generated tar files when installing pkgs.
Also it fixes `repositories` for the 1.0 Docker Image Specification.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently if you install packages to a docker container, even if you ensure that all the files in the generated tar will be the same (e.g. by using the `installation_cleanup_commands` feature) you still won't get a reproducible tar file.
The reason is that there is a `repositories` file in the generated tar, that is similar to the `manifest.json` (just representing data for a legacy docker API).
`manifest.json` is being cleaned up by `config_stripper.py`, but `repositories` is not.
As an effect, `repositories` in the current implementation doesn't point to an existing layer, as stripping changes the layer names, but `repositories` stays unchanged.

Issue Number: N/A


## What is the new behavior?

Clean up also `repositories` basing on the stripped data from the manifest. This fixes `repositories` semantics and also fixes reproducibility.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Assuming `repositories` can be parsed in the new version by older docker implementations. In fact if it's a breaking change, then I assume we'd need a different solution (e.g. remove the legacy `repositories` file from the tar if some option is set).


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Any alternative ideas how to fix the lack of reproducibility caused by the existing `repositories` file would be welcome.