### PR TITLE
Make golden image digests work with Python 3.9

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,8 +5,8 @@ buildifier:
   warnings: "-function-docstring-args,-print,-provider-params,-unnamed-macro"
 bazel: 4.0.0
 tasks:
-  default_workspace_ubuntu1804:
-    platform: ubuntu1804
+  default_workspace_ubuntu2104:
+    platform: ubuntu2104
     test_targets:
       - //...
     test_flags:
@@ -170,7 +170,7 @@ tasks:
       - --keep_going
       - --config=buildkite
   testing_examples:
-    platform: ubuntu1804
+    platform: ubuntu2104
     working_directory: testing/examples
     shell_commands:
       - cp ../../.bazelrc .
@@ -183,14 +183,14 @@ tasks:
     test_flags:
       - --test_output=errors
   testing_java_image:
-    platform: ubuntu1804
+    platform: ubuntu2104
     working_directory: testing/java_image
     shell_commands:
       - cp ../../.bazelrc .
     build_targets:
       - //...
   testing_download_pkgs_at_root:
-    platform: ubuntu1804
+    platform: ubuntu2104
     working_directory: testing/download_pkgs_at_root
     shell_commands:
       - cp ../../.bazelrc .
@@ -199,7 +199,7 @@ tasks:
     test_flags:
       - --test_output=errors
   testing_custom_toolchain_flags:
-    platform: ubuntu1804
+    platform: ubuntu2104
     working_directory: testing/custom_toolchain_flags
     shell_commands:
       - cp ../../.bazelrc .

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -240,7 +240,7 @@ container_push(
 # BEGIN_DO_NOT_IMPORT
 file_test(
     name = "test_digest_output1",
-    content = "sha256:4ec78686f1edd4f30cca6222f17ace5a2b9f8db9708727c3a140c954af0a534d",
+    content = "sha256:7d1a06dae0021fb7a0bb789d414ec3799a397141d7299dce5ba287627737eaea",
     file = ":deb_image_with_dpkgs.digest",
 )
 
@@ -616,13 +616,13 @@ file_test(
 
 file_test(
     name = "alpine_custom_attr_digest_test",
-    content = "sha256:2f3bf2d061a1bab130cdd98f10b73dfceb08bfbf94a610c62f20c787073e5178",
+    content = "sha256:63a40621b30af05f51fb2b38c2b5c56f9cc82cc605d556e09cacdbbdc5adec63",
     file = ":new_push_test_legacy_from_container_img.digest",
 )
 
 file_test(
     name = "new_alpine_linux_armv6_image_tar_digest_test",
-    content = "sha256:249804db68a05bb88cc353d4aff090b084d8b8312665638d2f8d7bdaeaa423b3",
+    content = "sha256:8876a15fad80a30d9ec8660a09c0b795513febc64084047e394a5b534a596ecd",
     file = ":new_alpine_linux_armv6_image_tar.digest",
 )
 

--- a/tests/container/image_test.py
+++ b/tests/container/image_test.py
@@ -83,21 +83,21 @@ class ImageTest(unittest.TestCase):
     def test_files_base(self):
         with TestImage('files_base') as img:
             self.assertDigest(
-                img, '83eeb10d7699ce30c6fcc7246540da38ef91802d2c0ce1c378b6b66d335f25fe')
+                img, '84a3ebbfae2f49509b76c0beb3414b10fdd1bb0ceeed457754a3e44a251ed019')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './foo'])
 
     def test_files_with_file_base(self):
         with TestImage('files_with_files_base') as img:
             self.assertDigest(
-                img, '2dcc8b4e1e0dac1b2b3845e239dd67528e8fe92fe5954264a383381d1345bfab')
+                img, '6793f8771bd38ebed45f5a4516fb67ada632d06b2fc0179e95e01847448c8386')
             self.assertEqual(2, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './bar'])
 
     def test_files_in_layer_with_file_base(self):
         with TestImage('files_in_layer_with_files_base') as img:
             self.assertDigest(
-                img, '6f685967678e9eb6a5c8aed9a47c519e90c0fd253e433831d610885eb364d287')
+                img, '828eb1d0daa2f797497ec54de421e79a663429e0e791b246c420e84ec171fe7f')
             self.assertEqual(3, len(img.fs_layers()))
             self.assertLayerNContains(img, 2, ['.', './foo'])
             self.assertLayerNContains(img, 1, ['.', './baz'])
