### PR TITLE
Load foreign layers last

### DIFF
--- a/container/go/pkg/compat/reader.go
+++ b/container/go/pkg/compat/reader.go
@@ -314,9 +314,6 @@ func (r *Reader) ReadImage() (v1.Image, error) {
 	if err := r.loadMetadata(); err != nil {
 		return nil, errors.Wrap(err, "unable to load image metadata")
 	}
-	if err := r.loadForeignLayers(); err != nil {
-		return nil, errors.Wrap(err, "unable to load foreign layers specified in the base manifest")
-	}
 	if err := r.loadImages(r.Parts.Images); err != nil {
 		return nil, errors.Wrap(err, "unable to load layers from the images in the given image parts")
 	}
@@ -325,6 +322,9 @@ func (r *Reader) ReadImage() (v1.Image, error) {
 	}
 	if err := r.loadLayers(); err != nil {
 		return nil, errors.Wrap(err, "unable to load layers from the given parts")
+	}
+	if err := r.loadForeignLayers(); err != nil {
+		return nil, errors.Wrap(err, "unable to load foreign layers specified in the base manifest")
 	}
 	layers := []v1.Layer{}
 	for _, diffID := range r.config.RootFS.DiffIDs {

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -197,6 +197,13 @@ container_image(
     operating_system = "windows",
 )
 
+container_image(
+    name = "basic_windows_image_from_tar",
+    base = ":import_windows_base_image.tar",
+    cmd = ["echo bar"],
+    operating_system = "windows",
+)
+
 container_test(
     name = "basic_windows_image_test",
     configs = ["//tests/container/configs:windows_image.yaml"],
@@ -960,6 +967,7 @@ TEST_DATA = [
     "//testdata:stamped_bundle_test",
     "//testdata:stamp_info_file.txt",
     "//tests/container:basic_windows_image.tar",
+    "//tests/container:basic_windows_image_from_tar.tar",
 ]
 
 py_test(

--- a/tests/container/image_test.py
+++ b/tests/container/image_test.py
@@ -623,6 +623,14 @@ class ImageTest(unittest.TestCase):
             self.assertIn("https://go.microsoft.com/fwlink/?linkid=873595",
                           img.manifest())
 
+    def test_windows_image_manifest_with_foreign_layers_from_tar(self):
+        imgPath = TestRunfilePath(
+            "tests", "container", "basic_windows_image_from_tar.tar")
+        with v2_2_image.FromTarball(imgPath) as img:
+            # Ensure the image manifest in the tarball includes the foreign layer.
+            self.assertIn("https://go.microsoft.com/fwlink/?linkid=873595",
+                          img.manifest())
+
     def test_py_image_with_symlinks_in_data(self):
         with TestImage('py_image_with_symlinks_in_data') as img:
             # Check the application layer, which is on top.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

As noted in #2099, if you use `container_import` to declare foreign layers, then depend on that in a `container_image` or `container_push` as a whole-image `.tar`, you lose the foreign layer URLs, resulting in an invalid image. This is because `compat/reader.go` loads the foreign image information from the image manifest first, *then* overwrites that with the empty stub layer found in the tarball. You can observe the loss of information in the resulting image's manifest.

This used to work with the Python-language image reader, but broke in the move to the Golang pusher.

Issue Number: #2099

## What is the new behavior?

We load the foreign layers last so that the stub information is overwritten.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
