### PR TITLE
Expand location templates in container_run_and_extract rule.

### DIFF
--- a/docker/util/run.bzl
+++ b/docker/util/run.bzl
@@ -76,13 +76,14 @@ def _extract_impl(
     toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
 
     # Generate a shell script to execute the run statement
+    docker_run_flags = ctx.expand_location(" ".join(docker_run_flags), ctx.attr.extra_deps)
     ctx.actions.expand_template(
         template = ctx.file._extract_tpl,
         output = script,
         substitutions = {
             "%{commands}": _process_commands(commands),
             "%{docker_flags}": " ".join(toolchain_info.docker_flags),
-            "%{docker_run_flags}": " ".join(docker_run_flags),
+            "%{docker_run_flags}": docker_run_flags,
             "%{docker_tool_path}": docker_path(toolchain_info),
             "%{extract_file}": extract_file,
             "%{image_id_extractor_path}": ctx.executable._extract_image_id.path,


### PR DESCRIPTION
The `container_run_and_extract` rule accepts list of labels as the input arguments passed to the action running the container. We could elevate this information by applying `expand_templates` to `docker_run_flags` and pass generated files (i.e. environmental variables) as the input to the shell script that executes the action.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Location templates in `docker_run_flags` are passed to `docker run` commands as literal strings.

Issue Number: N/A

## What is the new behavior?

Expand location templates before expanding shell script templates, so the paths to generated files are passed correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

