### PR TITLE
Fix the docker_target parameter for toolchains

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -197,3 +197,12 @@ tasks:
       - //...
     test_flags:
       - --test_output=errors
+  testing_custom_toolchain_target:
+    platform: ubuntu2004
+    working_directory: testing/custom_toolchain_target
+    shell_commands:
+      - cp ../../.bazelrc .
+    test_targets:
+      - //...
+    test_flags:
+      - --test_output=errors

--- a/.bazelignore
+++ b/.bazelignore
@@ -4,3 +4,4 @@ testing/examples
 testing/java_image
 testing/download_pkgs_at_root
 testing/custom_toolchain_flags
+testing/custom_toolchain_target

--- a/.bazelrc
+++ b/.bazelrc
@@ -57,7 +57,9 @@ test:remote --remote_timeout=3600
 test:remote --keep_going
 
 # Configuration specific to buildkite CI testing the default workspace
-test:buildkite --action_env=PATH 
-test:buildkite --define=ENV_KEY=my_key # for tests/container:set_env_make_vars_test 
-test:buildkite --define=ENV_VALUE=my_value # for tests/container:set_env_make_vars_test 
+test:buildkite --action_env=PATH
 test:buildkite --test_output=errors
+
+# A test verifies that these values can be expanded as make vars
+test --define=ENV_KEY=my_key # for tests/container:set_env_make_vars_test
+test --define=ENV_VALUE=my_value # for tests/container:set_env_make_vars_test

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -550,8 +550,12 @@ def _impl(
         command = "cp %s %s" % (config_digest.path, output_config_digest.path),
     )
 
+    toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
+    runfiles_files = [config_file, config_digest, output_config_digest]
+    if toolchain_info.tool_target:
+        runfiles_files.append(toolchain_info.tool_target.files_to_run.executable)
     runfiles = ctx.runfiles(
-        files = unzipped_layers + diff_ids + [config_file, config_digest, output_config_digest] +
+        files = unzipped_layers + diff_ids + runfiles_files +
                 ([container_parts["legacy"]] if container_parts["legacy"] else []),
     )
 

--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -31,9 +31,8 @@ function guess_runfiles() {
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
-DOCKER="%{docker_tool_path}"
+DOCKER="$(readlink -nf %{docker_tool_path})"
 DOCKER_FLAGS="%{docker_flags}"
-
 if [[ -z "${DOCKER}" ]]; then
     echo >&2 "error: docker not found; do you need to manually configure the docker toolchain?"
     exit 1

--- a/docker/package_managers/download_pkgs.bzl
+++ b/docker/package_managers/download_pkgs.bzl
@@ -118,12 +118,14 @@ def _impl(ctx, image_tar = None, packages = None, additional_repos = None, outpu
         },
         is_executable = True,
     )
-
+    tools = [ctx.executable._extract_image_id]
+    if toolchain_info.tool_target:
+        tools.append(toolchain_info.tool_target.files_to_run.executable)
     ctx.actions.run(
         outputs = [output_tar, output_metadata],
         executable = output_script,
         inputs = [image_tar],
-        tools = [ctx.executable._extract_image_id],
+        tools = tools,
         use_default_shell_env = True,
     )
 

--- a/docker/package_managers/install_pkgs.bzl
+++ b/docker/package_managers/install_pkgs.bzl
@@ -126,7 +126,9 @@ def _impl(ctx, image_tar = None, installables_tar = None, installation_cleanup_c
         },
         is_executable = True,
     )
