### PR TITLE
Add support for cred_helpers in push

### DIFF
--- a/container/push-tag.sh.tpl
+++ b/container/push-tag.sh.tpl
@@ -27,5 +27,6 @@ function guess_runfiles() {
 }
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+PATH="%{path_prefix}:$PATH"
 
 %{container_pusher} %{args} "$@"

--- a/toolchains/docker/BUILD.tpl
+++ b/toolchains/docker/BUILD.tpl
@@ -21,6 +21,7 @@ load("@io_bazel_rules_docker//toolchains/docker:toolchain.bzl", "docker_toolchai
 docker_toolchain(
     name = "toolchain",
     client_config = "%{DOCKER_CONFIG}",
+    %{CRED_HELPERS_ATTR}
     %{BUILD_TAR_ATTR}
     %{GZIP_ATTR}
     %{TOOL_ATTR}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2109

## What is the new behavior?

`container_push` now supports `cred_helpers` from the toolchain automatically.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I'm out of my depth with the layers of indirection and nuances of Bazel rules so I'd like feedback on the approach before I finish this off by adding tests/docs.

