### PR TITLE
Do not fail in case of empty image label values

### DIFF
--- a/container/image.bzl
+++ b/container/image.bzl
@@ -189,7 +189,7 @@ def _image_config(
     labels_fixed = dict()
     for label in labels:
         fname = labels[label]
-        if fname[0] == "@":
+        if fname.startswith("@"):
             labels_fixed[label] = "@" + label_file_dict[fname[1:]].path
         else:
             labels_fixed[label] = fname
@@ -1034,7 +1034,7 @@ def container_image(**kwargs):
             fail("reserved for internal use by container_image macro", attr = reserved)
 
     if "labels" in kwargs:
-        files = sorted({v[1:]: None for v in kwargs["labels"].values() if v[0] == "@"}.keys())
+        files = sorted({v[1:]: None for v in kwargs["labels"].values() if v.startswith("@")}.keys())
         kwargs["label_files"] = files
         kwargs["label_file_strings"] = files
 


### PR DESCRIPTION
If I understand correctly, image label value _may_ be an empty string. However, in that case, I got "index out of range" errors in two places. This PR uses `startswith` to avoid them.

```
	File "/private/var/tmp/_bazel_halil.sener/f6fb7d40b6b3160ce57e2d52769a8d36/external/io_bazel_rules_docker/container/image.bzl", line 976, column 76, in container_image
		files = sorted({v[1:]: None for v in kwargs["labels"].values() if v[0] == "@"}.keys())
Error: index out of range (index is 0, but sequence has 0 elements)
```

```
	File "/private/var/tmp/_bazel_halil.sener/f6fb7d40b6b3160ce57e2d52769a8d36/external/io_bazel_rules_docker/container/image.bzl", line 199, column 17, in _image_config
		if fname[0] == "@":
Error: index out of range (index is 0, but sequence has 0 elements)
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

