### PR TITLE
image.bzl: implement `tag_name`

### DIFF
--- a/docs/container.md
+++ b/docs/container.md
@@ -404,7 +404,7 @@ image.implementation(<a href="#image.implementation-ctx">ctx</a>, <a href="#imag
                      <a href="#image.implementation-compression_options">compression_options</a>, <a href="#image.implementation-experimental_tarball_format">experimental_tarball_format</a>, <a href="#image.implementation-debs">debs</a>, <a href="#image.implementation-tars">tars</a>, <a href="#image.implementation-architecture">architecture</a>,
                      <a href="#image.implementation-operating_system">operating_system</a>, <a href="#image.implementation-os_version">os_version</a>, <a href="#image.implementation-output_executable">output_executable</a>, <a href="#image.implementation-output_tarball">output_tarball</a>, <a href="#image.implementation-output_config">output_config</a>,
                      <a href="#image.implementation-output_config_digest">output_config_digest</a>, <a href="#image.implementation-output_digest">output_digest</a>, <a href="#image.implementation-output_layer">output_layer</a>, <a href="#image.implementation-workdir">workdir</a>, <a href="#image.implementation-user">user</a>, <a href="#image.implementation-null_cmd">null_cmd</a>,
-                     <a href="#image.implementation-null_entrypoint">null_entrypoint</a>)
+                     <a href="#image.implementation-null_entrypoint">null_entrypoint</a>, <a href="#image.implementation-tag_name">tag_name</a>)
 </pre>
 
 Implementation for the container_image rule.
@@ -469,5 +469,6 @@ You can write a customized container_image rule by writing something like:
 | <a id="image.implementation-user"></a>user |  str, overrides ctx.attr.user   |  <code>None</code> |
 | <a id="image.implementation-null_cmd"></a>null_cmd |  bool, overrides ctx.attr.null_cmd   |  <code>None</code> |
 | <a id="image.implementation-null_entrypoint"></a>null_entrypoint |  bool, overrides ctx.attr.null_entrypoint   |  <code>None</code> |
+| <a id="image.implementation-tag_name"></a>tag_name |  str, overrides ctx.attr.tag_name   |  <code>None</code> |
 
 

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -98,6 +98,12 @@ container_image(
 )
 
 container_image(
+    name = "tag_name",
+    files = ["foo"],
+    tag_name = "this-tag-instead",
+)
+
+container_image(
     name = "no_data_path_image",
     files = ["//testdata/test:test-data"],
     mode = "0o644",

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -935,6 +935,7 @@ TEST_TARGETS = [
     ":absolute_data_path_image",
     ":root_data_path_image",
     ":dummy_repository",
+    ":tag_name",
     # TODO(mattmoor): Re-enable once archive is visible
     # "extras_with_deb",
     ":bundle_test",

--- a/tests/container/image_test.py
+++ b/tests/container/image_test.py
@@ -301,6 +301,13 @@ class ImageTest(unittest.TestCase):
             self.assertEqual(1, len(img.fs_layers()))
             self.assertTopLayerContains(img, ['.', './foo'])
 
+    def test_tag_name(self):
+        # users may override the tag that comes after ':'
+        name = 'bazel/%s:this-tag-instead' % TEST_DATA_TARGET_BASE
+        with TestBundleImage('tag_name', name) as img:
+            self.assertEqual(1, len(img.fs_layers()))
+            self.assertTopLayerContains(img, ['.', './foo'])
+
     def test_with_double_env(self):
         with TestImage('with_double_env') as img:
             self.assertEqual(3, len(img.fs_layers()))


### PR DESCRIPTION
rules_docker decides the name of the resulting docker image:

    bazel/{target}:{name}

The repository (`bazel/` by default) and `{target}` are fine. However, we want to customize the tag part -- the thing after the colon. This patch allows customizing the last part.

Why?
====

In our case, we are always building two images for two architectures using transitions. Here is an extract of a macro that builds two containers:

Then we build two containers using outgoing transitions:

    container_image(
        name = "{name}-post_transition".format(name = name),
        ...,
    )

    multiplatform_image(
        name = "{name}-amd64".format(name),
        src_image = ":{name}-post_transition".format(name = name),
        ...,
    )

    multiplatform_image(
        name = "{name}-arm64".format(name = name),
        src_image = ":{name}-post_transition".format(name = name),
        ...,
    )

Both images (`-amd64` and `-arm64`) build correctly, but the resulting image name, according to Docker, happens to be
`bazel/{target}:{name}-post_transition`. So the internal implementation details of the transitions leak to the resulting images.

This patch makes it possible to rename the post-transition image name to something we like more, e.g. the architecture name, or remove the suffix altogether.