@@ -106,7 +106,7 @@ class ImageTest(unittest.TestCase):
     def test_tar_base(self):
         with TestImage('tar_base') as img:
             self.assertDigest(
-                img, '4ae5617fb03c1528b7871623ebe37c8baa51bfd9dfdc099161d3c1de12807cc5')
+                img, '1f952b078e8d380fce4097857f32823976203ed4aaa54821773474f98012bfac')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, [
                 './usr', './usr/bin', './usr/bin/unremarkabledeath'])
@@ -116,13 +116,13 @@ class ImageTest(unittest.TestCase):
     def test_tar_with_mtimes_preserved(self):
         with TestImage('tar_with_mtimes_preserved') as img:
             self.assertDigest(
-                img, 'bb41dd8b5c85c51fb4e88ddcb293a1b484ebf0615a8eacf7a617583b711616c8')
+                img, '8167d35b2267136fbb68f92b68fef2893000d74f372d4b694d6b53ca79a20146')
             self.assertNonZeroMtimesInTopLayer(img)
 
     def test_tar_with_tar_base(self):
         with TestImage('tar_with_tar_base') as img:
             self.assertDigest(
-                img, '0cbaf0a5f3dfeb37dc4d30eebedfe667988bc95edbfee88357a99ecbdbeb3df8')
+                img, '3bb6c0ebe52f6f4a76562eee9d79c4c46ff9d9dad749ef55f949d089f7a36b0a')
             self.assertEqual(2, len(img.fs_layers()))
             self.assertTopLayerContains(img, [
                 './asdf', './usr', './usr/bin',
@@ -131,7 +131,7 @@ class ImageTest(unittest.TestCase):
     def test_tars_in_layer_with_tar_base(self):
         with TestImage('tars_in_layer_with_tar_base') as img:
             self.assertDigest(
-                img, '6e95a8d96bded6f360a46c0a7dd0abe28280c2ef96ac5dd48b780182489a0907')
+                img, 'accf4062e218d20cdcc661dcd5d4ff4f4818d5bc8641db1ed00c884d46ec6999')
             self.assertEqual(3, len(img.fs_layers()))
             self.assertTopLayerContains(img, [
                 './asdf', './usr', './usr/bin',
@@ -144,7 +144,7 @@ class ImageTest(unittest.TestCase):
     def test_directory_with_tar_base(self):
         with TestImage('directory_with_tar_base') as img:
             self.assertDigest(
-                img, '20428e13bc65d571c97381b27badb0c100c9800d46d3633e04711c9624329de3')
+                img, '8fccb0a6c600b88fe117c81e368d62ad558b945cff8927110afed9f4072d2483')
             self.assertEqual(2, len(img.fs_layers()))
             self.assertTopLayerContains(img, [
                 '.', './foo', './foo/asdf', './foo/usr',
@@ -153,14 +153,14 @@ class ImageTest(unittest.TestCase):
     def test_files_with_tar_base(self):
         with TestImage('files_with_tar_base') as img:
             self.assertDigest(
-                img, 'dbff2c6807875670dbe6c1552980ab219f1faa07e973f242af1e54ff2abb5205')
+                img, '3ce522f4f9f80249eb75b9b7083a24b17f45c607a40f3d54418c6bad355b399f')
             self.assertEqual(2, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './bar'])
 
     def test_workdir_with_tar_base(self):
         with TestImage('workdir_with_tar_base') as img:
             self.assertDigest(
-                img, '6d04846ec7d263710897e6b6dabe4b79403917d7b280786d68bb960b4dc7d4ed')
+                img, '242ac990f663c8c49e540d470112b21dbf001b1c984097ab787f4af900543c47')
             self.assertEqual(2, len(img.fs_layers()))
             self.assertTopLayerContains(img, [])
             # Check that the working directory property has been properly configured.
@@ -169,7 +169,7 @@ class ImageTest(unittest.TestCase):
     def test_tar_with_files_base(self):
         with TestImage('tar_with_files_base') as img:
             self.assertDigest(
-                img, '596f8ce31445ba50efd929707c29ea9257baa7cab4ca04060f400e7944d3ca92')
+                img, 'c1d46001de2e021dcc6943351cc62d1f236c6a3528132ca9014c28dc5bb19d02')
             self.assertEqual(2, len(img.fs_layers()))
             self.assertTopLayerContains(img, [
                 './asdf', './usr', './usr/bin',
@@ -178,14 +178,14 @@ class ImageTest(unittest.TestCase):
     def test_docker_tarball_base(self):
         with TestImage('docker_tarball_base') as img:
             self.assertDigest(
-                img, '4540715e829ccec6b4801b42a4b4185f3a8ebd1bac5df20761f5c67f4119c9d5')
+                img, '67c9957f23377c8902412429c02c006a8a55fffaa6f44a9963a08aa1986abf01')
             self.assertEqual(3, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './foo'])
 
     def test_layers_with_docker_tarball_base(self):
         with TestImage('layers_with_docker_tarball_base') as img:
             self.assertDigest(
-                img, 'ba89f7d89b59f7a09e209cd5aac533d9ff1f97c0f2313ea45e4c70b081fcd976')
+                img, 'c0d4751af7d72f7ce80e3997dadfad4f176823743e1b0a5af147d55f70a0c8d5')
             self.assertEqual(5, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './foo'])
             self.assertLayerNContains(
@@ -195,7 +195,7 @@ class ImageTest(unittest.TestCase):
     def test_base_with_entrypoint(self):
         with TestImage('base_with_entrypoint') as img:
             self.assertDigest(
-                img, '732aa319e2bf017b174c182300fcd14b935df244c6539bf0aaa2ebd544b15126')
+                img, 'b8460d575a3d4558057bbdb6f05988259b4f61b1b1f3f117b941043e486914a2')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertConfigEqual(img, 'Entrypoint', ['/bar'])
             self.assertConfigEqual(img, 'ExposedPorts', {'8080/tcp': {}})
