### PR TITLE
Update `nodejs_image` repository settings to match current latest version of `rules_nodejs`

### DIFF
--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -120,8 +120,7 @@ def nodejs_image(
         binary = None,
         launcher = None,
         launcher_args = None,
-        node_repository_name = "nodejs",
-        include_node_repo_args = True,
+        node_repository_name = "nodejs_linux_amd64",
         **kwargs):
     """Constructs a container image wrapping a nodejs_binary target.
 
@@ -151,9 +150,6 @@ def nodejs_image(
         "@%s//:node" % node_repository_name,
         "@%s//:node_files" % node_repository_name,
     ]
-
-    if include_node_repo_args:
-        nodejs_layers.append("@%s//:bin/node_repo_args.sh" % node_repository_name)
 
     all_layers = nodejs_layers + layers
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2078 

## What is the new behavior?

See issue for more details.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

Removes the `include_node_repo_args` argument, which will break rules that use it. But this is probably only used for rules that disable it, so it'll be good for those rules to remove it when they update.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Remove the `include_node_repo_args = False` flag, which most repos include to fix this bug, and is no longer needed now that the bug is actually fixed.

## Other information

