### PR TITLE
Remove aspect docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 | :------: |
 [![Build status](https://badge.buildkite.com/693d7892250cfd44beea3cd95573388200935906a28cd3146d.svg?branch=master)](https://buildkite.com/bazel/docker-rules-docker-postsubmit)
 
-Generated API documentation is in the docs folder, or you can browse it online at
-<https://docs.aspect.dev/rules_docker>
-
 ## Basic Rules
 
 * [container_image](/docs/container.md#container_image) ([example](#container_image))


### PR DESCRIPTION
We only plan to document rules_oci.

In case anyone still wants to see what we hosted before, it's here:
https://docs-legacy.aspect.build/rules_docker