@@ -210,7 +210,7 @@ class ImageTest(unittest.TestCase):
     def test_derivative_with_cmd(self):
         with TestImage('derivative_with_cmd') as img:
             self.assertDigest(
-                img, '0f28b0372b8863f1aa05357ce2c1a97eb1e37ee658d23ede5343a52441916b03')
+                img, 'a861490554b3658254af83568adfc83992dc796dbc425fb6f0db35cef2e216ee')
             self.assertEqual(3, len(img.fs_layers()))
 
             self.assertConfigEqual(img, 'Entrypoint', ['/bar'])
@@ -221,7 +221,7 @@ class ImageTest(unittest.TestCase):
     def test_derivative_with_volume(self):
         with TestImage('derivative_with_volume') as img:
             self.assertDigest(
-                img, '02cbd6ab6c0321e19967e10f56a033619f03b7749cd94ee0477df63492d1b103')
+                img, 'f6c5b0e90cd0f22581669e0b4efd2b530c746bf50b9a8945c584456eafc0ffb6')
             self.assertEqual(2, len(img.fs_layers()))
 
             # Check that the topmost layer has the volumes exposed by the bottom
@@ -233,7 +233,7 @@ class ImageTest(unittest.TestCase):
     def test_with_unix_epoch_creation_time(self):
         with TestImage('with_unix_epoch_creation_time') as img:
             self.assertDigest(
-                img, '55e9615fe7b450c9962c520061b7d9bd1cc49f35d68629db8ac5389148b2eb0b')
+                img, 'bc6b0d9457585177d993fa23492f044e6ca3801096d34fef6bb2051f98f65b56')
             self.assertEqual(2, len(img.fs_layers()))
             cfg = json.loads(img.config_file())
             self.assertEqual('2009-02-13T23:31:30.119999885Z',
@@ -242,7 +242,7 @@ class ImageTest(unittest.TestCase):
     def test_with_millisecond_unix_epoch_creation_time(self):
         with TestImage('with_millisecond_unix_epoch_creation_time') as img:
             self.assertDigest(
-                img, '06e1facdeea3dee8185a6132a09087ff4de9f1509f560035094c2bc7486a7f34')
+                img, '6fbbd791c5daba03ff50f181cabe5a1cd1088979598f9cdc356ecf7653d39170')
             self.assertEqual(2, len(img.fs_layers()))
             cfg = json.loads(img.config_file())
             self.assertEqual('2009-02-13T23:31:30.12345004Z',
@@ -251,7 +251,7 @@ class ImageTest(unittest.TestCase):
     def test_with_rfc_3339_creation_time(self):
         with TestImage('with_rfc_3339_creation_time') as img:
             self.assertDigest(
-                img, '8d8198c4d4b2af1ac3bf643f0a35744a35e1c19040229b23e0f2e496a28436b5')
+                img, '58a8333ae43fe3e22d91ad8cbf0e171f3b97724e2421bdd16a9b2dcdd343f7e3')
             self.assertEqual(2, len(img.fs_layers()))
             cfg = json.loads(img.config_file())
             self.assertEqual('1989-05-03T12:58:12.345Z',
@@ -327,7 +327,7 @@ class ImageTest(unittest.TestCase):
         with TestBundleImage(
                 'with_env', 'bazel/%s:with_env' % TEST_DATA_TARGET_BASE) as img:
             self.assertDigest(
-                img, '1f74dcf381e204e4347c681460e1620104b7bbf4312a08c02e189e2cb95487b1')
+                img, '584c94c1660cd04e74f0aca32f2cb8d8696ee7826cce93b0cd21d6c870825238')
             self.assertEqual(2, len(img.fs_layers()))
             self.assertConfigEqual(
                 img, 'Env', ['bar=blah blah blah', 'foo=/asdf'])
