### PR TITLE
README.md: rename `client.json` -> `config.json` in one place.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,7 +1167,7 @@ docker_toolchain_configure(
   # in the client configuration JSON file.
   # See https://docs.docker.com/engine/reference/commandline/cli/#configuration-files
   # for more details.
-  client_config="@//path/to/docker:client.json",
+  client_config="@//path/to/docker:config.json",
 )
 ```
 In `BUILD` file:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I was unlucky to miss all the other references to `config.json` when I was
setting up, so I named my file `client.json`, looking instead only at the label
changed by this commit.

When I later ran a `container_push` target it failed with "permission denied"
issues. I read the shell script generated by `container_push` and saw that it
passes an argument to give the path to the _directory_ of the config file,
rather than the path to the file itself.

That made me realize that I had probably given the file the wrong name; the
Docker client didn't find a `config.json` file in that directory and ignored all
other files.