### PR TITLE
Ensure baseManifest is cleared in compat Reader.loadMetadata()

### DIFF
--- a/container/go/pkg/compat/reader.go
+++ b/container/go/pkg/compat/reader.go
@@ -149,7 +149,9 @@ func (r *Reader) loadMetadata() error {
 	r.config = c
 	if r.Parts.BaseManifest == "" {
 		// Base manifest is optional. It's only needed for images whose base
-		// manifests have foreign layers.
+		// manifests have foreign layers. The baseManifest must be cleared
+		// to allow reader reuse
+		r.baseManifest = nil
 		return nil
 	}
 	mf, err := os.Open(r.Parts.BaseManifest)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

If a Reader is reused, [as it is in `join_layers`](https://github.com/bazelbuild/rules_docker/blob/aada19062b15d7115b8684acf457735d1bd9f692/container/go/cmd/join_layers/join_layers.go#L92-L105), the execution of `loadForeignLayers` may incorrectly fail for a tag with no base manifest due to the reader previously being used on a tag with a base manifest. This failure is caused by attempting to use a base manifest for the previous tag with the config for the current tag. Whether this would fail would depend on the order in which the tags were loaded and the number of layers in each, since `loadForeignLayers` only checked that the config has at least as many layers as the base manifest.

This would show up when using `container_bundle`, which would spuriously fail when executing `join_layers` depending on the order of tags and presence of tags with and without base manifests.

The error observed is as below. This error referenced an image that has no base manifest, so no foreign layers should ever attempt to be loaded:

```
Failed to generate output at bazel-out/k8-opt/bin/<snip>: unable to load image <snip> corresponding to <snip>/config.json: unable to load foreign layers specified in the base manifest: unexpected number of layers in config 5 vs manifest 18, want config to have equal or greater number of layers
```

## What is the new behavior?

The baseManifest is now cleared on each Reader reuse during parsing of metadata, if there is no base manifest available.

This fix has been tested against a CI run that exhibited the error consistently and passes with this change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