@@ -335,7 +335,7 @@ class ImageTest(unittest.TestCase):
     def test_layers_with_env(self):
         with TestImage('layers_with_env') as img:
             self.assertDigest(
-                img, 'c8b7a7bd8519006146f056c0dbd914e9d91840d4155fd6d84bb159337d1a4504')
+                img, '200f73a0fcbe4f58beb411bd3f649ed1fc847e14353f1ec832ed377c17ffd2fb')
             self.assertEqual(3, len(img.fs_layers()))
             self.assertConfigEqual(
                 img, 'Env', [u'PATH=$PATH:/tmp/a:/tmp/b:/tmp/c', u'a=b', u'x=y'])
@@ -346,14 +346,14 @@ class ImageTest(unittest.TestCase):
         name = 'gcr.io/dummy/%s:dummy_repository' % TEST_DATA_TARGET_BASE
         with TestBundleImage('dummy_repository', name) as img:
             self.assertDigest(
-                img, '9ad95debf6ef9a6077302c9752af772559f69d95f70aab16e603efc03dc0dbf6')
+                img, '501c30ee6cb53cedc90d6b050e65bb44fd3fc81d25f0e868f95fedd31f32b097')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './foo'])
 
     def test_with_double_env(self):
         with TestImage('with_double_env') as img:
             self.assertDigest(
-                img, '24de5c8d60ea4a3f67d4b953d53f918742c863d1b7edf03b1e4f97652a0ed283')
+                img, '0643112fd89f93bac6f39cd43f789aadfafae888199010af134f80de581d62ef')
             self.assertEqual(3, len(img.fs_layers()))
             self.assertConfigEqual(img, 'Env', [
                 'bar=blah blah blah',
@@ -363,7 +363,7 @@ class ImageTest(unittest.TestCase):
     def test_with_label(self):
         with TestImage('with_label') as img:
             self.assertDigest(
-                img, '43f1870b2bbf25c12b8faad4a21d73554e7550f1db289b413b70f4a83f04c0cd')
+                img, '89b3df22e6375b6a46bf7cd64729a9c593e9604492eacaf089fc3ef9ae4f5804')
             self.assertEqual(2, len(img.fs_layers()))
             self.assertConfigEqual(img, 'Labels', {
                 'com.example.bar': '{"name": "blah"}',
@@ -374,7 +374,7 @@ class ImageTest(unittest.TestCase):
     def test_with_double_label(self):
         with TestImage('with_double_label') as img:
             self.assertDigest(
-                img, 'd4b9f98bfc526b8d1454bd72fabace51611dbd7a9b6b92b038a395c9bea60e99')
+                img, '03020ef43356189c27c77fd1dfec3153f7b8bfd15b449eef171f0d5f93ffd156')
             self.assertEqual(3, len(img.fs_layers()))
             self.assertConfigEqual(img, 'Labels', {
                 'com.example.bar': '{"name": "blah"}',
@@ -386,7 +386,7 @@ class ImageTest(unittest.TestCase):
     def test_with_user(self):
         with TestImage('with_user') as img:
             self.assertDigest(
-                img, '4c5b15d95197a2b476448125e68c8a2299b09fb77c5cb700bc64135630234917')
+                img, '4e1eef44f9c6deb8e83494a8a815d7f88ed0a411499e8e166942ac3f8930ec8a')
             self.assertEqual(2, len(img.fs_layers()))
             self.assertConfigEqual(img, 'User', 'nobody')
 
@@ -397,12 +397,12 @@ class ImageTest(unittest.TestCase):
         # (so `./test/test`).
         with TestImage('no_data_path_image') as img:
             self.assertDigest(
-                img, '46f7757c372468a48200f2c99e89bca59921f2298216fb8612faad24c446ee32')
+                img, 'd6ea07a7074a7c9cb29c98a064dd900e6f90e7be0628d71c8da509dee419220c')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './test'])
         with TestImage('data_path_image') as img:
             self.assertDigest(
-                img, 'f4f697840d586638cc5f6e0bb85e8b531a28d231aa6ddee38087cc78affe54b7')
+                img, 'c1eca42703357ed58c72bc726450d55ec5d1f1220089a9e447c3ad5b5f1e8356')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './test', './test/test'])
 
