### PR TITLE
Force package download when packages are present on build host

### DIFF
--- a/docker/package_managers/download_pkgs.bzl
+++ b/docker/package_managers/download_pkgs.bzl
@@ -40,8 +40,8 @@ rm -rf /var/lib/apt/lists/*
 apt-get update -y -qq
 # Make partial dir
 mkdir -p /tmp/install/./partial
-# Install command
-apt-get install --no-install-recommends -y -qq -o Dir::Cache="/tmp/install" -o Dir::Cache::archives="." {packages} --download-only
+# Install command.  Use --reinstall to ensure packages are downloaded when present on build host.
+apt-get install --no-install-recommends -y -qq -o Dir::Cache="/tmp/install" -o Dir::Cache::archives="." {packages} --download-only --reinstall
 
 items=$(ls /tmp/install/*.deb)
 if [ -z "$items" ]; then


### PR DESCRIPTION
Ensure that requested packages are downloaded, even if present on the build host.  This enables the build rules to declare their necessary package dependencies without having the knowledge of whether they are present on the specific build host which is running the bazel command.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
When defining package dependencies, the generate downloads script fails if the requested packages are already present on the host docker image.

Issue Number: N/A


## What is the new behavior?
Declared packages are always downloaded into the temporary Dir::Cache directory regardless of whether the binaries are present on the target machine or not.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Sometimes these base docker images and the software installed into them are often maintained by different teams and when the download packages script fails due to dependencies already being present it requires coordination between both teams to ensure that a mutually exclusive set of dependencies is installed in the host env vs. declared in the package dependencies in the software system's bazel target.

New tests were not added, but I tested the behavior with this newly added --reinstall command line flag.