### PR TITLE
Fixed issue #648 for Python

### DIFF
--- a/python/image.bzl
+++ b/python/image.bzl
@@ -101,7 +101,10 @@ def py_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     native.py_binary(
         name = binary_name,
         python_version = "PY2",
-        deps = deps + layers,
+        deps = depset(transitive = [
+            depset(deps),
+            depset(layers)
+        ]),
         exec_compatible_with = ["@io_bazel_rules_docker//platforms:run_in_container"],
         **kwargs
     )

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -96,7 +96,10 @@ def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     py_binary(
         name = binary_name,
         python_version = "PY3",
-        deps = deps + layers,
+        deps = depset(transitive = [
+            depset(deps),
+            depset(layers)
+        ]),
         exec_compatible_with = ["@io_bazel_rules_docker//platforms:run_in_container"],
         **kwargs
     )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
I have a couple targets at work that indirectly call py_binary and py3_binary respectively via py_image and py3_image. Without this change, these targets trigger errors on Bazel newer than when such unions were disallowed.

Issue Number: 648


## What is the new behavior?
It works.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Kinda funny this issue was fixed in 2019 for all the languages but Python :) I was quite confused since we're upgrading from 0.15.0 and this got merged in 0.7.0... well now I know why that was an issue. Here's a PR that should put this issue finally to rest.