@@ -413,7 +413,7 @@ class ImageTest(unittest.TestCase):
         # directory.
         with TestImage('absolute_data_path_image') as img:
             self.assertDigest(
-                img, '561fe9d52d073bf01590f08764d73da92230c908885915dee773357070a94901')
+                img, 'f2aff195a73deb3eff246f1b97a46ef8b634ca89e2b88a43cc000db745460bef')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, [
                 '.', './testdata', './testdata/test', './testdata/test/test'])
@@ -421,7 +421,7 @@ class ImageTest(unittest.TestCase):
             # root.
         with TestImage('root_data_path_image') as img:
             self.assertDigest(
-                img, '561fe9d52d073bf01590f08764d73da92230c908885915dee773357070a94901')
+                img, 'f2aff195a73deb3eff246f1b97a46ef8b634ca89e2b88a43cc000db745460bef')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, [
                 '.', './testdata', './testdata/test', './testdata/test/test'])
@@ -447,20 +447,20 @@ class ImageTest(unittest.TestCase):
             BUILD_USER=STAMP_DICT['BUILD_USER']
         )) as img:
             self.assertDigest(
-                img, '4c5b15d95197a2b476448125e68c8a2299b09fb77c5cb700bc64135630234917')
+                img, '4e1eef44f9c6deb8e83494a8a815d7f88ed0a411499e8e166942ac3f8930ec8a')
         with TestBundleImage('bundle_test', 'docker.io/ubuntu:latest') as img:
             self.assertDigest(
-                img, '732aa319e2bf017b174c182300fcd14b935df244c6539bf0aaa2ebd544b15126')
+                img, 'b8460d575a3d4558057bbdb6f05988259b4f61b1b1f3f117b941043e486914a2')
             self.assertEqual(1, len(img.fs_layers()))
         with TestBundleImage(
                 'bundle_test', 'us.gcr.io/google-appengine/base:fresh') as img:
             self.assertDigest(
-                img, '522197bc5a7d2cff9ce3821b8eb379c285af473af065860654ce9a374c407212')
+                img, '9117535b880556343e328aa20a08a8a2161173371c0e587ce4c7d3a9a4d1d12e')
             self.assertEqual(2, len(img.fs_layers()))
         with TestBundleImage(
                 'bundle_test', 'gcr.io/google-containers/pause:2.0') as img:
             self.assertDigest(
-                img, '24de5c8d60ea4a3f67d4b953d53f918742c863d1b7edf03b1e4f97652a0ed283')
+                img, '0643112fd89f93bac6f39cd43f789aadfafae888199010af134f80de581d62ef')
             self.assertEqual(3, len(img.fs_layers()))
 
     def test_with_stamped_label(self):
