### PR TITLE
Update README to account for new tar build output

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ client. Building this target can be expensive for large images. You will
 first need to query the ouput file location.
 
 ```bash
-TARBALL_LOCATION=$(bazel cquery my/image:helloworld \
+TARBALL_LOCATION=$(bazel cquery my/image:helloworld.tar \
     --output starlark \
     --starlark:expr="target.files.to_list()[0].path")
 docker load -i $TARBALL_LOCATION


### PR DESCRIPTION
The tar output location has been changed and is no longer stable. The old docs were not updated at the time of the change and the result is confusing build breakages. Unless the original behavior is added back (comments elsewhere indicate this will not happen) the README should document the new behavior.

See Issue #2014 for info on why this change is needed (the issue was closed as WAI). See [GoogleContainerTools PR#7251](https://github.com/GoogleContainerTools/skaffold/pull/7251) for this fix.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Incorrect and misleading documentation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

