### PR TITLE
Force lower case on Bazel pkg path to play nice with oci container name spec

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -237,12 +237,12 @@ def _repository_name(ctx):
     """Compute the repository name for the current rule."""
     if ctx.attr.legacy_repository_naming:
         # Legacy behavior, off by default.
-        return _join_path(ctx.attr.repository, ctx.label.package.replace("/", "_"))
+        return _join_path(ctx.attr.repository, ctx.label.package.lower().replace("/", "_"))
 
     # Newer Docker clients support multi-level names, which are a part of
     # the v2 registry specification.
 
-    return _join_path(ctx.attr.repository, ctx.label.package)
+    return _join_path(ctx.attr.repository, ctx.label.package.lower())
 
 def _assemble_image_digest(ctx, name, image, image_tarball, output_digest):
     img_args, inputs = _gen_img_args(ctx, image)


### PR DESCRIPTION
The OCI distribution spec only allows lower case letter in container repository name
(https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests), this doesn't bode well with Bazel package path using upper case.

Relevant docker spec on 'repository name' scheme: https://github.com/moby/moby/blob/master/image/spec/v1.2.md.  Among other things: "...Name components may contain lowercase characters, digits, and separators...."

So force lower case on pkg path.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<bazel_ws>/Pkg_path_with_upper_case/ $ bazel build <:container_image_target.tar>
...
FAILED: Build did NOT complete successfully
...
Unable to process values passed using the flag --tag: unable to parse stamped image name "bazel/Pkg_path_with_upper_case:container_image_target" as a fully qualified image reference: repository can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-./`: bazel/Pkg_path_with_upper_case

Issue Number: N/A


## What is the new behavior?
bazel builds successfully.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No.  (Since this makes a previously broken build to successfully build)


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
