### PR TITLE
Update distroless images with running update_deps.sh

### DIFF
--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/cc:debug" circa 2021-12-01 22:45 +0200
-    "debug": "sha256:fbf229f6c5fcf038de4a7fa8139119c92785e24e68f9f26ef0906ad6d37bc62c",
-    # "gcr.io/distroless/cc:latest" circa 2021-12-01 22:45 +0200
-    "latest": "sha256:ceab2b378860e134f3b470f153fbd1117b81438ae51ab97e2568149e9883cd32",
+    # "gcr.io/distroless/cc:debug" circa 2022-11-08 11:59 +0900
+    "debug": "sha256:6865ad48467c89c3c3524d4c426f52ad12d9ab7dec31fad31fae69da40eb6445",
+    # "gcr.io/distroless/cc:latest" circa 2022-11-08 11:59 +0900
+    "latest": "sha256:41036fc7ed8df0f6addc18484cef0c94a85867508967789f947e11ffd5ff0cc8",
 }

--- a/go/go.bzl
+++ b/go/go.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/base:debug" circa 2021-12-01 22:44 +0200
-    "debug": "sha256:4e644c5d3a7341cf7ca568fe33356734601ad90d6be01a07090cf48c4f329371",
-    # "gcr.io/distroless/base:latest" circa 2021-12-01 22:44 +0200
-    "latest": "sha256:0530d193888bcd7bd0376c8b34178ea03ddb0b2b18caf265135b6d3a393c8d05",
+    # "gcr.io/distroless/base:debug" circa 2022-11-08 11:58 +0900
+    "debug": "sha256:65668d2b78d25df3d8ccf5a778d017fcaba513b52078c700083eaeef212b9979",
+    # "gcr.io/distroless/base:latest" circa 2022-11-08 11:58 +0900
+    "latest": "sha256:b9b124f955961599e72630654107a0cf04e08e6fa777fa250b8f840728abd770",
 }

--- a/go/static.bzl
+++ b/go/static.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/static:debug" circa 2021-12-01 22:44 +0200
-    "debug": "sha256:6450ee51087a953dd2c771d2dcdeb89fa570bfb9f2e9a70efd0494c49e79f319",
-    # "gcr.io/distroless/static:latest" circa 2021-12-01 22:44 +0200
-    "latest": "sha256:fac888659ca3eb59f7d5dcb0d62540cc5c53615e2671062b36c815d000da8ef4",
+    # "gcr.io/distroless/static:debug" circa 2022-11-08 11:59 +0900
+    "debug": "sha256:56655dceb80c142846d72bf164b02a15c2e8a4d7537900fde710a408eb66fad2",
+    # "gcr.io/distroless/static:latest" circa 2022-11-08 11:59 +0900
+    "latest": "sha256:ebd8cc37d22551dce0957ba8e58f03b22a8448bbf844c8c9ded4feef883b36bc",
 }

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java:debug" circa 2021-12-01 22:45 +0200
-    "debug": "sha256:eeb8d72edc294dbc99165147d281ce98ca305b1262aacdb8515f1118e9be73d5",
-    # "gcr.io/distroless/java:latest" circa 2021-12-01 22:45 +0200
-    "latest": "sha256:1d377403a44d32779be00fceec4803be0301c7f4a62b72d7307dc411860c24c3",
+    # "gcr.io/distroless/java:debug" circa 2022-11-08 11:59 +0900
+    "debug": "sha256:80f87dcce03ba2591d777471818ab77f6fb580faa86628d2f885f7700af7941b",
+    # "gcr.io/distroless/java:latest" circa 2022-11-08 11:59 +0900
+    "latest": "sha256:629d4fdc17eec821242d45497abcb88cc0442c47fd5748baa79d88dde7da3e2d",
 }

