### PR TITLE
Support push_targets in container_bundle

### DIFF
--- a/container/providers.bzl
+++ b/container/providers.bzl
@@ -52,7 +52,10 @@ LayerInfo = provider(fields = [
 PushInfo = provider(fields = [
     "registry",
     "repository",
+    "image",
     "digest",
+    "tag",
+    "tag_file",
 ])
 
 # A provider containing information exposed by filter_layer rules

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -136,7 +136,10 @@ def _impl(ctx):
         PushInfo(
             registry = registry,
             repository = repository,
+            image = ctx.attr.image,
             digest = ctx.outputs.digest,
+            tag = tag,
+            tag_file = ctx.file.tag_file,
         ),
     ]
 

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -416,6 +416,29 @@ docker_push_all(
     bundle = ":three_images_bundle",
 )
 
+container_bundle(
+    name = "push_targets_bundle",
+    push_targets = [
+        ":new_push_test_oci",
+        ":new_push_test_oci_from_new_puller",
+        ":new_push_test_legacy_from_container_img",
+        ":new_push_test_legacy_from_container_img_with_auth",
+        ":new_push_test_legacy_from_new_puller",
+        ":new_push_test_legacy_from_old_puller",
+        ":new_push_test_tar",
+        ":new_push_test_old_puller_tar",
+        ":new_push_test_oci_tag_file",
+        ":new_push_test_legacy_tag_file",
+        ":new_push_stamped_test_legacy",
+        ":new_push_stamped_test_oci",
+    ]
+)
+
+docker_push_all(
+    name = "test_docker_push_push_targets_bundle",
+    bundle = ":push_targets_bundle",
+)
+
 py_test(
     name = "build_tar_test",
     srcs = ["build_tar_test.py"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`container_bundle` only supports a strange dictionary format for images.

## What is the new behavior?

`container_bundle` can take a `push_targets` parameter, and the info for the image (repository, tag, etc) is taken from existing push rules. This also means `contains_bundle` supports using `tag_file`s, and the subsequent `push-all` rule can push using these tag files as well.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

