### PR TITLE
Revert "Temporarily Disable some //test/container tests in Mac"

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -14,16 +14,6 @@ tasks:
   default_workspace_macos:
     platform: macos
     test_targets:
-      # We don't know why this test started failing. Disable this until
-      # I have some time to look into it:
-      - -//tests/container:alpine_custom_attr_digest_test
-      - -//tests/container:image_test
-      - -//tests/container:test_digest_output1
-      - -//tests/container:test_digest_output1_impl
-      - -//tests/container:test_digest_output2
-      - -//tests/container:test_digest_output2_impl
-      - -//tests/container:test_push_digest_output
-      - -//tests/container:test_push_digest_output_impl
       # Use "bazel query 'kind(".*_test", ...)'" to refresh this list.
       #
       # NOTE: per Philipp Wollermann, docker is not installed on the macos
@@ -127,6 +117,7 @@ tasks:
       - //container/go/pkg/oci:go_default_test
       - //docker/util:config_stripper_test
       - //docs:all
+      - //tests/container:alpine_custom_attr_digest_test
       - //tests/container:alpine_custom_attr_digest_test_impl
       - //tests/container:alpine_linux_armv6_tar_test_image_tar
       - //tests/container:alpine_linux_armv6_tar_test_image_tar_impl
@@ -137,6 +128,7 @@ tasks:
       - //tests/container:distroless_fixed_id_digest_test_impl
       - //tests/container:distroless_fixed_id_image_digest_test
       - //tests/container:distroless_fixed_id_image_digest_test_impl
+      - //tests/container:image_test
       - //tests/container:k8s_pause_arm64_digest_test
       - //tests/container:k8s_pause_arm64_digest_test_impl
       - //tests/container:pause_tar_test_0_tar_gz
@@ -148,6 +140,12 @@ tasks:
       - //tests/container:pull_info_validation_test
       - //tests/container:set_cmd_test_host
       - //tests/container:special_characters_test
+      - //tests/container:test_digest_output1
+      - //tests/container:test_digest_output1_impl
+      - //tests/container:test_digest_output2
+      - //tests/container:test_digest_output2_impl
+      - //tests/container:test_push_digest_output
+      - //tests/container:test_push_digest_output_impl
       - //tests/contrib:rename_image_test
       - //tests/contrib:test_id_compare_ids_test
       - //tests/docker/package_managers:test_download_pkgs_docker_cp


### PR DESCRIPTION
This reverts commit a351a3f22f08e58cb21290f1eaf79304387dcd39.

#2013 suggests this should be fixed now.