### PR TITLE
Correct docs for container_layer's mode attribute

### DIFF
--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -344,8 +344,12 @@ _layer_attrs = dicts.add({
         A list of files that should be included in the Docker image.""",
     ),
     "mode": attr.string(
-        default = "0o555",  # 0o555 == a+rx
-        doc = "Set the mode of files added by the `files` attribute.",
+        default = "0o555",
+        doc = """Set the mode of files and directories added.
+
+        "0o555" == a+rx
+
+        Applies to `files`, `empty_files`, and `empty_dirs` attributes.""",
     ),
     "mtime": attr.int(default = _DEFAULT_MTIME),
     "operating_system": attr.string(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I have personally verified this. In addition, [you can see the code](https://github.com/bazelbuild/rules_docker/blob/8e70c6bcb584a15a8fd061ea489b933c0ff344ca/container/build_tar.py#L384) uses the same `file_attributes` function which [sets the mode](https://github.com/bazelbuild/rules_docker/blob/8e70c6bcb584a15a8fd061ea489b933c0ff344ca/container/build_tar.py#L375).