### PR TITLE
Improve xz support in TarFileWriter

### DIFF
--- a/container/archive.py
+++ b/container/archive.py
@@ -107,7 +107,8 @@ class TarFileWriter(object):
                compression='',
                root_directory='./',
                default_mtime=None,
-               preserve_tar_mtimes=True):
+               preserve_tar_mtimes=True,
+               xz_path='xz'):
     """TarFileWriter wraps tarfile.open().
     Args:
       name: the tar file name.
@@ -125,6 +126,7 @@ class TarFileWriter(object):
     self.gz = compression in ['tgz', 'gz']
     # Support xz compression through xz... until we can use Py3
     self.xz = compression in ['xz', 'lzma']
+    self.xz_path = xz_path
     self.name = name
     self.root_directory = root_directory.rstrip('/')
     self.preserve_mtime = preserve_tar_mtimes
@@ -356,10 +358,10 @@ class TarFileWriter(object):
       # large files.
       # TODO(dmarting): once our py3 support gets better, compile this tools
       # with py3 for proper lzma support.
-      if subprocess.call('which xzcat', shell=True, stdout=subprocess.PIPE):
+      if subprocess.call('which {0}'.format(self.xz_path), shell=True, stdout=subprocess.PIPE):
         raise self.Error('Cannot handle .xz and .lzma compression: '
-                         'xzcat not found.')
-      p = subprocess.Popen('cat %s | xzcat' % tar,
+                         'xz not found.')
+      p = subprocess.Popen('{0} --decompress --stdout {1}'.format(self.xz_path, tar),
                            shell=True,
                            stdout=subprocess.PIPE)
       f = io.BytesIO(p.stdout.read())
@@ -439,10 +441,10 @@ class TarFileWriter(object):
       self.fileobj.close()
     if self.xz:
       # Support xz compression through xz... until we can use Py3
-      if subprocess.call('which xz', shell=True, stdout=subprocess.PIPE):
+      if subprocess.call('which {0}'.format(self.xz_path), shell=True, stdout=subprocess.PIPE):
         raise self.Error('Cannot handle .xz and .lzma compression: '
                          'xz not found.')
       subprocess.call(
-          'mv {0} {0}.d && xz -z {0}.d && mv {0}.d.xz {0}'.format(self.name),
+          'mv {0} {0}.d && {1} -z {0}.d && mv {0}.d.xz {0}'.format(self.name, self.xz_path),
           shell=True,
           stdout=subprocess.PIPE)

--- a/container/archive.py
+++ b/container/archive.py
@@ -108,7 +108,7 @@ class TarFileWriter(object):
                root_directory='./',
                default_mtime=None,
                preserve_tar_mtimes=True,
-               xz_path='xz'):
+               xz_path=None):
     """TarFileWriter wraps tarfile.open().
     Args:
       name: the tar file name.
@@ -358,11 +358,10 @@ class TarFileWriter(object):
       # large files.
       # TODO(dmarting): once our py3 support gets better, compile this tools
       # with py3 for proper lzma support.
-      if subprocess.call('which {0}'.format(self.xz_path), shell=True, stdout=subprocess.PIPE):
+      if not self.xz_path:
         raise self.Error('Cannot handle .xz and .lzma compression: '
                          'xz not found.')
-      p = subprocess.Popen('{0} --decompress --stdout {1}'.format(self.xz_path, tar),
-                           shell=True,
+      p = subprocess.Popen([self.xz_path, '--decompress', '--stdout', tar],
                            stdout=subprocess.PIPE)
       f = io.BytesIO(p.stdout.read())
       p.wait()
@@ -441,7 +440,7 @@ class TarFileWriter(object):
       self.fileobj.close()
     if self.xz:
       # Support xz compression through xz... until we can use Py3
-      if subprocess.call('which {0}'.format(self.xz_path), shell=True, stdout=subprocess.PIPE):
+      if not self.xz_path:
         raise self.Error('Cannot handle .xz and .lzma compression: '
                          'xz not found.')
       subprocess.call(

--- a/container/archive.py
+++ b/container/archive.py
@@ -17,6 +17,7 @@
 import gzip
 import io
 import os
+import shutil
 import subprocess
 import tarfile
 import posixpath
@@ -447,11 +448,11 @@ class TarFileWriter(object):
     if self.fileobj:
       self.fileobj.close()
     if self.xz:
-      # Support xz compression through xz... until we can use Py3
+      # Support xz compression through xz...
       if not self.xz_path:
         raise self.Error('Cannot handle .xz and .lzma compression: '
                          'xz not found.')
-      subprocess.call(
-          'mv {0} {0}.d && {1} -z {0}.d && mv {0}.d.xz {0}'.format(self.name, self.xz_path),
-          shell=True,
-          stdout=subprocess.PIPE)
+      shutil.move(self.name, self.name+'.d')
+      subprocess.call([self.xz_path, '--compress', self.name+'.d'],
+                      stdout=subprocess.PIPE)
+      shutil.move(self.name+'.d.xz', self.name)

--- a/container/build_tar.py
+++ b/container/build_tar.py
@@ -68,6 +68,7 @@ class TarFile(object):
         self.root_directory,
         self.default_mtime,
         self.enable_mtime_preservation,
+        self.xz_path,
     )
     return self
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I'm using nix with home-manager, and my binaries doesn't live in a "conventional" folder.
It seems that the actual tooling succeeds to find xz_path but fails detect `xzcat` or when trying to directly use `xz` in a subprocess.
With xzcat in a non conventional folder but in PATH, the `archive.py` fails with `xzcat not found`.


## What is the new behavior?

Since the path of `xz` is properly found in `build_tar.py`, provide the path for `xz` to `archive.py` and replace usage of `xz` and `xzcat` with the provided path.

Also added support for lzma in `archive.py` in a similar fashion than `build_tar.py`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I was wondering if this should be replaced with proper settings given to tarfile or directly using lzma python library.
I feel that it is not well supported in python2, but do we still support python2 ?