### PR TITLE
Add gazelle rule for bzl_library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 load("//contrib:test.bzl", "container_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -25,8 +25,17 @@ exports_files(["WORKSPACE"])
 
 gazelle(
     name = "gazelle",
+    gazelle = ":gazelle_bin",
     prefix = "github.com/bazelbuild/rules_docker",
 )
+
+gazelle_binary(
+    name = "gazelle_bin",
+    languages = DEFAULT_LANGUAGES + [
+        "@bazel_skylib_gazelle_plugin//bzl",
+    ],
+)
+
 # Make Gazelle ignore Go files in the tesdata directory used by test Go Image
 # targets.
 # gazelle:exclude testdata

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -542,3 +542,33 @@ http_archive(
         "https://github.com/bazelbuild/stardoc/archive/d93ee5347e2d9c225ad315094507e018364d5a67.tar.gz",
     ],
 )
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+http_archive(
+    name = "bazel_skylib_gazelle_plugin",
+    sha256 = "3327005dbc9e49cc39602fb46572525984f7119a9c6ffe5ed69fbe23db7c1560",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-gazelle-plugin-1.4.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-gazelle-plugin-1.4.2.tar.gz",
+    ],
+)
+
+load("@bazel_skylib_gazelle_plugin//:workspace.bzl", "bazel_skylib_gazelle_plugin_workspace")
+
+bazel_skylib_gazelle_plugin_workspace()
+
+load("@bazel_skylib_gazelle_plugin//:setup.bzl", "bazel_skylib_gazelle_plugin_setup")
+
+bazel_skylib_gazelle_plugin_setup(register_go_toolchains = False)

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -19,13 +19,17 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 bzl_library(
-    name = "image_bzl",
+    name = "image",
     srcs = ["image.bzl"],
-    visibility = ["//visibility:private"],
+    deps = [
+        ":cc",
+        "//container",
+        "//lang:image",
+        "//repositories:go_repositories",
+    ],
 )
 
 bzl_library(
-    name = "cc_bzl",
+    name = "cc",
     srcs = ["cc.bzl"],
-    visibility = ["//visibility:private"],
 )

