### PR TITLE
Add java_layer rule that allows fine layering of JVM dependencies (like py_layer for Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ py_image(
 ```
 
 You can also implement more complex fine layering strategies by using the
-`py_layer` rule and its `filter` attribute.  For example:
+`py_layer` or `java_layer` rules and their `filter` attribute.  For example:
 
 ```python
 # Suppose that we are synthesizing an image that depends on a complex set

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -27,6 +27,7 @@ load(
 )
 load(
     "//lang:image.bzl",
+    "filter_layer",
     "layer_file_path",
     lang_image = "image",
 )
@@ -104,6 +105,11 @@ DEFAULT_JETTY_BASE = select({
     "@io_bazel_rules_docker//:optimized": "@jetty_image_base//image",
     "//conditions:default": "@jetty_image_base//image",
 })
+
+def java_layer(name, deps = [], runtime_deps = [], filter = "", **kwargs):
+    binary_name = name + ".layer-binary"
+    native.java_library(name = binary_name, runtime_deps = deps + runtime_deps, **kwargs)
+    filter_layer(name = name, dep = binary_name, filter = filter)
 
 def java_files(f):
     """Filter out the list of java source files from the given list of runfiles.

--- a/lang/image.bzl
+++ b/lang/image.bzl
@@ -296,8 +296,14 @@ def _filter_aspect_impl(target, ctx):
         # then take the filtered depset instead of descending further.
         return [FilterAspectInfo(depset = target[FilterLayerInfo].filtered_depset)]
 
-    # Collect transitive deps from all children (propagating along "deps" attr).
-    target_deps = depset(transitive = [dep[FilterAspectInfo].depset for dep in getattr(ctx.rule.attr, "deps", [])])
+    # Collect transitive deps from all children (propagating along "deps" and
+    # "runtime_deps" (for the JVM) attrs).
+    target_deps = depset(
+        transitive =
+            [dep[FilterAspectInfo].depset for dep in getattr(ctx.rule.attr, "deps", [])] +
+            [dep[FilterAspectInfo].depset for dep in getattr(ctx.rule.attr, "runtime_deps", [])],
+    )
+
     myself = struct(target = target, target_deps = target_deps)
     return [
         FilterAspectInfo(
@@ -307,7 +313,7 @@ def _filter_aspect_impl(target, ctx):
 
 # Aspect for collecting dependency info.
 _filter_aspect = aspect(
-    attr_aspects = ["deps"],
+    attr_aspects = ["deps", "runtime_deps"],
     implementation = _filter_aspect_impl,
 )
 
@@ -316,18 +322,28 @@ def _filter_layer_rule_impl(ctx):
 
     runfiles = ctx.runfiles()
     filtered_depsets = []
+    java_infos = []
+
     for dep in transitive_deps.to_list():
         if str(dep.target.label).startswith(ctx.attr.filter) and str(dep.target.label) != str(ctx.attr.dep.label):
             runfiles = runfiles.merge(dep.target[DefaultInfo].default_runfiles)
+
+            if JavaInfo in dep.target:
+                java_infos.append(dep.target[JavaInfo])
+
             filtered_depsets.append(dep.target_deps)
 
-    # Forward legacy builtin provider and PyInfo provider
+    # Forward legacy builtin provider and PyInfo/JavaInfo provider
+    maybe_pyinfo = [ctx.attr.dep[PyInfo]] if PyInfo in ctx.attr.dep else []
+    maybe_javainfo = \
+        [java_common.merge(java_infos)] if java_infos else []
+
     return [
         FilterLayerInfo(
             runfiles = runfiles,
             filtered_depset = depset(transitive = filtered_depsets),
         ),
-    ] + ([ctx.attr.dep[PyInfo]] if PyInfo in ctx.attr.dep else [])
+    ] + maybe_pyinfo + maybe_javainfo
 
 # A rule that allows selecting a subset of transitive dependencies, and using
 # them as a layer in an image.

--- a/tests/container/java/BUILD
+++ b/tests/container/java/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("//contrib:test.bzl", "container_test")
-load("//java:image.bzl", "java_image")
+load("//java:image.bzl", "java_image", "java_layer")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -50,6 +50,20 @@ java_image(
     ],
     layers = [":java_image_library"],
     main_class = "examples.images.Binary",
+)
+
+java_layer(
+    name = "java_image_external_deps_layer",
+    filter = "@",
+    deps = [":java_image_library"],
+)
+
+java_image(
+    name = "java_image_complex_external_deps",
+    srcs = ["//testdata:Binary.java"],
+    layers = [":java_image_external_deps_layer"],
+    main_class = "examples.images.Binary",
+    deps = [":java_image_library"],
 )
 
 java_image(
@@ -107,6 +121,12 @@ container_test(
     name = "java_image_test",
     configs = ["//tests/container/java/configs:java_image.yaml"],
     image = ":java_image",
+)
+
+container_test(
+    name = "java_image_complex_external_deps_test",
+    configs = ["//tests/container/java/configs:java_image_complex_external_deps.yaml"],
+    image = ":java_image_complex_external_deps",
 )
 
 container_test(

--- a/tests/container/java/configs/java_image_complex_external_deps.yaml
+++ b/tests/container/java/configs/java_image_complex_external_deps.yaml
@@ -1,0 +1,9 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  entrypoint: [
+        '/usr/bin/java',
+        '-cp',
+        '/app/io_bazel_rules_docker/../com_google_guava_guava/guava-18.0.jar:/app/io_bazel_rules_docker/tests/container/java/libjava_image_library.jar:/app/io_bazel_rules_docker/tests/container/java/java_image_complex_external_deps.binary.jar:/app/io_bazel_rules_docker/tests/container/java/java_image_complex_external_deps.binary',
+        'examples.images.Binary'
+  ]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
There is no rule that allows fine layering of JVM dependencies (like `py_layer`) for `java_image`s.

Issue Number: N/A


## What is the new behavior?
`JavaInfo` is forwarded by `filter_layer` and there is a rule `java_layer` which functions identically to `py_layer` that allows filtering dependencies.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
I wasn't sure that building the merged JavaInfo was the best way to do this, but I think any other way requires some more intrusive changes to `java_image` - I tried with an empty JavaInfo and forwarding the JavaInfo (as the code does with PyInfo) and they result in an empty layer and a layer with all dependencies (not filtering them at all) respectively.
