### PR TITLE
Load py symbols from @rules_python

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -459,6 +459,8 @@ rbe_autoconfig(
 http_archive(
     name = "httplib2",
     build_file_content = """
+load("@rules_python//python:defs.bzl", "py_library")
+
 py_library(
     name = "httplib2",
     srcs = glob(["**/*.py"]),
@@ -477,6 +479,8 @@ py_library(
 http_archive(
     name = "six",
     build_file_content = """
+load("@rules_python//python:defs.bzl", "py_library")
+
 # Rename six.py to __init__.py
 genrule(
     name = "rename",
@@ -502,6 +506,8 @@ py_library(
 http_archive(
     name = "oauth2client",
     build_file_content = """
+load("@rules_python//python:defs.bzl", "py_library")
+
 py_library(
     name = "oauth2client",
     srcs = glob(["**/*.py"]),

--- a/container/BUILD
+++ b/container/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/docker/util/BUILD
+++ b/docker/util/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/python/image.bzl
+++ b/python/image.bzl
@@ -29,6 +29,7 @@ load(
     "//repositories:go_repositories.bzl",
     _go_deps = "go_deps",
 )
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 # Load the resolved digests.
 load(":python.bzl", "DIGESTS")
@@ -75,7 +76,7 @@ DEFAULT_BASE = select({
 
 def py_layer(name, deps, filter = "", **kwargs):
     binary_name = name + ".layer-binary"
-    native.py_library(name = binary_name, deps = deps, **kwargs)
+    py_library(name = binary_name, deps = deps, **kwargs)
     filter_layer(name = name, dep = binary_name, filter = filter)
 
 def py_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
@@ -98,7 +99,7 @@ def py_image(name, base = None, deps = [], layers = [], env = {}, **kwargs):
     # TODO(mattmoor): Consider using par_binary instead, so that
     # a single target can be used for all three.
 
-    native.py_binary(
+    py_binary(
         name = binary_name,
         python_version = "PY2",
         deps = deps + layers,

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -54,6 +54,7 @@ load("//python3:image.bzl", "py3_image")
 load("//scala:image.bzl", "scala_image")
 load("//testdata:utils.bzl", "generate_deb", "rule_with_symlinks")
 load(":stamp_info.bzl", "stamp_info")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/testdata/test/BUILD
+++ b/testdata/test/BUILD
@@ -14,6 +14,7 @@
 
 load("@io_bazel_rules_docker//python3:image.bzl", "py3_image")
 load("@io_bazel_rules_docker_pip_deps//:requirements.bzl", "all_requirements", "requirement")
+load("@rules_python//python:defs.bzl", "py_library")
 
 package(default_visibility = ["//testdata:__subpackages__"])
 

--- a/tests/container/python/BUILD
+++ b/tests/container/python/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_python//python:defs.bzl", "py_library")
 load("//contrib:test.bzl", "container_test")
 load("//python3:image.bzl", "py3_image")
 


### PR DESCRIPTION
```
# Use hermetic Python for bootstarpping py_binary rules.
# Do not foget to load py_binary like: load("@rules_python//python:defs.bzl", "py_binary")!
# Failing to do so will result in a following error:
#    xxxxxxx/%stage2_bootstrap%': [Errno 2] No such file or directory
common --@rules_python//python/config_settings:bootstrap_impl=script
```