--- a/container/BUILD
+++ b/container/BUILD
@@ -148,16 +148,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "providers",
-    srcs = ["providers.bzl"],
-)
-
-bzl_library(
-    name = "pull",
-    srcs = ["pull.bzl"],
-)
-
-bzl_library(
     name = "push",
     srcs = ["push.bzl"],
     deps = [
@@ -165,4 +155,14 @@ bzl_library(
         ":providers",
         "//skylib:path",
     ],
+)
+
+bzl_library(
+    name = "providers",
+    srcs = ["providers.bzl"],
+)
+
+bzl_library(
+    name = "pull",
+    srcs = ["pull.bzl"],
 )

--- a/container/go/cmd/update_deps/BUILD
+++ b/container/go/cmd/update_deps/BUILD
@@ -25,12 +25,10 @@ go_binary(
 go_library(
     name = "go_default_library",
     srcs = ["update_deps.go"],
-    importpath = "github.com/bazelbuild/rules_docker",
+    importpath = "github.com/bazelbuild/rules_docker/container/go/cmd/update_deps",
     visibility = ["//visibility:private"],
     deps = [
-        "//container/go/pkg/compat:go_default_library",
         "@com_github_google_go_containerregistry//pkg/crane:go_default_library",
         "@com_github_google_go_containerregistry//pkg/v1:go_default_library",
-        "@com_github_pkg_errors//:go_default_library",
     ],
 )

--- a/container/go/cmd/zipper/BUILD
+++ b/container/go/cmd/zipper/BUILD
@@ -25,6 +25,6 @@ go_binary(
 go_library(
     name = "go_default_library",
     srcs = ["zipper.go"],
-    importpath = "github.com/bazelbuild/rules_docker",
+    importpath = "github.com/bazelbuild/rules_docker/container/go/cmd/zipper",
     visibility = ["//visibility:private"],
 )

--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -69,61 +69,50 @@ alias(
 )
 
 bzl_library(
-    name = "push-all_bzl",
-    srcs = ["push-all.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "with-tag_bzl",
-    srcs = ["with-tag.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "repro_test_bzl",
-    srcs = ["repro_test.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "compare_ids_test_bzl",
-    srcs = ["compare_ids_test.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "with-defaults_bzl",
-    srcs = ["with-defaults.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "test_bzl",
-    srcs = ["test.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "rename_image_bzl",
-    srcs = ["rename_image.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "group_bzl",
-    srcs = ["group.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "dockerfile_build_bzl",
-    srcs = ["dockerfile_build.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "passwd_bzl",
+    name = "passwd",
     srcs = ["passwd.bzl"],
-    visibility = ["//visibility:private"],
+    deps = ["//skylib:path"],
+)
+
+bzl_library(
+    name = "push-all",
+    srcs = ["push-all.bzl"],
+    deps = [
+        "//container:layer_tools",
+        "//skylib:path",
+        "@io_bazel_rules_docker//container:providers",
+    ],
+)
+
+bzl_library(
+    name = "rename_image",
+    srcs = ["rename_image.bzl"],
+    deps = ["//container:bundle"],
+)
+
+bzl_library(
+    name = "test",
+    srcs = ["test.bzl"],
+    deps = ["//container:bundle"],
+)
+
+bzl_library(
+    name = "with-tag",
+    srcs = ["with-tag.bzl"],
+    deps = ["//container"],
+)
+
+bzl_library(
+    name = "dockerfile_build",
+    srcs = ["dockerfile_build.bzl"],
+)
+
+bzl_library(
+    name = "group",
+    srcs = ["group.bzl"],
+)
+
+bzl_library(
+    name = "with-defaults",
+    srcs = ["with-defaults.bzl"],
 )

--- a/contrib/automatic_container_release/BUILD
+++ b/contrib/automatic_container_release/BUILD
@@ -22,14 +22,15 @@ exports_files(["run_checker.sh.tpl"])
 
 bzl_library(
     name = "configs_test",
-    srcs = ["configs_test.bzl"],
     deps = ["//skylib:docker"],
 )
 
 bzl_library(
+    name = "metadata_merge",
+    srcs = ["metadata_merge.bzl"],
+)
+
+bzl_library(
     name = "packages_metadata",
-    srcs = [
-        "metadata_merge.bzl",
-        "packages_metadata.bzl",
-    ],
+    srcs = ["packages_metadata.bzl"],
 )

--- a/d/BUILD
+++ b/d/BUILD
@@ -19,7 +19,11 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 bzl_library(
-    name = "image_bzl",
+    name = "image",
     srcs = ["image.bzl"],
-    visibility = ["//visibility:private"],
+    deps = [
+        "//cc:image",
+        "//lang:image",
+        "@io_bazel_rules_d//d",
+    ],
 )

--- a/docker/package_managers/BUILD
+++ b/docker/package_managers/BUILD
@@ -26,14 +26,34 @@ exports_files([
 
 bzl_library(
     name = "package_managers",
-    srcs = [
-        "apt_key.bzl",
-        "download_pkgs.bzl",
-        "install_pkgs.bzl",
-    ],
     deps = [
         "//container",
         "//docker/util",
         "//skylib:docker",
     ],
+)
+
+bzl_library(
+    name = "apt_key",
+    srcs = ["apt_key.bzl"],
+    deps = [
+        "//container",
+        "//docker/util:run",
+    ],
+)
+
+bzl_library(
+    name = "download_pkgs",
+    srcs = ["download_pkgs.bzl"],
+    deps = [
+        "//skylib:docker",
+        "//skylib:path",
+        "@bazel_skylib//lib:types",
+    ],
+)
+
+bzl_library(
+    name = "install_pkgs",
+    srcs = ["install_pkgs.bzl"],
+    deps = ["//skylib:docker"],
 )

--- a/docker/security/BUILD
+++ b/docker/security/BUILD
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@subpar//:subpar.bzl", "par_binary")
 
 package(default_visibility = ["//visibility:public"])
@@ -27,11 +26,4 @@ par_binary(
     main = "security_check.py",
     python_version = "PY3",
     visibility = ["//visibility:public"],
-)
-
-bzl_library(
-    name = "security_check_lib",
-    srcs = [
-        "security_check.bzl",
-    ],
 )

--- a/docker/toolchain_container/BUILD
+++ b/docker/toolchain_container/BUILD
@@ -20,13 +20,20 @@ package(default_visibility = ["//visibility:public"])
 
 bzl_library(
     name = "toolchain_container",
-    srcs = [
-        "debian_pkg_tar.bzl",
-        "toolchain_container.bzl",
-    ],
+    srcs = ["toolchain_container.bzl"],
     deps = [
         "//container",
         "//docker/package_managers",
+        "@bazel_skylib//lib:dicts",
+    ],
+)
+
+bzl_library(
+    name = "debian_pkg_tar",
+    srcs = ["debian_pkg_tar.bzl"],
+    deps = [
+        "//docker/package_managers:apt_key",
+        "//docker/package_managers:download_pkgs",
         "@bazel_skylib//lib:dicts",
     ],
 )

--- a/docker/util/BUILD
+++ b/docker/util/BUILD
@@ -39,7 +39,6 @@ exports_files([
 
 bzl_library(
     name = "util",
-    srcs = ["run.bzl"],
     deps = ["//skylib:docker"],
 )
 
@@ -58,4 +57,17 @@ py_test(
     data = ["//docker/util/testdata:image_with_symlinked_layer.tar"],
     python_version = "PY3",
     deps = [":config_stripper_lib"],
+)
+
+bzl_library(
+    name = "run",
+    srcs = ["run.bzl"],
+    deps = [
+        "//skylib:docker",
+        "//skylib:hash",
+        "//skylib:zip",
+        "@bazel_skylib//lib:dicts",
+        "@io_bazel_rules_docker//container:layer",
+        "@io_bazel_rules_docker//container:providers",
+    ],
 )

--- a/go/BUILD
+++ b/go/BUILD
@@ -19,19 +19,24 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 bzl_library(
-    name = "go_bzl",
-    srcs = ["go.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "image_bzl",
+    name = "image",
     srcs = ["image.bzl"],
-    visibility = ["//visibility:private"],
+    deps = [
+        ":go",
+        ":static",
+        "//container",
+        "//lang:image",
+        "//repositories:go_repositories",
+        "@io_bazel_rules_go//go:def",
+    ],
 )
 
 bzl_library(
-    name = "static_bzl",
+    name = "go",
+    srcs = ["go.bzl"],
+)
+
+bzl_library(
+    name = "static",
     srcs = ["static.bzl"],
-    visibility = ["//visibility:private"],
 )

--- a/groovy/BUILD
+++ b/groovy/BUILD
@@ -19,7 +19,10 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 bzl_library(
-    name = "image_bzl",
+    name = "image",
     srcs = ["image.bzl"],
-    visibility = ["//visibility:private"],
+    deps = [
+        "//java:image",
+        "@io_bazel_rules_groovy//groovy",
+    ],
 )

--- a/java/BUILD
+++ b/java/BUILD
@@ -19,25 +19,25 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 bzl_library(
-    name = "jetty_bzl",
-    srcs = ["jetty.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "java_bzl",
-    srcs = ["java.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "image_bzl",
+    name = "image",
     srcs = ["image.bzl"],
-    visibility = ["//visibility:private"],
+    deps = [
+        ":java",
+        ":jetty",
+        "//container",
+        "//lang:image",
+        "//repositories:go_repositories",
+        "@bazel_skylib//lib:dicts",
+        "@bazel_tools//tools/build_defs/repo:jvm.bzl",
+    ],
 )
 
-# needed for stardoc
 bzl_library(
     name = "java",
-    srcs = glob(["*.bzl"]),
+    srcs = ["java.bzl"],
+)
+
+bzl_library(
+    name = "jetty",
+    srcs = ["jetty.bzl"],
 )

--- a/kotlin/BUILD
+++ b/kotlin/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,3 +16,12 @@
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
+
+bzl_library(
+    name = "image",
+    srcs = ["image.bzl"],
+    deps = [
+        "//java:image",
+        "@io_bazel_rules_kotlin//kotlin:jvm",
+    ],
+)

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,3 +16,22 @@
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
+
+bzl_library(
+    name = "image",
+    srcs = ["image.bzl"],
+    deps = [
+        ":nodejs",
+        "//container",
+        "//lang:image",
+        "//repositories:go_repositories",
+        "@bazel_skylib//lib:dicts",
+        "@build_bazel_rules_nodejs//:index",
+        "@build_bazel_rules_nodejs//:providers",
+    ],
+)
+
+bzl_library(
+    name = "nodejs",
+    srcs = ["nodejs.bzl"],
+)

--- a/python/BUILD
+++ b/python/BUILD
@@ -36,13 +36,17 @@ py_runtime(
 )
 
 bzl_library(
-    name = "python_bzl",
-    srcs = ["python.bzl"],
-    visibility = ["//visibility:private"],
+    name = "image",
+    srcs = ["image.bzl"],
+    deps = [
+        ":python",
+        "//container",
+        "//lang:image",
+        "//repositories:go_repositories",
+    ],
 )
 
 bzl_library(
-    name = "image_bzl",
-    srcs = ["image.bzl"],
-    visibility = ["//visibility:private"],
+    name = "python",
+    srcs = ["python.bzl"],
 )

--- a/python3/BUILD
+++ b/python3/BUILD
@@ -19,13 +19,18 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 bzl_library(
-    name = "image_bzl",
+    name = "image",
     srcs = ["image.bzl"],
-    visibility = ["//visibility:private"],
+    deps = [
+        ":python3",
+        "//container",
+        "//lang:image",
+        "//repositories:go_repositories",
+        "@rules_python//python:defs",
+    ],
 )
 
 bzl_library(
-    name = "python3_bzl",
+    name = "python3",
     srcs = ["python3.bzl"],
-    visibility = ["//visibility:private"],
 )

--- a/repositories/BUILD
+++ b/repositories/BUILD
@@ -19,37 +19,40 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 bzl_library(
-    name = "go_repositories_bzl",
-    srcs = ["go_repositories.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "repositories_bzl",
-    srcs = ["repositories.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "images_bzl",
-    srcs = ["images.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "deps_bzl",
+    name = "deps",
     srcs = ["deps.bzl"],
-    visibility = ["//visibility:private"],
+    deps = [
+        ":go_repositories",
+        "@rules_pkg//:deps",
+    ],
 )
 
 bzl_library(
-    name = "py_repositories_bzl",
-    srcs = ["py_repositories.bzl"],
-    visibility = ["//visibility:private"],
+    name = "go_repositories",
+    srcs = ["go_repositories.bzl"],
+    deps = [
+        "@bazel_gazelle//:deps",
+        "@io_bazel_rules_go//go:deps",
+    ],
 )
 
-# needed for stardoc
+bzl_library(
+    name = "images",
+    srcs = ["images.bzl"],
+    deps = ["//container"],
+)
+
+bzl_library(
+    name = "py_repositories",
+    srcs = ["py_repositories.bzl"],
+    deps = ["@rules_python//python:pip"],
+)
+
 bzl_library(
     name = "repositories",
-    srcs = glob(["*.bzl"]),
+    srcs = ["repositories.bzl"],
+    deps = [
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "@io_bazel_rules_docker//toolchains/docker:toolchain",
+    ],
 )

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -19,7 +19,11 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 bzl_library(
-    name = "image_bzl",
+    name = "image",
     srcs = ["image.bzl"],
-    visibility = ["//visibility:private"],
+    deps = [
+        "//cc:image",
+        "//lang:image",
+        "@rules_rust//rust:defs",
+    ],
 )

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -19,7 +19,10 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 bzl_library(
-    name = "image_bzl",
+    name = "image",
     srcs = ["image.bzl"],
-    visibility = ["//visibility:private"],
+    deps = [
+        "//java:image",
+        "@io_bazel_rules_scala//scala",
+    ],
 )

--- a/skylib/BUILD
+++ b/skylib/BUILD
@@ -29,6 +29,11 @@ bzl_library(
 )
 
 bzl_library(
+    name = "hash",
+    srcs = ["hash.bzl"],
+)
+
+bzl_library(
     name = "label",
     srcs = ["label.bzl"],
 )
@@ -41,9 +46,4 @@ bzl_library(
 bzl_library(
     name = "zip",
     srcs = ["zip.bzl"],
-)
-
-bzl_library(
-    name = "hash",
-    srcs = ["hash.bzl"],
 )

--- a/testing/default_toolchain/BUILD
+++ b/testing/default_toolchain/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,3 +15,9 @@
 # limitations under the License.
 
 # Placeholder top level BUILD file
+
+bzl_library(
+    name = "local_tool",
+    srcs = ["local_tool.bzl"],
+    visibility = ["//visibility:public"],
+)

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -870,24 +870,6 @@ pull_info_validation_test(
 
 # END_DO_NOT_IMPORT
 
-bzl_library(
-    name = "apple_bzl",
-    srcs = ["apple.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "empty_layers_bzl",
-    srcs = ["empty_layers.bzl"],
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "pull_info_validation_test_bzl",
-    srcs = ["pull_info_validation_test.bzl"],
-    visibility = ["//visibility:private"],
-)
-
 TEST_TARGETS = [
     ":base_with_entrypoint",
     ":base_with_volume",
@@ -1085,4 +1067,20 @@ transition_test(
     name = "transitions_off_test",
     actual = ":_transitions_off_test_base",
     transitions_enabled = False,
+)
+
+bzl_library(
+    name = "empty_layers",
+    srcs = ["empty_layers.bzl"],
+    deps = ["//container"],
+)
+
+bzl_library(
+    name = "apple",
+    srcs = ["apple.bzl"],
+)
+
+bzl_library(
+    name = "transitions",
+    srcs = ["transitions.bzl"],
 )

--- a/toolchains/docker/BUILD
+++ b/toolchains/docker/BUILD
@@ -17,12 +17,6 @@ load(":toolchain.bzl", "docker_toolchain")
 
 package(default_visibility = ["//visibility:private"])
 
-bzl_library(
-    name = "docker",
-    srcs = ["toolchain.bzl"],
-    visibility = ["//visibility:public"],
-)
-
 # Docker toolchain type
 toolchain_type(
     name = "toolchain_type",
@@ -64,4 +58,9 @@ toolchain(
     ],
     toolchain = "@docker_config//:toolchain",
     toolchain_type = ":toolchain_type",
+)
+
+bzl_library(
+    name = "toolchain",
+    srcs = ["toolchain.bzl"],
 )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, there are either no `bzl_library` targets defined for `.bzl` files or the ones that exist are private.  This is problematic for downstream users who wish to generate stardoc.


## What is the new behavior?

Adds the bzl gazelle rule while will automatically generate these targets.  It also removed the private visibility from the existing targets, as I don't believe there's a reason to keep those private (their underlying .bzl files are all public).


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This would be a big QoL improvement - right now it is actually impossible for my team to use stardoc based on the nodejs package since it doesn't load any bzl files.  I know this repo isn't really maintained but a few of us still use it!
