### PR TITLE
Revert "Update providers.bzl (#2077)"

### DIFF
--- a/container/providers.bzl
+++ b/container/providers.bzl
@@ -52,6 +52,8 @@ LayerInfo = provider(fields = [
 PushInfo = provider(fields = [
     "registry",
     "repository",
+    "tag",
+    "stamp_inputs",
     "digest",
 ])
 

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -136,6 +136,8 @@ def _impl(ctx):
         PushInfo(
             registry = registry,
             repository = repository,
+            tag = tag,
+            stamp_inputs = stamp_inputs,
             digest = ctx.outputs.digest,
         ),
     ]


### PR DESCRIPTION
This reverts commit 0768e1b7f6aa973f9879ac5b8f622dd2f3d88f1d.

In the original patch
https://github.com/bazelbuild/rules_docker/pull/2077, `tag` and `stamp_input` fields of PushInfo were removed with the assumption that they become obsolete since bazel 5.0. However, bazel itself doesn't control our customized `PushInfo` provider.

We have some downstream rules that are relying on these field and would like to keep using them in latest version of rules_docker.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