@@ -472,7 +472,7 @@ class ImageTest(unittest.TestCase):
     def test_pause_based(self):
         with TestImage('pause_based') as img:
             self.assertDigest(
-                img, 'ee4d1a868d5d69131af85b5106e5bf6e35243c39b0b6e59a8c7b0b1caac4c27e')
+                img, '29ce23be35b02e583cd4b5836024b6cb4e942a8e5e09671de97ae33ed4f06fb9')
             self.assertEqual(3, len(img.fs_layers()))
 
     def test_pause_piecemeal(self):
@@ -489,13 +489,13 @@ class ImageTest(unittest.TestCase):
     def test_build_with_tag(self):
         with TestBundleImage('build_with_tag', 'gcr.io/build/with:tag') as img:
             self.assertDigest(
-                img, '46014ba1cefa362387c428c36ca5afd81cae169a7c277e01ac5f12b410198007')
+                img, '388ccb8b26078eb6dc12e4204e93835fe1886033b1848a964abb71d3c4acb890')
             self.assertEqual(3, len(img.fs_layers()))
 
     def test_with_passwd(self):
         with TestImage('with_passwd') as img:
             self.assertDigest(
-                img, '803022993d158f7927176a1f490547775640c5b71aa3ce0bb8ace5706d3142f4')
+                img, '81420a14782ff8a0de928199d7e3e5bbf8684f02a977326b96d863329c97f055')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './etc', './etc/passwd'])
 
@@ -511,7 +511,7 @@ class ImageTest(unittest.TestCase):
     def test_with_passwd_tar(self):
         with TestImage('with_passwd_tar') as img:
             self.assertDigest(
-                img, '20be1ce9d44fd90a431edf37aee85b71d4bc6540d9a82880c9dd0719f4e6fccb')
+                img, 'a87a5060f2abb7dccbd61bf303f66561a170da43076afeeb4dee4444f8e4b5d3')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(
                 img, ['.', './etc', './etc/password', './root', './myhomedir'])
@@ -532,7 +532,7 @@ class ImageTest(unittest.TestCase):
     def test_with_group(self):
         with TestImage('with_group') as img:
             self.assertDigest(
-                img, 'a9ae91bd9dbd684f47b14a41c9a833b3191c49c5ccb950c20c81b08a8b3b4e18')
+                img, '3abaf45eda502f6826f3745627c707cd0ac12536915fa8ed45883fe21aaac075')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './etc', './etc/group'])
 
@@ -545,7 +545,7 @@ class ImageTest(unittest.TestCase):
     def test_with_empty_files(self):
         with TestImage('with_empty_files') as img:
             self.assertDigest(
-                img, 'aa82a3f747f2f5ecdd649d1f03c9480e9f16f17e9bdeaffcb9c490dad5d2e1fa')
+                img, '8f69b3fadd1b35804d526880f3ed4d9687dea623d5510ba67a0917cdc73e145c')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './file1', './file2'])
 
@@ -559,7 +559,7 @@ class ImageTest(unittest.TestCase):
     def test_with_empty_dirs(self):
         with TestImage('with_empty_dirs') as img:
             self.assertDigest(
-                img, '4dce65b210d6c31ad6c3efd9e703446dcb9d53cee1f7528df90467b39f24d050')
+                img, '6ac23017e088e15e05df6533787c053e766c1ff6705eab5110226127115a8a21')
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './etc', './foo', './bar'])
 


### PR DESCRIPTION
This fixes #2097 wherein `image_test` fails with Python 3.9+

For future reference this commit was generated with:

```
bazel test tests/container:image_test
grep sha256: .../testlogs/tests/container/image_test/test.log  | grep Assertion | sed -r 's@AssertionError: .sha256:(.*). != .sha256:(.*).@s/\2/\1/@' > /tmp/seds
sed -f /tmp/seds -i tests/container/image_test.py

# then repeat the above a couple times because some of the digest errors are only exposed after you fix the first ones.
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] (n/a) Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

This test fails with Python 3.9 and it looks like the best fix is to change the golden image digests to match the new reality.

Issue Number: #2097

## What is the new behavior?

Just new digests in the test to match CPython 3.9 `tarfile` behavior.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

Technically Python 3.9 creates a breaking changes in that the image digests generated by `rules_docker` aren't reproducible across the upgrade from Python <=3.8, but this PR didn't create and doesn't attempt to change that situation.

## Other information

