### PR TITLE
Add config flag to further disable transition effects caused by bazel pre-5.0 support

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -768,6 +768,9 @@ _outputs["build_script"] = "%{name}.executable"
 
 def _image_transition_impl(settings, attr):
     if not settings["@io_bazel_rules_docker//transitions:enable"]:
+        if not settings["@io_bazel_rules_docker//transitions:support_bazel_pre5.0"]:
+            return {}
+
         # Once bazel < 5.0 is not supported we can return an empty dict here
         return {
             "//command_line_option:platforms": settings["//command_line_option:platforms"],
@@ -790,6 +793,7 @@ _image_transition = transition(
     implementation = _image_transition_impl,
     inputs = [
         "@io_bazel_rules_docker//transitions:enable",
+        "@io_bazel_rules_docker//transitions:support_bazel_pre5.0",
         "//command_line_option:platforms",
     ],
     outputs = [

--- a/transitions/BUILD
+++ b/transitions/BUILD
@@ -32,3 +32,8 @@ config_setting(
     name = "disabled",
     flag_values = {"@io_bazel_rules_docker//transitions:enable": "false"},
 )
+
+bool_flag(
+    name = "support_bazel_pre5.0",
+    build_setting_default = True,
+)


### PR DESCRIPTION
(DRAFT -- looking for feedback)


This is an attempt to address an issue that even when setting --@io_bazel_rules_docker//transitions:enable=no, we still get some config differences across targets built as a docker image dep, and targets not built as a docker image dep. This appears to be caused by this support for Bazel pre-5.0.

Looking for some initial feedback as to whether this approach seems reasonable -- if so, I can add tests and open for review.

Context: https://bazelbuild.slack.com/archives/CA3NW13MH/p1654287739299629

Even more context: we build our app twice (once for pushing to GCS, and once just to get the SHA256 digest of the app so that we know where to find it in GCS), and these path differences due to the config transition are causing the app SHA to mismatch, since we have some path references in some of the app's contents.



---

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

