### PR TITLE
feat: support custom python entrypoints

### DIFF
--- a/python/image.bzl
+++ b/python/image.bzl
@@ -78,7 +78,7 @@ def py_layer(name, deps, filter = "", **kwargs):
     native.py_library(name = binary_name, deps = deps, **kwargs)
     filter_layer(name = name, dep = binary_name, filter = filter)
 
-def py_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
+def py_image(name, base = None, deps = [], layers = [], env = {}, entrypoint = ["/usr/bin/python"], **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
   Args:
@@ -117,7 +117,7 @@ def py_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     app_layer(
         name = name,
         base = base,
-        entrypoint = ["/usr/bin/python"],
+        entrypoint = entrypoint,
         env = env,
         binary = binary_name,
         visibility = visibility,

--- a/python3/image.bzl
+++ b/python3/image.bzl
@@ -73,7 +73,7 @@ DEFAULT_BASE = select({
     "//conditions:default": "@py3_image_base//image",
 })
 
-def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
+def py3_image(name, base = None, deps = [], layers = [], env = {}, entrypoint = ["/usr/bin/python"], **kwargs):
     """Constructs a container image wrapping a py_binary target.
 
   Args:
@@ -113,7 +113,7 @@ def py3_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     app_layer(
         name = name,
         base = base,
-        entrypoint = ["/usr/bin/python"],
+        entrypoint = entrypoint,
         env = env,
         binary = binary_name,
         visibility = visibility,

--- a/tests/container/python3/BUILD
+++ b/tests/container/python3/BUILD
@@ -37,3 +37,22 @@ container_test(
     configs = ["//tests/container/python3/configs:py3_image.yaml"],
     image = ":py3_image",
 )
+
+py3_image(
+    name = "py3_image_custom_entrypoint",
+    entrypoint = ["/usr/bin/python3"],
+    srcs = ["//testdata:py3_image.py"],
+    args = [
+        "arg0"
+    ],
+    data = [":BUILD"],
+    layers = [
+        "//tests/container/python:py_image_library",
+    ],
+)
+
+container_test(
+    name = "py3_image_test_custom_entrypoint",
+    configs = ["//tests/container/python3/configs:py3_image_custom_entrypoint.yaml"],
+    image = ":py3_image_custom_entrypoint",
+)

--- a/tests/container/python3/configs/py3_image_custom_entrypoint.yaml
+++ b/tests/container/python3/configs/py3_image_custom_entrypoint.yaml
@@ -1,0 +1,10 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  cmd: [
+    'arg0',
+  ]
+  entrypoint: [
+    '/usr/bin/python3',
+    '/app/tests/container/python3/py3_image.binary',
+  ]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
`py3_image` always uses `/usr/bin/python` as an entrypoint, which may or may not be correct for some base images. For instance, many images provide `/usr/bin/python3`, and don't provide a symlink to `/usr/bin/python`.


## What is the new behavior?
This PR allows a developer to override the `entrypoint` of a `py3_image` or a `py_image`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