--- a/java/jetty.bzl
+++ b/java/jetty.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/java/jetty:debug" circa 2021-12-01 22:45 +0200
-    "debug": "sha256:dd69072db325f955cd55d0adad84e80b9e94f738adc2e2158c1244c3a2c4b2bc",
-    # "gcr.io/distroless/java/jetty:latest" circa 2021-12-01 22:45 +0200
-    "latest": "sha256:3f2d63f336d2adc95547b9a6cb462388130c0ee089a32caaea19df58e05a0f6a",
+    # "gcr.io/distroless/java/jetty:debug" circa 2022-11-08 11:59 +0900
+    "debug": "sha256:c9ac5a5bf6f3187095277b8141517d3c3c5bd307e9f72ef40713d9f622d348f3",
+    # "gcr.io/distroless/java/jetty:latest" circa 2022-11-08 11:59 +0900
+    "latest": "sha256:8eb486e24d352ae46ef2a069a7e4bdb43800728c53463d097061540d2166667e",
 }

--- a/nodejs/nodejs.bzl
+++ b/nodejs/nodejs.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/google-appengine/debian9:debug" circa 2021-12-01 22:45 +0200
-    "debug": "sha256:8e4639cb270046abd646f7cc7c16363b778149513a2f27b86494e135b2760dbf",
-    # "gcr.io/google-appengine/debian9:latest" circa 2021-12-01 22:45 +0200
-    "latest": "sha256:8e4639cb270046abd646f7cc7c16363b778149513a2f27b86494e135b2760dbf",
+    # "gcr.io/google-appengine/debian9:debug" circa 2022-11-08 11:59 +0900
+    "debug": "sha256:0b18331f4d42ffd2ee8e5fbb9dbdd31dad39e7bef062414888ae971e9c13436b",
+    # "gcr.io/google-appengine/debian9:latest" circa 2022-11-08 11:59 +0900
+    "latest": "sha256:0b18331f4d42ffd2ee8e5fbb9dbdd31dad39e7bef062414888ae971e9c13436b",
 }

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python2.7:debug" circa 2021-12-01 22:45 +0200
+    # "gcr.io/distroless/python2.7:debug" circa 2022-11-08 11:59 +0900
     "debug": "sha256:85f45e3b5ab66da2eb04c10d29519deb21bf14bcfa8fa6769817db4f031ad3c9",
-    # "gcr.io/distroless/python2.7:latest" circa 2021-12-01 22:45 +0200
+    # "gcr.io/distroless/python2.7:latest" circa 2022-11-08 11:59 +0900
     "latest": "sha256:83b8dc7881f3e3c85740bfffd32b7ce64527757e74c68d6a31102a7d1b2a977b",
 }

