### PR TITLE
Allow labels to be overriden by custom container_image rules

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -380,7 +380,7 @@ def _impl(
     build_script = ctx.outputs.build_script
     null_cmd = null_cmd or ctx.attr.null_cmd
     null_entrypoint = null_entrypoint or ctx.attr.null_entrypoint
-    tag_name = tag_name or ctx.attr.tag_namei
+    tag_name = tag_name or ctx.attr.tag_name
     labels = labels or ctx.attr.labels
     label_files = label_files or ctx.files.label_files
     label_file_strings = label_file_strings or ctx.attr.label_file_strings

--- a/docs/container.md
+++ b/docs/container.md
@@ -404,7 +404,7 @@ image.implementation(<a href="#image.implementation-ctx">ctx</a>, <a href="#imag
                      <a href="#image.implementation-compression_options">compression_options</a>, <a href="#image.implementation-experimental_tarball_format">experimental_tarball_format</a>, <a href="#image.implementation-debs">debs</a>, <a href="#image.implementation-tars">tars</a>, <a href="#image.implementation-architecture">architecture</a>,
                      <a href="#image.implementation-operating_system">operating_system</a>, <a href="#image.implementation-os_version">os_version</a>, <a href="#image.implementation-output_executable">output_executable</a>, <a href="#image.implementation-output_tarball">output_tarball</a>, <a href="#image.implementation-output_config">output_config</a>,
                      <a href="#image.implementation-output_config_digest">output_config_digest</a>, <a href="#image.implementation-output_digest">output_digest</a>, <a href="#image.implementation-output_layer">output_layer</a>, <a href="#image.implementation-workdir">workdir</a>, <a href="#image.implementation-user">user</a>, <a href="#image.implementation-null_cmd">null_cmd</a>,
-                     <a href="#image.implementation-null_entrypoint">null_entrypoint</a>, <a href="#image.implementation-tag_name">tag_name</a>)
+                     <a href="#image.implementation-null_entrypoint">null_entrypoint</a>, <a href="#image.implementation-tag_name">tag_name</a>, <a href="#image.implementation-labels">labels</a>, <a href="#image.implementation-label_files">label_files</a>, <a href="#image.implementation-label_file_strings">label_file_strings</a>)
 </pre>
 
 Implementation for the container_image rule.
@@ -470,5 +470,8 @@ You can write a customized container_image rule by writing something like:
 | <a id="image.implementation-null_cmd"></a>null_cmd |  bool, overrides ctx.attr.null_cmd   |  <code>None</code> |
 | <a id="image.implementation-null_entrypoint"></a>null_entrypoint |  bool, overrides ctx.attr.null_entrypoint   |  <code>None</code> |
 | <a id="image.implementation-tag_name"></a>tag_name |  str, overrides ctx.attr.tag_name   |  <code>None</code> |
+| <a id="image.implementation-labels"></a>labels |  str Dict, overrides ctx.attr.labels   |  <code>None</code> |
+| <a id="image.implementation-label_files"></a>label_files |  File list, overrides ctx.attr.label_files   |  <code>None</code> |
+| <a id="image.implementation-label_file_strings"></a>label_file_strings |  str list, overrides ctx.attr.label_file_strings   |  <code>None</code> |
 
 


### PR DESCRIPTION
Follows the pattern used for other attributes of the
container_image macro to expose overriding via the method
recommended for custom rules using the _impl() method and
image attrs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently labels cannot be overriden by custom container image rules.


## What is the new behavior?

Labels can be overriden by custom container image rules.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

