### PR TITLE
Forward architecture from language rules to layers

### DIFF
--- a/go/image.bzl
+++ b/go/image.bzl
@@ -89,7 +89,7 @@ STATIC_DEFAULT_BASE = select({
     "//conditions:default": "@go_image_static//image",
 })
 
-def go_image(name, base = None, deps = [], layers = [], env = {}, binary = None, **kwargs):
+def go_image(name, base = None, deps = [], layers = [], env = {}, binary = None, architecture = "x86_64", **kwargs):
     """Constructs a container image wrapping a go_binary target.
 
   Args:
@@ -99,6 +99,7 @@ def go_image(name, base = None, deps = [], layers = [], env = {}, binary = None,
     layers: Augments "deps" with dependencies that should be put into their own layers.
     env: Environment variables for the go_image.
     binary: An alternative binary target to use instead of generating one.
+    architecture: The target architecture, defaults to `x86_64`.
     **kwargs: See go_binary.
   """
     if layers:
@@ -115,8 +116,8 @@ def go_image(name, base = None, deps = [], layers = [], env = {}, binary = None,
 
     tags = kwargs.get("tags", None)
     for index, dep in enumerate(layers):
-        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep, tags = tags)
-        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary, tags = tags)
+        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep, tags = tags, architecture = architecture)
+        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary, tags = tags, architecture = architecture)
 
     visibility = kwargs.get("visibility", None)
     restricted_to = kwargs.get("restricted_to", None)
@@ -133,4 +134,5 @@ def go_image(name, base = None, deps = [], layers = [], env = {}, binary = None,
         testonly = kwargs.get("testonly"),
         restricted_to = restricted_to,
         compatible_with = compatible_with,
+        architecture = architecture,
     )

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -89,7 +89,7 @@ STATIC_DEFAULT_BASE = select({
     "//conditions:default": "@go_image_static//image",
 })
 
-def go_image(name, base = None, deps = [], layers = [], env = {}, binary = None, architecture = "x86_64", **kwargs):
+def go_image(name, base = None, deps = [], layers = [], env = {}, binary = None, architecture = None, **kwargs):
     """Constructs a container image wrapping a go_binary target.
 
   Args:
@@ -99,7 +99,7 @@ def go_image(name, base = None, deps = [], layers = [], env = {}, binary = None,
     layers: Augments "deps" with dependencies that should be put into their own layers.
     env: Environment variables for the go_image.
     binary: An alternative binary target to use instead of generating one.
-    architecture: The target architecture, defaults to `x86_64`.
+    architecture: The target architecture.
     **kwargs: See go_binary.
   """
     if layers:

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -275,6 +275,7 @@ def java_image(
         env = {},
         jvm_flags = [],
         classpath_as_file = None,
+        architecture = "x86_64",
         **kwargs):
     """Builds a container image overlaying the java_binary.
 
@@ -295,6 +296,7 @@ def java_image(
                 construction of the container entrypoint. Omitting main_class
                 allows the user to specify additional arguments to the JVM at
                 runtime.
+    architecture: The architecture of the target, defaults to `x86_64`.
     **kwargs: See java_binary.
   """
     binary_name = name + ".binary"
@@ -320,7 +322,7 @@ def java_image(
     base = base or DEFAULT_JAVA_BASE
     for index, dep in enumerate(layers):
         this_name = "%s.%d" % (name, index)
-        jar_dep_layer(name = this_name, base = base, dep = dep, tags = tags)
+        jar_dep_layer(name = this_name, base = base, dep = dep, tags = tags, architecture = architecture)
         base = this_name
 
     visibility = kwargs.get("visibility", None)
@@ -340,6 +342,7 @@ def java_image(
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
         classpath_as_file = classpath_as_file,
+        architecture = architecture,
     )
 
 def _war_dep_layer_impl(ctx):

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -275,7 +275,7 @@ def java_image(
         env = {},
         jvm_flags = [],
         classpath_as_file = None,
-        architecture = "x86_64",
+        architecture = None,
         **kwargs):
     """Builds a container image overlaying the java_binary.
 
@@ -296,7 +296,7 @@ def java_image(
                 construction of the container entrypoint. Omitting main_class
                 allows the user to specify additional arguments to the JVM at
                 runtime.
-    architecture: The architecture of the target, defaults to `x86_64`.
+    architecture: The architecture of the target.
     **kwargs: See java_binary.
   """
     binary_name = name + ".binary"

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -73,7 +73,7 @@ DEFAULT_BASE = select({
     "//conditions:default": "@py3_image_base//image",
 })
 
-def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
+def py3_image(name, base = None, deps = [], layers = [], env = {}, architecture = "x86_64", **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
   Args:
@@ -83,6 +83,7 @@ def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     env: Environment variables for the py_image.
+    architecture: The target architecture, defaults to `x86_64`.
     **kwargs: See py_binary.
   """
     binary_name = name + ".binary"
@@ -106,13 +107,14 @@ def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     base = base or DEFAULT_BASE
     tags = kwargs.get("tags", None)
     for index, dep in enumerate(layers):
-        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep, tags = tags)
-        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary_name, tags = tags)
+        base = app_layer(name = "%s.%d" % (name, index), base = base, dep = dep, tags = tags, architecture = architecture)
+        base = app_layer(name = "%s.%d-symlinks" % (name, index), base = base, dep = dep, binary = binary_name, tags = tags, architecture = architecture)
 
     visibility = kwargs.get("visibility", None)
     app_layer(
         name = name,
         base = base,
+        architecture = architecture,
         entrypoint = ["/usr/bin/python"],
         env = env,
         binary = binary_name,

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -73,7 +73,7 @@ DEFAULT_BASE = select({
     "//conditions:default": "@py3_image_base//image",
 })
 
-def py3_image(name, base = None, deps = [], layers = [], env = {}, architecture = "x86_64", **kwargs):
+def py3_image(name, base = None, deps = [], layers = [], env = {}, architecture = None, **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
   Args:
@@ -83,7 +83,7 @@ def py3_image(name, base = None, deps = [], layers = [], env = {}, architecture 
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     env: Environment variables for the py_image.
-    architecture: The target architecture, defaults to `x86_64`.
+    architecture: The target architecture.
     **kwargs: See py_binary.
   """
     binary_name = name + ".binary"


### PR DESCRIPTION
Ideally, this would be able to be inferred from the base image but I don't think it is possible to propagate that information into the build transition. Explicitly setting the architecture seems like the simplest way to trigger the build transition and support non-x86_64 target platforms.

Opening for feedback first.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## What is the current behavior?

Non-x86 target platforms aren't supported.

## What is the new behavior?

Non-x86 target platforms are supported.

## Does this PR introduce a breaking change?

- [x] No


## Other information

---

#### Commits _(oldest to newest)_

8d69206 Forward architecture for py3_image


<br/>

a9ee0fc Forward architecture for go_image


<br/>

466a8de Forward architecture for java_image


<br/>

130dea5 squash! don't set a default architecture

Respond to feedback from PR review.

<br/>