### PR TITLE
Allow setting architecture/operating_system in language-specific image macros

### DIFF
--- a/cc/image.bzl
+++ b/cc/image.bzl
@@ -63,7 +63,16 @@ DEFAULT_BASE = select({
     "//conditions:default": "@cc_image_base//image",
 })
 
-def cc_image(name, base = None, deps = [], layers = [], env = {}, binary = None, **kwargs):
+def cc_image(
+        name,
+        base = None,
+        deps = [],
+        layers = [],
+        env = {},
+        binary = None,
+        architecture = None,
+        operating_system = None,
+        **kwargs):
     """Constructs a container image wrapping a cc_binary target.
 
   Args:
@@ -74,6 +83,8 @@ def cc_image(name, base = None, deps = [], layers = [], env = {}, binary = None,
            their own layers.
     env: Environment variables for the cc_image.
     binary: An alternative binary target to use instead of generating one.
+    architecture: The desired CPU architecture to be used as label in the container image.
+    operating_system: operating system to target (e.g. linux, windows)
     **kwargs: See cc_binary.
   """
     if layers:
@@ -102,4 +113,6 @@ def cc_image(name, base = None, deps = [], layers = [], env = {}, binary = None,
         args = kwargs.get("args"),
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
+        architecture = architecture,
+        operating_system = operating_system,
     )

--- a/d/image.bzl
+++ b/d/image.bzl
@@ -32,7 +32,16 @@ def repositories():
     """
     _repositories()
 
-def d_image(name, base = None, deps = [], layers = [], env = {}, binary = None, **kwargs):
+def d_image(
+        name,
+        base = None,
+        deps = [],
+        layers = [],
+        env = {},
+        binary = None,
+        architecture = None,
+        operating_system = None,
+        **kwargs):
     """Constructs a container image wrapping a d_binary target.
 
   Args:
