### PR TITLE
Fix label override provided by custom container_image rules

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -187,8 +187,8 @@ def _image_config(
     )
 
     labels_fixed = dict()
-    for label in ctx.attr.labels:
-        fname = ctx.attr.labels[label]
+    for label in labels:
+        fname = labels[label]
         if fname[0] == "@":
             labels_fixed[label] = "@" + label_file_dict[fname[1:]].path
         else:


### PR DESCRIPTION
_image_config was retrieving labels from ctx instead of the
labels arg.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

