### PR TITLE
chore: add maintenance status to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 | :------: |
 [![Build status](https://badge.buildkite.com/693d7892250cfd44beea3cd95573388200935906a28cd3146d.svg?branch=master)](https://buildkite.com/bazel/docker-rules-docker-postsubmit)
 
+## Status
+
+🚨 rules_docker is in minimal maintenance mode.
+
+- The maintainers have very little time, and are unlikely to review PRs or respond to issues.
+- Releases will be infrequent or may not happen at all.
+- The maintainers are determining if the project has a long-term future, and hope to post a roadmap soon.
+
+You may find more details in
+[the discussion](https://github.com/bazelbuild/rules_docker/discussions/2038).
+
 ## Basic Rules
 
 * [container_image](/docs/container.md#container_image) ([example](#container_image))


### PR DESCRIPTION
14 out of 25 issues on the first page of https://github.com/bazelbuild/rules_docker/issues have no replies.

Issues like #2213 show that releases are stalled right now.

https://github.com/bazelbuild/rules_docker/pulse/monthly shows four commits touching four files in the last month, one of those was me removing an external docs link.

I discussed this with the maintainers on the discussion thread, and we agreed to put up a message for now to better set user expectations. I also alerted the Bazel team to this change in the SIG meeting on March 7, see https://docs.google.com/document/d/1YGCYAGLzTfqSOgRFVsB8hDz-kEoTgTEKKp9Jd07TJ5c/edit#

To be clear: I greatly appreciate the effort that the current two maintainers have made, this is not a vote-of-no-confidence in their engineering abilities or desire to make this repo great. It's just acknowledging the current state of the resources (time and funding) available for this project at the present time.
