### PR TITLE
fix: Print logs if a subshell process exits

### DIFF
--- a/docker/package_managers/run_install.sh.tpl
+++ b/docker/package_managers/run_install.sh.tpl
@@ -40,7 +40,11 @@ mkdir -p $(dirname $tmpdir/%{installables_tar})
 cp -L $(pwd)/%{installables_tar} $tmpdir/%{installables_tar}
 cp -L $(pwd)/%{installer_script} $tmpdir/installer.sh
 
+# Don't exit the parent shell if the sub-shell exits early,
+# as we want to print the logs in that case
+set +e
 (
+set -e
 # Temporarily create a container so we can mount the named volume
 # and copy files.  It's okay if /bin/true doesn't exist inside the
 # image; we are never going to run the image anyways.
@@ -60,7 +64,10 @@ reset_cmd $image_id $cid %{output_image_name}
 "$DOCKER" $DOCKER_FLAGS rm $cid
 "$DOCKER" $DOCKER_FLAGS volume rm $vid
 ) > "$log" 2>&1
+status=$?
 
-if (( $? )); then
+if (( ${status} )); then
     cat "$log"
 fi
+
+exit ${status}


### PR DESCRIPTION
Ensure that the logs of the subshell get printed if any of the commands
it is executing fails.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

