### PR TITLE
run.bzl: allow passing extra_deps to all the container_run rules

### DIFF
--- a/tests/docker/util/BUILD
+++ b/tests/docker/util/BUILD
@@ -37,10 +37,15 @@ container_run_and_extract(
     commands = [
         "touch /foo.txt",
         "echo 'test' > /foo.txt",
+        "test -f /foo",
     ],
     docker_run_flags = [
         "-u",
         "root",
+        "-v ${PWD}/$(location //testdata:foo):/foo",
+    ],
+    extra_deps = [
+        "//testdata:foo",
     ],
     extract_file = "/foo.txt",
     image = "@debian_base//image",
@@ -69,10 +74,17 @@ file_test(
 
 container_run_and_commit(
     name = "test_container_commit",
-    commands = ["touch /foo.txt"],
+    commands = [
+        "touch /foo.txt",
+        "test -f /foo",
+    ],
     docker_run_flags = [
         "-u",
         "root",
+        "-v ${PWD}/$(location //testdata:foo):/foo",
+    ],
+    extra_deps = [
+        "//testdata:foo",
     ],
     image = "@debian_base//image",
 )
@@ -99,10 +111,17 @@ container_test(
 
 container_run_and_commit_layer(
     name = "test_container_commit_layer",
-    commands = ["touch /foo.txt"],
+    commands = [
+        "touch /foo.txt",
+        "test -f /foo",
+    ],
     docker_run_flags = [
         "-u",
         "root",
+        "-v ${PWD}/$(location //testdata:foo):/foo",
+    ],
+    extra_deps = [
+        "//testdata:foo",
     ],
     image = "@debian_base//image",
 )


### PR DESCRIPTION
It's very convenient to be able to mount generated files into the build context so those can be consumed without impacting the size of the resulting image (for instance to execute commands on some intermediate artifacts)

Example:

```
container_run_and_commit_layer(
    name = "foo",
    image = "some-image",
    docker_run_flags = [
        # when mounting from the runfiles we may have a directory with symlinks, so we need to mount
        # the actual file
        "-v ${PWD}/$(location :bar/bar.tar):/data/bar.tar"
    ],
    extra_deps = [
        ":bar"
    ],
    commands = [
        "ls /data/bar.tar",
    ],
)
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Only `container_run_and_extract` allows to pass `extra_deps` which allows for instance to mount a directory into the container that's being built

Issue Number: 2156


## What is the new behavior?
Now `container_run_and_commit` and `container_run_and_commit_layer` also allows for this behaviour

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

