### PR TITLE
Build darwin arm64 on buildkit workflow.

### DIFF
--- a/container/go/cloudbuild.yaml
+++ b/container/go/cloudbuild.yaml
@@ -157,3 +157,35 @@ steps:
       - "gs://rules_docker/$COMMIT_SHA/loader-darwin-amd64"
     id: "push-loader-darwin-amd64"
     waitFor: ["build-darwin-amd64"]
+
+# Step: build the puller and loader release binaries for Darwin ARM64
+  - name: "l.gcr.io/google/bazel"
+    args:
+      - "build"
+      - "--platforms=@io_bazel_rules_go//go/toolchain:darwin_arm64"
+      - "//container/go/cmd/puller:puller"
+      - "//container/go/cmd/loader:loader"
+    id: "build-darwin-arm64"
+    waitFor: ["push-loader-darwin-amd64"]
+
+# Step: push the puller release binary for Darwin ARM64
+  - name: "gcr.io/cloud-builders/gsutil"
+    args:
+      - "cp"
+      - "-a"
+      - "public-read"
+      - "bazel-bin/container/go/cmd/puller/puller_/puller"
+      - "gs://rules_docker/$COMMIT_SHA/puller-darwin-arm64"
+    id: "push-puller-darwin-arm64"
+    waitFor: ["build-darwin-arm64"]
+
+# Step: push the loader release binary for Darwin ARM64
+  - name: "gcr.io/cloud-builders/gsutil"
+    args:
+      - "cp"
+      - "-a"
+      - "public-read"
+      - "bazel-bin/container/go/cmd/loader/loader_/loader"
+      - "gs://rules_docker/$COMMIT_SHA/loader-darwin-arm64"
+    id: "push-loader-darwin-arm64"
+    waitFor: ["build-darwin-arm64"]

--- a/container/go/cloudbuild.yaml
+++ b/container/go/cloudbuild.yaml
@@ -166,7 +166,7 @@ steps:
       - "//container/go/cmd/puller:puller"
       - "//container/go/cmd/loader:loader"
     id: "build-darwin-arm64"
-    waitFor: ["push-loader-darwin-amd64"]
+    waitFor: ["push-puller-darwin-amd64", "push-loader-darwin-amd64"]
 
 # Step: push the puller release binary for Darwin ARM64
   - name: "gcr.io/cloud-builders/gsutil"


### PR DESCRIPTION
def5c9644be8eddb2637c8619198152d3c2f0c33 added to a github action workflow that does not appear to be actually used...

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Darwin arm64 binaries are not built or published to cloud storage.

Prereq to https://github.com/bazelbuild/rules_docker/pull/2191 and https://github.com/bazelbuild/rules_docker/pull/2033 before that


## What is the new behavior?
Darwin arm64 binaries are built and published to cloud storage.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

