### PR TITLE
Add toolchain param to the affected actions

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -229,6 +229,7 @@ def _image_config(
         outputs = [config, manifest],
         use_default_shell_env = True,
         mnemonic = "ImageConfig",
+        toolchain = None,
     )
 
     return config, _sha256(ctx, config), manifest, _sha256(ctx, manifest)
@@ -259,6 +260,7 @@ def _assemble_image_digest(ctx, name, image, image_tarball, output_digest):
         arguments = [args],
         mnemonic = "ImageDigest",
         progress_message = "Extracting image digest of %s" % image_tarball.short_path,
+        toolchain = None,
     )
 
 def _impl(

--- a/container/layer.bzl
+++ b/container/layer.bzl
@@ -100,12 +100,14 @@ def build_layer(
        the layer tar and its sha256 digest
 
     """
-    toolchain_info = ctx.toolchains["@io_bazel_rules_docker//toolchains/docker:toolchain_type"].info
+    toolchain_type = "@io_bazel_rules_docker//toolchains/docker:toolchain_type"
+    toolchain_info = ctx.toolchains[toolchain_type].info
     layer = output_layer
     if toolchain_info.build_tar_target:
         build_layer_exec = toolchain_info.build_tar_target.files_to_run.executable
     else:
         build_layer_exec = ctx.executable.build_layer
+        toolchain_type = None
     args = ctx.actions.args()
     args.add(layer, format = "--output=%s")
     args.add(directory, format = "--directory=%s")
@@ -168,6 +170,7 @@ def build_layer(
         outputs = [layer],
         use_default_shell_env = True,
         mnemonic = "ImageLayer",
+        toolchain = toolchain_type,
     )
     return layer, _sha256(ctx, layer)
 

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -40,6 +40,7 @@ def _extract_layers(ctx, name, artifact):
         tools = [artifact],
         outputs = [config_file, manifest_file],
         mnemonic = "ExtractConfig",
+        toolchain = None,
     )
     return {
         "config": config_file,
@@ -199,6 +200,7 @@ def assemble(
         tools = inputs,
         outputs = [output],
         mnemonic = "JoinLayers",
+        toolchain = None,
     )
 
 def incremental_load(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ x] Other... Please describe: This is a step forward for the migration of Automatic Exec Groups. Each action which uses tool/executable should add a `toolchain` param.


## What is the current behavior?

Exec platform selection is on a rule level. Which means that a rule can have one default execution platform, unless specified differently via exec_groups.

Issue Number: N/A


## What is the new behavior?

Exec platform selection is on a toolchain_type level. Which means that each action on a rule can have a different execution platform.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No - Not for now since AEGs are still disabled in Bazel. Once they becom enabled, you will have more information connected to possible errors (issue description on github and incompatible flag).  


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

