### PR TITLE
Use empty string as fallback value for undefined environment variables

### DIFF
--- a/contrib/dockerfile_build.bzl
+++ b/contrib/dockerfile_build.bzl
@@ -59,7 +59,7 @@ def _impl(repository_ctx):
             build_args.extend(["--build-arg", "%s=%s" % (pair[0], pair[1])])
     if repository_ctx.attr.vars:
         for env_var in repository_ctx.attr.vars:
-            build_args.extend(["--build-arg", "%s=%s" % (env_var, repository_ctx.os.environ.get(env_var))])
+            build_args.extend(["--build-arg", "%s=%s" % (env_var, repository_ctx.os.environ.get(env_var, ""))])
 
     # The docker bulid command needs to run using the supplied Dockerfile
     # because it may refer to relative paths in its ADD, COPY and WORKDIR


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
 
The current implementation of [dockerfile_build](https://github.com/bazelbuild/rules_docker/blob/master/contrib/dockerfile_build.bzl#L62) rule looks up for environment variables value and uses `None` as fallback value for undefined one. This causes to resolve into `--build-arg <ENV_VAR>=None` build argument, which is interpreted as valid, defined value.

## What is the new behavior?

Instead, we should fallback to empty string for undefined environment variables, which resolves to `--build-arg <ENV_VAR>=''` and is interpreted as empty value. This would match the same output as produced in shell:

```bash
$ echo "NON_EXISTING_VARIABLE='${NON_EXISTING_VARIABLE}'"
NON_EXISTING_VARIABLE=''
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

