### PR TITLE
Update rules_go version

### DIFF
--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -111,10 +111,10 @@ def repositories():
     if "io_bazel_rules_go" not in excludes:
         http_archive(
             name = "io_bazel_rules_go",
-            sha256 = "08c3cd71857d58af3cda759112437d9e63339ac9c6e0042add43f4d94caf632d",
+            sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
             urls = [
-                "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.24.2/rules_go-v0.24.2.tar.gz",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.24.2/rules_go-v0.24.2.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
             ],
         )
     if "rules_python" not in excludes:


### PR DESCRIPTION
## PR Type

- [x] Build related changes
- [x] Other... Please describe: Upgrading dependencies


## What is the current behavior?

Build breaks with latest Bazel version, because of old rules_go

Issue Number: https://github.com/bazelbuild/bazel-buildfarm/issues/1440
See also: https://github.com/bazelbuild/bazel/issues/19493

## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

