### PR TITLE
Add configurable entrypoint to py3_image

### DIFF
--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -73,7 +73,7 @@ DEFAULT_BASE = select({
     "//conditions:default": "@py3_image_base//image",
 })
 
-def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
+def py3_image(name, base = None, deps = [], layers = [], env = {}, entrypoint = ["/usr/bin/python"], **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
   Args:
@@ -113,7 +113,7 @@ def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     app_layer(
         name = name,
         base = base,
-        entrypoint = ["/usr/bin/python"],
+        entrypoint = entrypoint,
         env = env,
         binary = binary_name,
         visibility = visibility,


### PR DESCRIPTION
This makes entrypoint for py3_image configurable so that a user can provide path to a hermetic python environment.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently the Python binary is fixed as `/usr/bin/python`.


## What is the new behavior?

The Python binary can be choses by overrideing the `entrypoint` for example to point to a hermetic Python.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