-
+    tools = [ctx.executable._extract_image_id, ctx.executable._to_json_tool]
+    if toolchain_info.tool_target:
+        tools.append(toolchain_info.tool_target.files_to_run.executable)
     ctx.actions.run(
         outputs = [unstripped_tar],
         inputs = [
@@ -136,7 +138,7 @@ def _impl(ctx, image_tar = None, installables_tar = None, installation_cleanup_c
             image_util,
         ],
         mnemonic = "ExtractImageId",
-        tools = [ctx.executable._extract_image_id, ctx.executable._to_json_tool],
+        tools = tools,
         executable = script,
         use_default_shell_env = True,
     )

--- a/docker/package_managers/run_download.sh.tpl
+++ b/docker/package_managers/run_download.sh.tpl
@@ -15,7 +15,7 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 # Resolve the docker tool path
-DOCKER="%{docker_tool_path}"
+DOCKER="$(readlink -nf %{docker_tool_path})"
 DOCKER_FLAGS="%{docker_flags}"
 
 if [[ -z "$DOCKER" ]]; then

--- a/docker/package_managers/run_install.sh.tpl
+++ b/docker/package_managers/run_install.sh.tpl
@@ -2,7 +2,7 @@
 set -o errexit
 
 # Resolve the docker tool path
-DOCKER="%{docker_tool_path}"
+DOCKER="$(readlink -nf %{docker_tool_path})"
 DOCKER_FLAGS="%{docker_flags}"
 
 if [[ -z "$DOCKER" ]]; then

--- a/docker/util/commit.sh.tpl
+++ b/docker/util/commit.sh.tpl
@@ -7,7 +7,7 @@ TO_JSON_TOOL="%{to_json_tool}"
 source %{util_script}
 
 # Resolve the docker tool path
-DOCKER="%{docker_tool_path}"
+DOCKER="$(readlink -nf %{docker_tool_path})"
 DOCKER_FLAGS="%{docker_flags}"
 
 if [[ -z "$DOCKER" ]]; then

--- a/docker/util/commit_layer.sh.tpl
+++ b/docker/util/commit_layer.sh.tpl
@@ -6,7 +6,7 @@ set -o errexit
 source %{util_script}
 
 # Resolve the docker tool path
-DOCKER="%{docker_tool_path}"
+DOCKER="$(readlink -nf %{docker_tool_path})"
 DOCKER_FLAGS="%{docker_flags}"
 
 if [[ -z "$DOCKER" ]]; then

--- a/docker/util/extract.sh.tpl
+++ b/docker/util/extract.sh.tpl
@@ -3,7 +3,7 @@
 set -o errexit
 
 # Resolve the docker tool path
-DOCKER="%{docker_tool_path}"
+DOCKER="$(readlink -nf %{docker_tool_path})"
 DOCKER_FLAGS="%{docker_flags}"
 
 if [[ -z "$DOCKER" ]]; then

--- a/docker/util/image_util.sh.tpl
+++ b/docker/util/image_util.sh.tpl
@@ -6,7 +6,7 @@ reset_cmd() {
     local output_image_name=$3
 
     # Resolve the docker tool path
-    DOCKER="%{docker_tool_path}"
+    DOCKER="$(readlink -nf %{docker_tool_path})"
     DOCKER_FLAGS="%{docker_flags}"
     local old_cmd
     # docker inspect input cannot be piped into docker commit directly, we need to JSON format it.

--- a/docker/util/run.bzl
+++ b/docker/util/run.bzl
@@ -91,11 +91,13 @@ def _extract_impl(
         },
         is_executable = True,
     )
-
+    tools = [image, ctx.executable._extract_image_id]
+    if toolchain_info.tool_target:
+        tools.append(toolchain_info.tool_target.files_to_run.executable)
     ctx.actions.run(
         inputs = extra_deps if extra_deps else [],
         outputs = [output_file],
-        tools = [image, ctx.executable._extract_image_id],
+        tools = tools,
         executable = script,
         use_default_shell_env = True,
         mnemonic = "RunAndExtract",
@@ -229,12 +231,15 @@ def _commit_impl(
     )
 
     runfiles = [image, image_utils]
+    tools = [ctx.executable._extract_image_id, ctx.executable._to_json_tool]
+    if toolchain_info.tool_target:
+        tools.append(toolchain_info.tool_target.files_to_run.executable)
 
     ctx.actions.run(
         outputs = [output_image_tar],
         inputs = runfiles,
         executable = script,
-        tools = [ctx.executable._extract_image_id, ctx.executable._to_json_tool],
+        tools = tools,
         use_default_shell_env = True,
         mnemonic = "RunAndCommit",
     )

--- a/testing/custom_toolchain_target/BUILD
+++ b/testing/custom_toolchain_target/BUILD
@@ -1,0 +1,137 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@bazel_tools//tools/build_rules:test_rules.bzl",
+    "file_test",
+    "rule_test",
+)
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
+load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
+load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit", "container_run_and_extract")
+
+package(default_visibility = ["//visibility:public"])
+
+download_pkgs(
+    name = "test_download_pkgs",
+    image_tar = "@debian_base//image",
+    packages = [
+        "curl",
+        "netbase",
+    ],
+)
+
+install_pkgs(
+    name = "test_install_pkgs",
+    image_tar = "@debian_base//image",
+    installables_tar = ":test_download_pkgs.tar",
+    installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
+    output_image_name = "test_install_pkgs",
+)
+
+container_image(
+    name = "test_container_image",
+    base = ":test_install_pkgs.tar",
+)
+
+container_run_and_extract(
+    name = "test_container_run_and_extract",
+    commands = [
+        "touch /foo",
+    ],
+    extract_file = "/foo",
+    image = "@debian_base//image",
+)
+
+container_run_and_commit(
+    name = "test_container_run_and_commit",
+    commands = [
+        "touch /foo",
+    ],
+    image = "@debian_base//image",
+)
+
+rule_test(
+    name = "test_download_pkgs_rule",
+    generates = [
+        "test_download_pkgs",
+    ],
+    rule = "test_download_pkgs",
+)
+
+file_test(
+    name = "test_custom_target_download_pkgs",
+    file = ":test_download_pkgs.sh",
+    regexp = "DOCKER=\".(readlink -nf external/docker_binary/docker)\"",
+)
+
+rule_test(
+    name = "test_install_pkgs_rule",
+    generates = [
+        "test_install_pkgs.build",
+        "test_install_pkgs.tar",
+    ],
+    rule = "test_install_pkgs",
+)
+
+file_test(
+    name = "test_custom_target_install_pkgs",
+    file = ":test_install_pkgs.build",
+    regexp = "DOCKER=\".(readlink -nf external/docker_binary/docker)\"",
+)
+
+rule_test(
+    name = "test_container_image_rule",
+    generates = [
+        "test_container_image-layer.tar",
+    ],
+    rule = "test_container_image",
+)
+
+file_test(
+    name = "test_custom_target_container_image",
+    file = ":test_container_image.executable",
+    regexp = "DOCKER=\".(readlink -nf external/docker_binary/docker)\"",
+)
+
+rule_test(
+    name = "test_container_run_and_extract_rule",
+    generates = [
+        "test_container_run_and_extract.build",
+        "test_container_run_and_extract/foo",
+    ],
+    rule = "test_container_run_and_extract",
+)
+
+file_test(
+    name = "test_custom_target_container_run_and_extract",
+    file = ":test_container_run_and_extract.build",
+    regexp = "DOCKER=\".(readlink -nf external/docker_binary/docker)\"",
+)
+
+rule_test(
+    name = "test_container_run_and_commit_rule",
+    generates = [
+        "test_container_run_and_commit.build",
+        "test_container_run_and_commit_commit.tar",
+    ],
+    rule = "test_container_run_and_commit",
+)
+
+file_test(
+    name = "test_custom_target_container_run_and_commit",
+    file = ":test_container_run_and_commit.build",
+    regexp = "DOCKER=\".(readlink -nf external/docker_binary/docker)\"",
+)

--- a/testing/custom_toolchain_target/WORKSPACE
+++ b/testing/custom_toolchain_target/WORKSPACE
@@ -1,0 +1,64 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workspace(name = "e2e_testing")
+
+local_repository(
+    name = "io_bazel_rules_docker",
+    path = "../../",
+)
+
+load(
+    "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
+    docker_toolchain_configure = "toolchain_configure",
+)
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# This is a static linked docker binary
+http_archive(
+    name = "docker_binary",
+    build_file_content = """exports_files(["docker"])""",
+    strip_prefix = "docker",
+    urls = ["https://download.docker.com/linux/static/stable/x86_64/docker-20.10.9.tgz"],
+)
+
+docker_toolchain_configure(
+    name = "docker_config",
+    docker_target = "@docker_binary//:docker",
+)
+
+# This is NOT needed when going through the language lang_image
+# "repositories" function(s).
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+
+container_repositories()
+
+load(
+    "@io_bazel_rules_docker//repositories:go_repositories.bzl",
+    container_go_deps = "go_deps",
+)
+
+container_go_deps()
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
+
+container_pull(
+    name = "debian_base",
+    digest = "sha256:00109fa40230a081f5ecffe0e814725042ff62a03e2d1eae0563f1f82eaeae9b",
+    registry = "gcr.io",
+    repository = "google-appengine/debian9",
+)

--- a/testing/custom_toolchain_target/cloudbuild.yaml
+++ b/testing/custom_toolchain_target/cloudbuild.yaml
@@ -1,0 +1,22 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests that verify that download_pkgs targets can be declared
+# in the top level BUILD file.
+
+steps:
+  # Test the download_pkgs examples.
+  - name: "l.gcr.io/google/bazel"
+    args: ["test", "//..."] 
+    dir: "testing/custom_toolchain_target"

--- a/toolchains/docker/toolchain.bzl
+++ b/toolchains/docker/toolchain.bzl
@@ -126,7 +126,7 @@ def _toolchain_configure_impl(repository_ctx):
 
     tool_attr = ""
     if repository_ctx.attr.docker_target:
-        tool_attr = "tool_target = \"%s\"," % repository_ctx.attr.tool_target
+        tool_attr = "tool_target = \"%s\"," % repository_ctx.attr.docker_target
     elif repository_ctx.attr.docker_path:
         tool_attr = "tool_path = \"%s\"," % repository_ctx.attr.docker_path
     elif repository_ctx.which("docker"):


### PR DESCRIPTION
We have to update the configure parameter to actually use docker_target. Once that is setup, we have to make sure that the executable is added to the runfiles, and update the entrypoint script to find the built binary. This should resolve https://github.com/bazelbuild/rules_docker/issues/2170

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2170 


## What is the new behavior?
Fixes the functionality to work as described

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No



