### PR TITLE
Add retry option in container pull

### DIFF
--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -243,7 +243,6 @@ def _impl(repository_ctx):
     result = struct(return_code = -1, stdout = "", stderr = "")
 
     for i in range(total_attempts):
-        print("tanx", i)
         result = repository_ctx.execute(args, **kwargs)
         if result.return_code == 0:
             break

--- a/container/pull.bzl
+++ b/container/pull.bzl
@@ -240,7 +240,7 @@ def _impl(repository_ctx):
         }
 
     total_attempts = repository_ctx.attr.retry + 1
-    result = struct(return_code=-1, stdout="", stderr="")
+    result = struct(return_code = -1, stdout = "", stderr = "")
 
     for i in range(total_attempts):
         print("tanx", i)
@@ -249,7 +249,7 @@ def _impl(repository_ctx):
             break
 
     if result.return_code != 0:  # If it still fails after all retries
-        fail("Pull command failed after {%d} attempts: %s (%s)" % (total_attempts , result.stderr, " ".join([str(a) for a in args])))
+        fail("Pull command failed after {%d} attempts: %s (%s)" % (total_attempts, result.stderr, " ".join([str(a) for a in args])))
 
     updated_attrs = {
         k: getattr(repository_ctx.attr, k)

--- a/docker/util/config_stripper.py
+++ b/docker/util/config_stripper.py
@@ -70,7 +70,10 @@ def strip_tar(input, output):
         # that symlinks to a lower layer that hasn't been extracted yet. Just
         # reversing the iteration order avoids this problem.
         for layer in reversed(image['Layers']):
-          (new_layer_name, new_diff_id) = strip_layer(os.path.join(tempdir, layer))
+          layer_path = os.path.join(tempdir, layer)
+          if not os.path.exists(layer_path):
+              continue
+          (new_layer_name, new_diff_id) = strip_layer(layer_path)
 
           new_layers.append(new_layer_name)
           new_diff_ids.append(new_diff_id)

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -42,5 +42,5 @@ write_file(
 sh_binary(
     name = "update",
     srcs = [":gen_update"],
-    data = [":container_doc"],
+    data = [":container.md_"],
 )

--- a/docs/container.md
+++ b/docs/container.md
@@ -163,7 +163,7 @@ The created target can be referenced as `@label_name//image`.
 container_pull(<a href="#container_pull-name">name</a>, <a href="#container_pull-architecture">architecture</a>, <a href="#container_pull-cpu_variant">cpu_variant</a>, <a href="#container_pull-cred_helpers">cred_helpers</a>, <a href="#container_pull-digest">digest</a>, <a href="#container_pull-docker_client_config">docker_client_config</a>,
                <a href="#container_pull-import_tags">import_tags</a>, <a href="#container_pull-os">os</a>, <a href="#container_pull-os_features">os_features</a>, <a href="#container_pull-os_version">os_version</a>, <a href="#container_pull-platform_features">platform_features</a>, <a href="#container_pull-puller_darwin">puller_darwin</a>,
                <a href="#container_pull-puller_linux_amd64">puller_linux_amd64</a>, <a href="#container_pull-puller_linux_arm64">puller_linux_arm64</a>, <a href="#container_pull-puller_linux_s390x">puller_linux_s390x</a>, <a href="#container_pull-registry">registry</a>, <a href="#container_pull-repo_mapping">repo_mapping</a>,
-               <a href="#container_pull-repository">repository</a>, <a href="#container_pull-tag">tag</a>, <a href="#container_pull-timeout">timeout</a>)
+               <a href="#container_pull-repository">repository</a>, <a href="#container_pull-retry">retry</a>, <a href="#container_pull-tag">tag</a>, <a href="#container_pull-timeout">timeout</a>)
 </pre>
 
 A repository rule that pulls down a Docker base image in a manner suitable for use with the `base` attribute of `container_image`.
@@ -211,6 +211,7 @@ please use the bazel startup flag `--loading_phase_threads=1` in your bazel invo
 | <a id="container_pull-registry"></a>registry |  The registry from which we are pulling.   | String | required |  |
 | <a id="container_pull-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 | <a id="container_pull-repository"></a>repository |  The name of the image.   | String | required |  |
+| <a id="container_pull-retry"></a>retry |  The number of retries that will be attempted should there be a failure when pulling   | Integer | optional | 0 |
 | <a id="container_pull-tag"></a>tag |  The <code>tag</code> of the Docker image to pull from the specified <code>repository</code>.<br><br>        If neither this nor <code>digest</code> is specified, this attribute defaults to <code>latest</code>.         If both are specified, then <code>tag</code> is ignored.<br><br>        Note: For reproducible builds, use of <code>digest</code> is recommended.   | String | optional | "latest" |
 | <a id="container_pull-timeout"></a>timeout |  Timeout in seconds to fetch the image from the registry.<br><br>        This attribute will be overridden by the PULLER_TIMEOUT environment variable, if it is set.   | Integer | optional | 0 |
 

--- a/testing/custom_toolchain_auth/WORKSPACE
+++ b/testing/custom_toolchain_auth/WORKSPACE
@@ -61,6 +61,7 @@ container_pull(
     name = "distroless_fixed_id",
     registry = "gcr.io",
     repository = "distroless/base",
+    retry = 2,
 )
 
 load(
@@ -73,4 +74,5 @@ authenticated_local_pull(
     registry = "localhost:5000",
     repository = "docker/test",
     tag = "test",
+    retry = 3,
 )

--- a/testing/custom_toolchain_auth/WORKSPACE
+++ b/testing/custom_toolchain_auth/WORKSPACE
@@ -73,6 +73,6 @@ authenticated_local_pull(
     name = "local_pull",
     registry = "localhost:5000",
     repository = "docker/test",
-    tag = "test",
     retry = 3,
+    tag = "test",
 )

--- a/testing/examples/WORKSPACE
+++ b/testing/examples/WORKSPACE
@@ -46,9 +46,9 @@ container_pull(
     digest = "sha256:954b378c375d852eb3c63ab88978f640b4348b01c1b3456a024a81536dafbbf4",
     registry = "index.docker.io",
     repository = "library/alpine",
+    retry = 2,
     # tag field is ignored since digest is set
     tag = "3.8",
-    retry = 2,
 )
 
 container_pull(
@@ -56,9 +56,9 @@ container_pull(
     digest = "sha256:8f0b64fd212007183434b8b3271b723700ab14e4230b5bec1415b79aaa3ac97b",
     registry = "l.gcr.io",
     repository = "google/ubuntu1604",
+    retry = 2,
     # tag field is ignored since digest is set
     tag = "latest",
-    retry = 2,
 )
 
 container_pull(

--- a/testing/examples/WORKSPACE
+++ b/testing/examples/WORKSPACE
@@ -48,6 +48,7 @@ container_pull(
     repository = "library/alpine",
     # tag field is ignored since digest is set
     tag = "3.8",
+    retry = 2,
 )
 
 container_pull(
@@ -57,6 +58,7 @@ container_pull(
     repository = "google/ubuntu1604",
     # tag field is ignored since digest is set
     tag = "latest",
+    retry = 2,
 )
 
 container_pull(
@@ -64,6 +66,7 @@ container_pull(
     digest = "sha256:ace9881e6e9c5d48b5fd637321361aeffe54000265894a65f7d818dc1065bd80",
     registry = "launcher.gcr.io",
     repository = "google/bazel",
+    retry = 2,
 )
 
 dockerfile_image(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
each container is only pulled once and immediately fail, if there's an error. This means should the pull fails over unstable network from the repository. The rule will not attempt to retry 
Issue Number: N/A


## What is the new behavior?
Users of the container_pull rule will be able to specify an attribute tell it the max number of retries should be attempted before declaring failure

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