--- a/python3/python3.bzl
+++ b/python3/python3.bzl
@@ -19,8 +19,8 @@
 # git repository.
 
 DIGESTS = {
-    # "gcr.io/distroless/python3:debug" circa 2021-12-01 22:45 +0200
-    "debug": "sha256:c6374d0612e77d912c17690eecc6fbca1b9402814cd5bc61adad23824b87388c",
-    # "gcr.io/distroless/python3:latest" circa 2021-12-01 22:45 +0200
-    "latest": "sha256:70feef894a89e769eb0b5e3b0c04d7006d4eb7753fc6b797ce4b86d7deafcf13",
+    # "gcr.io/distroless/python3:debug" circa 2022-11-08 11:59 +0900
+    "debug": "sha256:84b5e6a7e091754b31b34e65307c2f60a4ab1c1ceb583db55da9bbe1f272498a",
+    # "gcr.io/distroless/python3:latest" circa 2022-11-08 11:59 +0900
+    "latest": "sha256:2bcee59e0ecbadf01e1b5df29ad27598c7775b822b7f2bfae4a271e2ee139ed4",
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Update distroless images


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

It's been 10 months since the images were updated last time. 
As described in [README.md](https://github.com/bazelbuild/rules_docker#updating-the-distroless-base-images), it's better to update the distroless base images over time to pick up bug fixes and security patches :smile:

<details><summary>update_deps.sh command log</summary>

```sh
➜  rules_docker git:(update-distroless-deps) ✗ ./update_deps.sh
2022/09/30 10:05:55 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
2022/09/30 10:05:55 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
INFO: Analyzed target //container/go/cmd/update_deps:update_deps (4 packages loaded, 80 targets configured).
INFO: Found 1 target...
Target //container/go/cmd/update_deps:update_deps up-to-date:
  bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps
INFO: Elapsed time: 2.378s, Critical Path: 0.04s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps '--repository=gcr.io/distroless/base' '--output=/Users/dragon3/src/gitINFO: Build completed successfully, 1 total action
2022/09/30 10:06:02 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
2022/09/30 10:06:02 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
INFO: Analyzed target //container/go/cmd/update_deps:update_deps (4 packages loaded, 80 targets configured).
INFO: Found 1 target...
Target //container/go/cmd/update_deps:update_deps up-to-date:
  bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps
INFO: Elapsed time: 1.919s, Critical Path: 0.04s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps '--repository=gcr.io/distroless/static' '--output=/Users/dragon3/src/gINFO: Build completed successfully, 1 total action
2022/09/30 10:06:08 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
2022/09/30 10:06:08 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
INFO: Analyzed target //container/go/cmd/update_deps:update_deps (4 packages loaded, 80 targets configured).
INFO: Found 1 target...
Target //container/go/cmd/update_deps:update_deps up-to-date:
  bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps
INFO: Elapsed time: 1.218s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps '--repository=gcr.io/distroless/cc' '--output=/Users/dragon3/src/githuINFO: Build completed successfully, 1 total action
2022/09/30 10:06:14 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
2022/09/30 10:06:14 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
INFO: Analyzed target //container/go/cmd/update_deps:update_deps (4 packages loaded, 80 targets configured).
INFO: Found 1 target...
Target //container/go/cmd/update_deps:update_deps up-to-date:
  bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps
INFO: Elapsed time: 1.320s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps '--repository=gcr.io/distroless/python2.7' '--output=/Users/dragon3/srINFO: Build completed successfully, 1 total action
2022/09/30 10:06:19 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
2022/09/30 10:06:19 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
INFO: Analyzed target //container/go/cmd/update_deps:update_deps (4 packages loaded, 80 targets configured).
INFO: Found 1 target...
Target //container/go/cmd/update_deps:update_deps up-to-date:
  bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps
INFO: Elapsed time: 1.785s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps '--repository=gcr.io/distroless/python3' '--output=/Users/dragon3/src/INFO: Build completed successfully, 1 total action
2022/09/30 10:06:25 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
2022/09/30 10:06:25 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
INFO: Analyzed target //container/go/cmd/update_deps:update_deps (4 packages loaded, 80 targets configured).
INFO: Found 1 target...
Target //container/go/cmd/update_deps:update_deps up-to-date:
  bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps
INFO: Elapsed time: 1.378s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps '--repository=gcr.io/distroless/java' '--output=/Users/dragon3/src/gitINFO: Build completed successfully, 1 total action
2022/09/30 10:06:29 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
2022/09/30 10:06:29 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
INFO: Analyzed target //container/go/cmd/update_deps:update_deps (4 packages loaded, 80 targets configured).
INFO: Found 1 target...
Target //container/go/cmd/update_deps:update_deps up-to-date:
  bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps
INFO: Found 1 target...
Target //container/go/cmd/update_deps:update_deps up-to-date:
  bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps
INFO: Elapsed time: 1.329s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps '--repository=gcr.io/distroless/java/jetty' '--output=/Users/dragon3/sINFO: Build completed successfully, 1 total action
2022/09/30 10:06:34 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
2022/09/30 10:06:34 WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0
INFO: Analyzed target //container/go/cmd/update_deps:update_deps (4 packages loaded, 80 targets configured).
INFO: Found 1 target...
Target //container/go/cmd/update_deps:update_deps up-to-date:
  bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps
INFO: Elapsed time: 1.304s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/container/go/cmd/update_deps/update_deps_/update_deps '--repository=gcr.io/google-appengine/debian9' '--output=/Users/dragonINFO: Build completed successfully, 1 total action
```

</details>