@@ -43,6 +52,8 @@ def d_image(name, base = None, deps = [], layers = [], env = {}, binary = None, 
            their own layers.
     env: Environment variables for the d_image.
     binary: An alternative binary target to use instead of generating one.
+    architecture: The desired CPU architecture to be used as label in the container image.
+    operating_system: operating system to target (e.g. linux, windows)
     **kwargs: See d_binary.
   """
     if layers:
@@ -71,4 +82,6 @@ def d_image(name, base = None, deps = [], layers = [], env = {}, binary = None, 
         args = kwargs.get("args"),
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
+        architecture = architecture,
+        operating_system = operating_system,
     )

--- a/go/image.bzl
+++ b/go/image.bzl
@@ -89,7 +89,17 @@ STATIC_DEFAULT_BASE = select({
     "//conditions:default": "@go_image_static//image",
 })
 
-def go_image(name, base = None, tag_name = None, deps = [], layers = [], env = {}, binary = None, **kwargs):
+def go_image(
+        name,
+        base = None,
+        tag_name = None,
+        deps = [],
+        layers = [],
+        env = {},
+        binary = None,
+        architecture = None,
+        operating_system = None,
+        **kwargs):
     """Constructs a container image wrapping a go_binary target.
 
   Args:
@@ -99,6 +109,8 @@ def go_image(name, base = None, tag_name = None, deps = [], layers = [], env = {
     layers: Augments "deps" with dependencies that should be put into their own layers.
     env: Environment variables for the go_image.
     binary: An alternative binary target to use instead of generating one.
+    architecture: The desired CPU architecture to be used as label in the container image.
+    operating_system: operating system to target (e.g. linux, windows)
     **kwargs: See go_binary.
   """
     if layers:
@@ -134,4 +146,6 @@ def go_image(name, base = None, tag_name = None, deps = [], layers = [], env = {
         testonly = kwargs.get("testonly"),
         restricted_to = restricted_to,
         compatible_with = compatible_with,
+        architecture = architecture,
+        operating_system = operating_system,
     )

--- a/groovy/image.bzl
+++ b/groovy/image.bzl
@@ -35,6 +35,8 @@ def groovy_image(
         env = {},
         jvm_flags = [],
         classpath_as_file = None,
+        architecture = None,
+        operating_system = None,
         **kwargs):
     """Builds a container image overlaying the groovy_binary.
 
@@ -49,6 +51,8 @@ def groovy_image(
            their own layers.
     env: Environment variables for the groovy_image.
     jvm_flags: The flags to pass to the JVM when running the groovy image.
+    architecture: The desired CPU architecture to be used as label in the container image.
+    operating_system: operating system to target (e.g. linux, windows)
     **kwargs: See groovy_binary.
   """
     binary_name = name + ".binary"
@@ -98,6 +102,8 @@ def groovy_image(
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
         classpath_as_file = classpath_as_file,
+        architecture = architecture,
+        operating_system = operating_system,
     )
 
 def repositories():

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -275,6 +275,8 @@ def java_image(
         env = {},
         jvm_flags = [],
         classpath_as_file = None,
+        architecture = None,
+        operating_system = None,
         **kwargs):
     """Builds a container image overlaying the java_binary.
 
@@ -295,6 +297,8 @@ def java_image(
                 construction of the container entrypoint. Omitting main_class
                 allows the user to specify additional arguments to the JVM at
                 runtime.
+    architecture: The desired CPU architecture to be used as label in the container image.
+    operating_system: operating system to target (e.g. linux, windows)
     **kwargs: See java_binary.
   """
     binary_name = name + ".binary"
@@ -340,6 +344,8 @@ def java_image(
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
         classpath_as_file = classpath_as_file,
+        architecture = architecture,
+        operating_system = operating_system,
     )
 
 def _war_dep_layer_impl(ctx):

--- a/kotlin/image.bzl
+++ b/kotlin/image.bzl
@@ -36,6 +36,8 @@ def kt_jvm_image(
         env = {},
         jvm_flags = [],
         classpath_as_file = None,
+        architecture = None,
+        operating_system = None,
         **kwargs):
     """Builds a container image overlaying the kt_jvm_binary.
 
@@ -50,6 +52,8 @@ def kt_jvm_image(
         their own layers.
     env: Environment variables for the kt_jvm_image.
     jvm_flags: The flags to pass to the JVM when running the kotlin image.
+    architecture: The desired CPU architecture to be used as label in the container image.
+    operating_system: operating system to target (e.g. linux, windows)
     **kwargs: See kt_jvm_binary.
   """
     binary_name = name + ".binary"
@@ -97,6 +101,8 @@ def kt_jvm_image(
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
         classpath_as_file = classpath_as_file,
+        architecture = architecture,
+        operating_system = operating_system,
     )
 
 def repositories():

--- a/nodejs/image.bzl
+++ b/nodejs/image.bzl
@@ -122,6 +122,8 @@ def nodejs_image(
         launcher_args = None,
         node_repository_name = "nodejs",
         include_node_repo_args = True,
+        architecture = None,
+        operating_system = None,
         **kwargs):
     """Constructs a container image wrapping a nodejs_binary target.
 
@@ -135,6 +137,8 @@ def nodejs_image(
     binary: An alternative binary target to use instead of generating one.
     launcher: The container_image launcher to set.
     launcher_args: The args for the container_image launcher.
+    architecture: The desired CPU architecture to be used as label in the container image.
+    operating_system: operating system to target (e.g. linux, windows)
     **kwargs: See nodejs_binary.
   """
 
@@ -183,4 +187,6 @@ def nodejs_image(
         testonly = kwargs.get("testonly"),
         launcher = launcher,
         launcher_args = launcher_args,
+        architecture = architecture,
+        operating_system = operating_system,
     )

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -78,7 +78,15 @@ def py_layer(name, deps, filter = "", **kwargs):
     native.py_library(name = binary_name, deps = deps, **kwargs)
     filter_layer(name = name, dep = binary_name, filter = filter)
 
-def py_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
+def py_image(
+        name,
+        base = None,
+        deps = [],
+        layers = [],
+        env = {},
+        architecture = None,
+        operating_system = None,
+        **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
   Args:
@@ -88,6 +96,8 @@ def py_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     layers: Augments "deps" with dependencies that should be put into
         their own layers.
     env: Environment variables for the py_image.
+    architecture: The desired CPU architecture to be used as label in the container image.
+    operating_system: operating system to target (e.g. linux, windows)
     **kwargs: See py_binary.
   """
     binary_name = name + ".binary"
@@ -130,4 +140,6 @@ def py_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
         # workspace directory to ensure the symlinks are valid. See
         # https://github.com/bazelbuild/rules_docker/issues/161 for details.
         create_empty_workspace_dir = True,
+        architecture = architecture,
+        operating_system = operating_system,
     )

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -73,7 +73,15 @@ DEFAULT_BASE = select({
     "//conditions:default": "@py3_image_base//image",
 })
 
-def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
+def py3_image(
+        name,
+        base = None,
+        deps = [],
+        layers = [],
+        env = {},
+        architecture = None,
+        operating_system = None,
+        **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
   Args:
@@ -83,6 +91,8 @@ def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     layers: Augments "deps" with dependencies that should be put into
            their own layers.
     env: Environment variables for the py_image.
+    architecture: The desired CPU architecture to be used as label in the container image.
+    operating_system: operating system to target (e.g. linux, windows)
     **kwargs: See py_binary.
   """
     binary_name = name + ".binary"
@@ -126,4 +136,6 @@ def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
         # workspace directory to ensure the symlinks are valid. See
         # https://github.com/bazelbuild/rules_docker/issues/161 for details.
         create_empty_workspace_dir = True,
+        architecture = architecture,
+        operating_system = operating_system,
     )

--- a/rust/image.bzl
+++ b/rust/image.bzl
@@ -32,7 +32,16 @@ def repositories():
     """
     _repositories()
 
-def rust_image(name, base = None, deps = [], layers = [], env = {}, binary = None, **kwargs):
+def rust_image(
+        name,
+        base = None,
+        deps = [],
+        layers = [],
+        env = {},
+        binary = None,
+        architecture = None,
+        operating_system = None,
+        **kwargs):
     """Constructs a container image wrapping a rust_binary target.
 
   Args:
@@ -42,6 +51,8 @@ def rust_image(name, base = None, deps = [], layers = [], env = {}, binary = Non
     layers: Augments "deps" with dependencies that should be put into their own layers.
     env: Environment variables for the rust_image.
     binary: An alternative binary target to use instead of generating one.
+    architecture: The desired CPU architecture to be used as label in the container image.
+    operating_system: operating system to target (e.g. linux, windows)
     **kwargs: See rust_binary.
   """
     if layers:
@@ -71,4 +82,6 @@ def rust_image(name, base = None, deps = [], layers = [], env = {}, binary = Non
         args = kwargs.get("args"),
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
+        architecture = architecture,
+        operating_system = operating_system,
     )

--- a/scala/image.bzl
+++ b/scala/image.bzl
@@ -35,6 +35,8 @@ def scala_image(
         env = {},
         jvm_flags = [],
         classpath_as_file = None,
+        architecture = None,
+        operating_system = None,
         **kwargs):
     """Builds a container image overlaying the scala_binary.
 
@@ -49,6 +51,8 @@ def scala_image(
            their own layers.
     env: Environment variables for the scala_image.
     jvm_flags: Flags to pass to the JVM when running the scala image.
+    architecture: The desired CPU architecture to be used as label in the container image.
+    operating_system: operating system to target (e.g. linux, windows)
     **kwargs: See scala_binary.
   """
     binary_name = name + ".binary"
@@ -90,6 +94,8 @@ def scala_image(
         data = kwargs.get("data"),
         testonly = kwargs.get("testonly"),
         classpath_as_file = classpath_as_file,
+        architecture = architecture,
+        operating_system = operating_system,
     )
 
 def repositories():


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Users can't use the language-specific macros to build images with non-default architecture/operating_system


## What is the new behavior?

Users are able to select architecture/operating_system in the language-specific macros. The defaults are not changed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

I did briefly try to add tests for this in [a961a36](https://github.com/bazelbuild/rules_docker/commit/a961a3660bf002eb4c9debbaa86ee7ccac94425d), but the straightforward approach does not work: we need to use a non-amd64 arch to test the new behavior(because amd64 is the default), but it doesn't seem like non-amd64 platforms have the required toolchains configured on CI. Would be happy to take advice on the best way to introduce an automated test for this.

I have manually tested java_image and go_image with `architecture = "arm64"` and verified that they're working as expcected:
* The resulting image shows `"Architecture": "aarch64"` in `docker image inspect`
* The contents of the image are built with an ARM 64 configuration