### PR TITLE
De-duplicate run args passed to bazel image targets.

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -249,6 +249,16 @@ function read_variables() {
 # This is not executed if the single argument --norun is passed or
 # no run_statements are generated (in which case, 'run' is 'False').
 if [[ "%{run}" == "True" ]]; then
+  # When 'bazel run' is called, it expects that the args specified in the BUILD
+  # file are not known to the run command and will prepend them to all other
+  # arguments.
+  #
+  # However, we have already baked those commands into the image, because users
+  # expect that 'args' in the case of an image target will be included in the
+  # image.  This templated script de-duplicates the args specified in the BUILD
+  # file by passing itself the number of args already included in the image.
+  shift "%{run_num_args}"
+
   docker_args=()
   container_args=()
 

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -290,6 +290,7 @@ def incremental_load(
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
             "%{docker_tool_path}": docker_path(toolchain_info),
             "%{load_statements}": "\n".join(load_statements),
+            "%{run_num_args}": str(len(ctx.attr.args)),
             "%{run_statement}": run_statement,
             "%{run_tag}": run_tag,
             "%{run}": str(run),


### PR DESCRIPTION
When 'bazel run' is called, it expects that the args specified in the BUILD file are not known to the run command and will prepend them to all other arguments.

However, we have already baked those commands into the image, because users expect that 'args' in the case of an image target will be included in the image.  This templated script de-duplicates the args specified in the BUILD file by passing itself the number of args already included in the image.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/bazelbuild/rules_docker/issues/2124

In the case of an image target being passed arguments, the arguments will actually be passed to the image
target by bazel twice, once at build time and another at runtime.  This interferes with the expected order of
arguments (because command arguments are inserted before docker run arguments)

## What is the new behavior?

The new behavior should match the documentation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

