### PR TITLE
Add timeout for attr for `dockerfile_image`.

### DIFF
--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -78,7 +78,7 @@ def _impl(repository_ctx):
     if repository_ctx.attr.target:
         command.extend(["--target", repository_ctx.attr.target])
 
-    build_result = repository_ctx.execute(command)
+    build_result = repository_ctx.execute(command, timeout = repository_ctx.attr.timeout)
     if build_result.return_code:
         fail("docker build command failed: {} ({})".format(
             build_result.stderr,
@@ -125,6 +125,10 @@ dockerfile_image = repository_rule(
         ),
         "target": attr.string(
             doc = "Specify which intermediate stage to finish at, passed to `--target`.",
+        ),
+        "timeout": attr.int(
+            doc = "Timeout for the build action (in seconds, default 600 seconds)",
+            default = 600,
         ),
     },
     implementation = _impl,


### PR DESCRIPTION
Some build take longer than 10 minutes since this doesn't use the docker cache so larger images can be slow. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [x] Documentation content changes
- [x] Other... Please describe:


## What is the current behavior?

Currently the `dockerfile_image` will timeout after 10 minutes. Since there isn't a cache larger images builds can take longer than that especially on slow networks. 

Issue Number: N/A

## What is the new behavior?

This adds the option to set a higher timeout for the action. 

## Does this PR introduce a breaking change?
dockerfile_build
- No
