### PR TITLE
Build darwin arm64 to ci workflow

### DIFF
--- a/.github/workflows/add_binaries_to_release.yml
+++ b/.github/workflows/add_binaries_to_release.yml
@@ -22,8 +22,6 @@ jobs:
         executable_mime: ["application/x-executable", "application/x-mach-binary"]
         exclude:
           - os: darwin
-            cpu: arm64
-          - os: darwin
             cpu: s390x
           - os: darwin
             executable_mime: "application/x-executable"


### PR DESCRIPTION
Would like to get apple silicon working natively.
This change would move https://github.com/bazelbuild/rules_docker/pull/2033 along

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Darwin arm64 binaries (puller/loader) are not prebuilt artifacts

Issue Number: Pull #2033


## What is the new behavior?

Darwin arm64 binaries (puller/loader) are prebuilt artifacts

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

